### PR TITLE
ci: release-pleaseのDeprecation警告解消のためアクションを更新

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,6 +12,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           release-type: node


### PR DESCRIPTION
## 概要
GitHub Actions の実行ログにて `release-please` に関する2つの Deprecation（非推奨化）警告が発生していたため、アクションの参照先を最新のものに更新します。

## 警告の内容と対応
1. `google-github-actions/release-please-action` が非推奨となり、`googleapis` 配下へ移行したという警告。
2. 上記の古いアクションが Node.js 20 で動作しており、将来的な Node.js 24 環境での動作に支障が出るという警告。

`uses:` の参照先を `googleapis/release-please-action@v4` に変更することで、最新の公式アクション（新しいNode.js環境に対応済み）を呼び出すように修正しました。