### PR TITLE
ci: 本番デプロイ時のトラフィック自動移行の修正

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -40,17 +40,21 @@ steps:
       - 'push'
       - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi:$SHORT_SHA'
 
-  # 4. Cloud Run へデプロイする
+  # 4. 本番の Cloud Run へデプロイし、トラフィックを100%向ける
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    entrypoint: gcloud
+    entrypoint: 'bash'
     args:
-      - 'run'
-      - 'deploy'
-      - 'kippu-navi'
-      - '--image'
-      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi:$SHORT_SHA'
-      - '--region'
-      - 'asia-northeast1'
+      - '-c'
+      - |
+        # ① 新しいイメージをデプロイ
+        gcloud run deploy kippu-navi \
+          --image asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi:$SHORT_SHA \
+          --region asia-northeast1
+        
+        # ② 強制的にトラフィックを最新リビジョン(100%)に切り替える
+        gcloud run services update-traffic kippu-navi \
+          --to-latest \
+          --region asia-northeast1
 
 # 正常終了の条件として、指定したイメージが正しくビルド・プッシュされたか検証する
 images:


### PR DESCRIPTION
PR環境と本番環境のデプロイ要件の競合により、本番デプロイ時にトラフィックが
最新リビジョンへ自動移行しなくなる問題を解決するため、以下の修正を実施。

- cloudbuild.yaml (本番用): デプロイ完了後に `update-traffic --to-latest` を実行するステップを追加し、 手動操作なしで100%のトラフィックが最新リビジョンへ向くように修正。