### PR TITLE
feat: 運賃計算モード（通常/最安/補正禁止）の選択機能を追加

### DIFF
--- a/src/app/api/mr/route.ts
+++ b/src/app/api/mr/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { processRouteAndCalculateFare } from '@/app/mr/lib/generateKippu';
+import { generateKippu } from '@/app/mr/lib/generateKippu';
 
 import { RouteRequest } from '@/app/types';
 
@@ -8,12 +8,12 @@ export async function POST(request: Request) {
     try {
         const body: RouteRequest = await request.json();
 
-        if (100 < body.path.length) {
+        if (100 <= body.path.length) {
             const endTime = performance.now();
             const calculationTimeMs = endTime - startTime;
             return NextResponse.json(
                 {
-                    error: '経路の上限は100です．',
+                    error: '経由路線の上限は99です。',
                     time: calculationTimeMs
                 },
                 { status: 400 }
@@ -29,13 +29,17 @@ export async function POST(request: Request) {
             const calculationTimeMs = endTime - startTime;
             return NextResponse.json(
                 {
-                    error: '不正な経路です',
+                    error: '不正な経路です。',
                     time: calculationTimeMs
                 },
                 { status: 400 }
             );
         }
-        const result = processRouteAndCalculateFare(body);
+
+        const result = generateKippu(body, {
+            calculationMode: body.calculationMode
+        });
+
         const endTime = performance.now();
         const calculationTimeMs = endTime - startTime;
         return NextResponse.json(

--- a/src/app/mr/components/Form.tsx
+++ b/src/app/mr/components/Form.tsx
@@ -9,16 +9,21 @@ import lineData from "@/app/mr/data/lines.json";
 import SelectStation from "@/app/mr/components/SelectStation";
 import SelectLine from "@/app/mr/components/SelectLine";
 
-import { Station, Line, KippuData, ApiFullResponse, IFormInput, PathStep, RouteRequest } from "@/app/types";
+import { Station, Line, KippuData, ApiFullResponse, IFormInput, PathStep, CalculationMode } from "@/app/types";
 
 const stationMap = new Map(stationData.map(s => [s.name, s]));
 
+interface FormValues extends IFormInput {
+    calculationMode: CalculationMode;
+}
+
 export default function Form() {
-    const { handleSubmit, control, watch, setValue, getValues, formState: { isValid } } = useForm<IFormInput>({
+    const { register, handleSubmit, control, watch, setValue, getValues, formState: { isValid } } = useForm<FormValues>({
         mode: 'onChange',
         defaultValues: {
             startStation: null,
             segments: [{ viaLine: null, destinationStation: null }],
+            calculationMode: "normal",
         },
     });
 
@@ -58,7 +63,7 @@ export default function Form() {
         append({ viaLine: null, destinationStation: null });
     };
 
-    const createApiRequestBody = (data: IFormInput): RouteRequest | null => {
+    const createApiRequestBody = (data: FormValues) => {
         if (data.startStation == null) {
             return null;
         }
@@ -80,7 +85,10 @@ export default function Form() {
             }
         });
 
-        return { path };
+        return {
+            path,
+            calculationMode: data.calculationMode
+        };
     };
 
     const [result, setResult] = useState<KippuData | null>(null);
@@ -88,7 +96,7 @@ export default function Form() {
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
-    const onSubmit: SubmitHandler<IFormInput> = async (data) => {
+    const onSubmit: SubmitHandler<FormValues> = async (data) => {
         setIsLoading(true);
         setError(null);
         setResult(null);
@@ -191,7 +199,6 @@ export default function Form() {
 
                         const selectedLine = formValues.segments[index]?.viaLine;
 
-                        // ★修正: type述語の型エラーを回避する安全なキャスト
                         const stationsOnLine = selectedLine
                             ? (selectedLine.stations
                                 .map(name => stationMap.get(name))
@@ -260,11 +267,55 @@ export default function Form() {
                             経由路線を追加
                         </button>
                     </div>
-                    <div>
-                        <button type="submit" className="px-6 py-2 bg-blue-400 text-black rounded disabled:bg-gray-400 disabled:text-white" disabled={!isValid}>
-                            <p>照　会</p>
-                        </button>
+                    {/* 運賃計算モード選択（ラジオボタン） */}
+                    <div className="mb-6 flex flex-col items-start bg-slate-50 p-4 rounded-md border border-slate-200 w-full max-w-xl">
+                        <p className="block text-base font-bold text-slate-700 mb-3">
+                            運賃計算モード
+                        </p>
+                        <div className="flex flex-col gap-3 w-full p-3">
+                            {/* ① 通常モード */}
+                            <label className="inline-flex items-center cursor-pointer w-fit">
+                                <input
+                                    type="radio"
+                                    value="normal"
+                                    className="w-4 h-4 text-blue-600 bg-white border-gray-300 focus:ring-blue-500"
+                                    {...register("calculationMode")}
+                                />
+                                <span className="ms-3 text-base font-medium text-slate-700">
+                                    通常 <span className="text-sm text-slate-500 font-normal">（発売可能なルートに自動補正）</span>
+                                </span>
+                            </label>
+
+                            {/* ② 最安探索モード */}
+                            <label className="inline-flex items-center cursor-pointer w-fit">
+                                <input
+                                    type="radio"
+                                    value="cheapest"
+                                    className="w-4 h-4 text-blue-600 bg-white border-gray-300 focus:ring-blue-500"
+                                    {...register("calculationMode")}
+                                />
+                                <span className="ms-3 text-base font-medium text-slate-700">
+                                    最安 <span className="text-sm text-slate-500 font-normal">（経路を延長して安くなる場合は適用）</span>
+                                </span>
+                            </label>
+
+                            {/* ③ 補正禁止モード */}
+                            <label className="inline-flex items-center cursor-pointer w-fit">
+                                <input
+                                    type="radio"
+                                    value="uncorrect"
+                                    className="w-4 h-4 text-blue-600 bg-white border-gray-300 focus:ring-blue-500"
+                                    {...register("calculationMode")}
+                                />
+                                <span className="ms-3 text-base font-medium text-slate-700">
+                                    補正禁止 <span className="text-sm text-red-500 font-normal">※上級者向け</span><span className="text-sm text-slate-500 font-normal">（入力経路のまま計算）</span>
+                                </span>
+                            </label>
+                        </div>
                     </div>
+                    <button type="submit" className="px-6 py-2 bg-blue-400 text-black rounded disabled:bg-gray-400 disabled:text-white" disabled={!isValid}>
+                        <p>運賃計算をする</p>
+                    </button>
                 </div>
             </form>
             <div className="my-8 p-4">

--- a/src/app/mr/lib/generateKippu.ts
+++ b/src/app/mr/lib/generateKippu.ts
@@ -3,17 +3,37 @@ import { loadLines } from '@/app/mr/lib/loadLines';
 import { loadKanas } from '@/app/mr/lib/loadKanas';
 import { correctPath, uncorrectPath } from '@/app/utils/correctPath';
 import { calculateFareFromPath, calculateBarrierFreeFeeFromPath } from '@/app/utils/calcFare';
+import { cheapestPathAndFare } from '@/app/utils/cheapestPath';
 
-import { RouteRequest, KippuData, PathStep } from '@/app/types';
+import { RouteRequest, KippuData, PathStep, CalculationMode } from '@/app/types';
 
-export function processRouteAndCalculateFare(request: RouteRequest): KippuData {
+export interface GenerateKippuOptions {
+    calculationMode?: CalculationMode;
+}
+
+export function generateKippu(request: RouteRequest, options: GenerateKippuOptions = {}): KippuData {
     const userInputPath = request.path;
+    const calculationMode = options.calculationMode ?? "normal";
 
     // 経路の展開
     let fullPath = createFullPath(userInputPath);
 
     // 経路の補正
-    const correctedPath = correctPath(fullPath);
+    let correctedPath: PathStep[];
+    let cheapestFare: number | null = null;
+    switch (calculationMode) {
+        case "uncorrect":
+            correctedPath = uncorrectPath(fullPath);
+            break;
+        case "cheapest":
+            const cheapestResult = cheapestPathAndFare(fullPath);
+            correctedPath = cheapestResult.path;
+            break;
+        case "normal":
+        default:
+            correctedPath = correctPath(fullPath);
+            break;
+    }
 
     // 出発駅と到着駅の名前を取得して変数に代入
     const departureStation = correctedPath[0].stationName;
@@ -21,13 +41,17 @@ export function processRouteAndCalculateFare(request: RouteRequest): KippuData {
 
     // 営業キロと運賃の計算
     const routeSegments = convertPathStepsToRouteSegments(correctedPath);
-    const totalEigyoKilo = calculateTotalEigyoKilo(routeSegments)
-    const fare = calculateFareFromPath(correctedPath)
-        + calculateBarrierFreeFeeFromPath(correctedPath);
+    const totalEigyoKilo = calculateTotalEigyoKilo(routeSegments);
+
+    const fare = cheapestFare !== null
+        ? cheapestFare
+        : calculateFareFromPath(correctedPath) + calculateBarrierFreeFeeFromPath(correctedPath);
+
     const validDays = calculateValidDaysFromKilo(totalEigyoKilo);
 
     // 経由文字列の生成 (ユーザー入力の経路を使用)
     const printedViaLines = generatePrintedViaStrings(correctedPath);
+
     return {
         totalEigyoKilo,
         departureStation,

--- a/src/app/mr/page.tsx
+++ b/src/app/mr/page.tsx
@@ -20,11 +20,23 @@ export default function Page() {
           <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 tracking-tight mb-3">
             運賃計算（経路入力）
           </h1>
-          <p className="text-sm sm:text-base text-slate-600">
+
+          <p className="text-sm sm:text-base text-slate-600 leading-relaxed mb-5">
             在来線の「発駅」「着駅」、および経由を入力してください。<br className="hidden sm:block" />
             片道乗車券の運賃を計算します。
-            経路重複による運賃計算の制限は行っていません。
           </p>
+
+          {/* 仕様・制限事項の枠組み */}
+          <div className="inline-block text-left bg-slate-50 border border-slate-200 rounded-lg p-4 max-w-xl mx-auto">
+            <p className="font-semibold text-xs sm:text-sm text-slate-600 mb-2">
+              【現在の仕様・制限事項】
+            </p>
+            <ul className="text-xs sm:text-sm text-slate-500 list-disc list-inside space-y-1">
+              <li>このプログラムで計算できる経由路線数の上限は99です。</li>
+              <li>経路の重複による運賃計算の制限は行っていません。</li>
+              <li>大都市近郊区間内完結の場合の最安経路への補正には対応していません。</li>
+            </ul>
+          </div>
         </div>
 
         {/* フォーム領域（カードスタイル） */}

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -54,6 +54,7 @@ export interface PathStep {
 
 export interface RouteRequest {
     path: PathStep[];
+    calculationMode: CalculationMode;
 }
 
 export interface KippuData {
@@ -160,3 +161,5 @@ export interface OuterSection {
     stations: string[];
     routes: PathStep[];
 }
+
+export type CalculationMode = "normal" | "cheapest" | "uncorrect";


### PR DESCRIPTION
## 概要
運賃計算処理において、従来の「発売可能なルートへの補正」に加え、「補正禁止」および「最安探索（経路延長による運賃の適用）」を選べるように、3つの運賃計算モードを追加しました。
また、これに伴いフロント・API・計算エンジン間で使われる型定義のクリーンアップを行っています。

## 背景・目的
* 特殊な計算要件や検証のため、「補正を行わない経路」や「経路を伸ばした方が安くなる場合の検出」での計算機能が必要だったため。
* 各層（UI, API, Core）でバラバラになっていた設定値の型を `types` で一元管理し、堅牢な設計にするため。

## 変更内容
* **UI:** * 運賃計算画面に「運賃計算モード」を選択するラジオボタン（通常 / 最安 / 補正禁止）を追加。
* **型定義 (`@/app/types`):** * `CalculationMode` 型 (`"normal" | "cheapest" | "uncorrect"`) を新設し、`RouteRequest` に統合。
* **バックエンド (API & Logic):** * `route.ts` の型定義を整理し、独自の型宣言を削除して共通の `RouteRequest` を使用するよう修正。
  * `generateKippu` 内の経路補正処理を `switch` 文にリファクタリングし、選択されたモードに応じて処理 (`correctPath` / `cheapestPathAndFare` / `uncorrectPath`) を分岐。

## 影響範囲
* 運賃計算画面の入力フォーム UI
* `/api/mr` エンドポイントのリクエスト受け付け処理
* `generateKippu` 関数の計算フロー

## 確認手順
- [x] ローカル環境を起動し、任意の経路を入力する。
- [x] 運賃計算モード「通常」を選択し、これまで通り発売可能なルートに補正されて計算されることを確認する。
- [x] 運賃計算モード「補正禁止」を選択し、入力した経路のままで計算されることを確認する。
- [x] 運賃計算モード「最安」を選択し、エラーなく計算処理が完了することを確認する。

## 備考
* 「補正禁止」モードを選択した場合、旅客営業規則上本来は発券不可となる経路でも理論値として計算を実行します。
* 「最安探索」モードの `cheapestPathAndFare` については、旅客営業規則 第69条の〇印が無い経路上と旅客営業取扱基準規程 第114条の範囲で計算を行う仕様としています。