### PR TITLE
fix: 最安探索モード適用時に安くなった運賃が正しく出力・表示されない不具合を修正

### DIFF
--- a/src/app/mr/lib/generateKippu.ts
+++ b/src/app/mr/lib/generateKippu.ts
@@ -1,8 +1,7 @@
-import { calculateTotalEigyoKilo, calculateValidDaysFromKilo, convertPathStepsToRouteSegments, generatePrintedViaStrings } from '@/app/utils/calc';
+import { calculateTotalEigyoKilo, calculateValidDaysFromKilo, convertPathStepsToRouteSegments, generatePrintedViaStrings, getFareForPath } from '@/app/utils/calc';
 import { loadLines } from '@/app/mr/lib/loadLines';
 import { loadKanas } from '@/app/mr/lib/loadKanas';
 import { correctPath, uncorrectPath } from '@/app/utils/correctPath';
-import { calculateFareFromPath, calculateBarrierFreeFeeFromPath } from '@/app/utils/calcFare';
 import { cheapestPathAndFare } from '@/app/utils/cheapestPath';
 
 import { RouteRequest, KippuData, PathStep, CalculationMode } from '@/app/types';
@@ -20,14 +19,13 @@ export function generateKippu(request: RouteRequest, options: GenerateKippuOptio
 
     // 経路の補正
     let correctedPath: PathStep[];
-    let cheapestFare: number | null = null;
+
     switch (calculationMode) {
         case "uncorrect":
             correctedPath = uncorrectPath(fullPath);
             break;
         case "cheapest":
-            const cheapestResult = cheapestPathAndFare(fullPath);
-            correctedPath = cheapestResult.path;
+            correctedPath = correctPath(cheapestPathAndFare(fullPath).path);
             break;
         case "normal":
         default:
@@ -43,9 +41,7 @@ export function generateKippu(request: RouteRequest, options: GenerateKippuOptio
     const routeSegments = convertPathStepsToRouteSegments(correctedPath);
     const totalEigyoKilo = calculateTotalEigyoKilo(routeSegments);
 
-    const fare = cheapestFare !== null
-        ? cheapestFare
-        : calculateFareFromPath(correctedPath) + calculateBarrierFreeFeeFromPath(correctedPath);
+    const fare = getFareForPath(correctedPath);
 
     const validDays = calculateValidDaysFromKilo(totalEigyoKilo);
 


### PR DESCRIPTION
## 概要
運賃計算モードで「最安」を選択した際、経路（駅名）は最安となるルートに補正されて表示されるものの、運賃が補正前の高い金額のまま出力されてしまう不具合を修正しました。

## 原因
経路の再計算（補正）処理と、運賃の算出処理の間で値の受け渡しに漏れがあり、`calculationMode: "cheapest"` によって導き出された経路が、最終的なデータへ上書きする前に補正をしていなかったため。

## 修正内容
* 最安探索ロジックから返却される「最安運賃」の数値を適切に保持し、最終的な `fare` に代入・反映されるように修正。

## 確認手順
1. ローカル環境にて運賃計算モード「最安」を選択。
2. 経路を伸ばしたほうが安くなる特定の区間（例：函館 → 大森 → 東森）を入力。
3. 計算結果の経路が延長後のものになり、かつ**運賃も延長後の安い金額を正しく表示されること**を確認。

## 関連Issue
Fixes #24 