### PR TITLE
fix: 鉄道駅バリアフリー料金の判定条件の誤りを修正

### DIFF
--- a/src/app/utils/calcFare.ts
+++ b/src/app/utils/calcFare.ts
@@ -731,6 +731,6 @@ export function calculateBarrierFreeFeeFromPath(fullPath: PathStep[]): number {
     const routeKeys = convertPathStepsToRouteKeys(fullPath);
     if (isAllTrainSpecificSections("電車特定区間", routeKeys)) return 10;
     if (isAllTrainSpecificSections("名古屋附近", routeKeys)) return 10;
-    if (routeKeys.size === 1 || routeKeys.has(createRouteKey("シンカ", "東京", "品川"))) return 10;
+    if (routeKeys.size === 1 && routeKeys.has(createRouteKey("シンカ", "東京", "品川"))) return 10;
     return 0;
 }


### PR DESCRIPTION
先ほどのコミットにて、東海道新幹線の鉄道バリアフリー料金において、routeKeys.size === 1 と 東京-品川区間の判定を || (OR) で結んでしまっていたため、&& (AND) に修正しました。これにより、他の路線を含む経路で誤ってバリアフリー料金が加算される不具合を解消しています。