### PR TITLE
fix: 更新履歴の表示から不要なIssue/コミットリンクを完全に除去

### DIFF
--- a/src/app/lib/changelog.ts
+++ b/src/app/lib/changelog.ts
@@ -4,7 +4,7 @@ import path from 'path';
 export interface ChangelogItem {
     date: string;
     version: string;
-    url?: string; // GitHubへのリンクURLを追加
+    url?: string;
     tag: 'アップデート' | '修正' | 'お知らせ';
     contents: string[];
 }
@@ -37,14 +37,17 @@ export async function getChangelogs(limit?: number): Promise<ChangelogItem[]> {
             if (section.includes('### Bug Fixes')) tag = '修正';
             else if (section.includes('### Features')) tag = 'アップデート';
 
-            // 箇条書きの更新内容を綺麗に抽出
             const contents = lines
                 .filter(line => line.trim().startsWith('*') || line.trim().startsWith('-'))
                 .map(line => {
-                    let text = line.replace(/^[\*\-]\s+/, ''); // 先頭の * や - を削除
+                    // 1. 先にtrim()して見えない改行コード(\r)や前後の空白を確実に除去
+                    let text = line.trim().replace(/^[\*\-]\s+/, '');
                     text = text.replace(/\*\*/g, ''); // 太字の ** を削除
-                    // 行末のコミットハッシュリンク "([3c6e0de](https:...))" を削除
-                    text = text.replace(/\s*\(\[[a-f0-9]+\]\([^)]+\)\)\s*$/, '');
+
+                    // 2. 行末の Issueリンク、コミットハッシュリンク、closes 等をまとめて削除
+                    // ※ [#32] や [c29b834] のような Issue番号・コミットハッシュの形式のみを対象としています
+                    text = text.replace(/(?:\s*(?:,?\s*closes\s*)?\(?\[(?:#[0-9]+|[a-f0-9]+)\]\([^)]+\)\)?)+$/i, '');
+
                     return text.trim();
                 });
 


### PR DESCRIPTION
## 概要
更新履歴ページに `CHANGELOG.md` の内容を反映させる際、行末の Issue リンクやコミットハッシュ（例: `([#32](...)) ([c29b834](...))`）がテキストとしてそのまま画面に表示されてしまう不具合を修正しました。

## 原因
今回の抽出漏れは、主に以下の2点が原因でした。

1. **正規表現のカバー範囲不足:**
   従来の正規表現では、行末に1つのリンクが存在するケースのみを想定しており、複数のリンクが連続するケースや、`, closes [#18]` のようなフォーマットに対応できていませんでした。
2. **改行コード（CRLF）による正規表現の判定ミス:**
   `CHANGELOG.md` が CRLF で保存されている場合、行分割（`split('\n')`）時に末尾にキャリッジリターン（`\r`）が残り、これが正規表現の `$`（行末）の判定を妨害して置換処理がスキップされていました。

## 変更内容
- 行末の不要な文字列除去の直前に `.trim()` を実行し、`\r` などの不可視文字を確実に除去するように修正。
- 正規表現を刷新し、複数の Markdown リンクや `closes` の記述が連なっている場合でも、一括でキャッチして削除できるように強化。
- 通常のテキストリンク等を誤って削除する事故を防ぐため、削除対象を `#[数字]` および `[英数字ハッシュ]` を含むフォーマットに厳格化。

## 影響範囲
- 更新履歴のパース・表示ロジック (`getChangelogs` 関数)
- ※ 既存の運賃計算やその他コア機能への影響はありません。

## 確認手順
1. 当ブランチをチェックアウトし、ローカルサーバーを起動。
2. 更新履歴ページにアクセスする。
3. `CHANGELOG.md` 内に複数の Issue リンクや `closes` が含まれるバージョン（例: v1.4.1 や v1.4.0）の更新内容に、不要な URL や `([#xx])` などの文字列が残っていないことを確認する。
4. 通常の日本語テキストが欠損していないことを確認する。