### PR TITLE
fix: スマホメニュー展開時のオーバーレイ表示領域と背景スクロールのバグ修正

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { FaBookOpen } from "react-icons/fa";
 import { MdMenu, MdClear, MdHome } from "react-icons/md";
 import { RiGuideLine, RiScissorsFill } from "react-icons/ri";
@@ -22,31 +22,45 @@ const Header = () => {
         setOpenMenu((prev) => !prev);
     };
 
+    useEffect(() => {
+        if (openMenu) {
+            document.body.style.overflow = "hidden";
+        } else {
+            document.body.style.overflow = "";
+        }
+
+        return () => {
+            document.body.style.overflow = "";
+        };
+    }, [openMenu]);
+
     return (
-        <header className="sticky top-0 bg-white/80 backdrop-blur-md z-20 border-b border-slate-200 flex items-center justify-between h-16 px-4 sm:px-6" >
+        <header className="sticky top-0 z-20 border-b border-slate-200 flex items-center justify-between h-16 px-4 sm:px-6">
+
+            <div className="absolute inset-0 bg-white/80 backdrop-blur-md -z-10" />
+
             <h1>
-                <Link href="/" className="text-2xl font-bold tracking-tight text-blue-600 hover:opacity-80 transition-opacity font-logo">
+                <Link href="/" className="text-2xl font-bold tracking-tight text-blue-600 hover:opacity-80 transition-opacity font-logo relative z-50">
                     きっぷナビ
                 </Link>
             </h1>
 
             <button
                 onClick={handleMenuToggle}
-                className="text-3xl z-50 md:hidden text-slate-700 hover:text-blue-600 transition-colors"
+                className="relative text-3xl z-50 md:hidden text-slate-700 hover:text-blue-600 transition-colors"
                 aria-label={openMenu ? "メニューバーを閉じる" : "メニューバーを開く"}
                 aria-expanded={openMenu}
             >
                 {openMenu ? <MdClear /> : <MdMenu />}
             </button>
 
-            {
-                openMenu && (
-                    <div
-                        className="fixed inset-0 bg-slate-900/50 backdrop-blur-sm z-30 md:hidden transition-opacity"
-                        onClick={handleMenuToggle}
-                    />
-                )
-            }
+            {openMenu && (
+                <div
+                    className="fixed inset-0 bg-slate-900/50 backdrop-blur-sm z-30 md:hidden transition-opacity"
+                    onClick={handleMenuToggle}
+                />
+            )}
+
             <nav
                 className={`fixed top-0 right-0 h-screen w-64 bg-white shadow-2xl transform transition-transform duration-300 ease-in-out z-40
                 ${openMenu ? "translate-x-0" : "translate-x-full"}
@@ -72,7 +86,7 @@ const Header = () => {
                     })}
                 </ul>
             </nav>
-        </header >
+        </header>
     );
 };
 


### PR DESCRIPTION
## 概要
スマホビューにおいて、ハンバーガーメニュー展開時の背景オーバーレイ（グレーの半透明背景）が画面全体を覆わず、ヘッダーの高さ分しか適用されない不具合、およびメニュー展開中に背面のコンテンツがスクロールできてしまう不具合を修正しました。

## 原因
大枠の `<header>` 要素に対して直接 `backdrop-blur-md` を指定していたため、CSSの仕様により新たな**包含ブロック（Containing Block）**が生成されていました。
これにより、内部の `fixed inset-0`（オーバーレイ要素）の基準点が「画面全体」ではなく「ヘッダー」になってしまい、高さが制限されていました。

## 変更内容
1. **フィルター要素の分離**
   - `<header>` 自体の `backdrop-blur` を削除し、背面に絶対配置（`absolute inset-0 -z-10`）した空の `div` にフィルターを適用する構造に変更しました。これにより `fixed` 要素の閉じ込めを回避しています。
2. **背面スクロールのロック**
   - `useEffect` を導入し、メニュー展開時（`openMenu === true`）は `document.body.style.overflow = "hidden"` を適用し、ネイティブアプリのような自然なスクロール制御を追加しました。
3. **z-indexの整理**
   - オーバーレイ（`z-30`）、メニュー（`z-40`）、ロゴやボタン（`z-50`）の重ね順を確実に機能させるため、必要箇所に `relative` を追記しました。

## 確認手順
1. 本ブランチをローカルで起動（`npm run dev`）し、モバイル表示（または画面幅を狭める）にする。
2. ヘッダーのハンバーガーボタン（`MdMenu`）をクリックする。
3. 以下の挙動を確認する。
   - [x] グレーの半透明なオーバーレイが、画面全体（下まで）を正しく覆っていること。
   - [x] メニューが開いている間、背面のページ（body）がスクロールできないこと。
   - [x] グレーのオーバーレイ部分をクリックすると、正しくメニューが閉じること。
   - [x] ヘッダー本来の「すりガラス効果（backdrop-blur）」がスクロール時にも維持されていること。