### PR TITLE
ui: スマホメニュー展開時のオーバーレイ表示領域の最適化（ヘッダーの視認性維持）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 
 ### Bug Fixes
 
-* **ui:** 発着駅名が長い場合に画面外にはみ出るレイアウト問題を修正 ([3c6e0de](https://github.com/tojoryohei/kippu-navi/commit/3c6e0de03be2b23970eaa3879645bc4a22c11bac))
+* 発着駅名が長い場合に画面外にはみ出るレイアウト問題を修正 ([3c6e0de](https://github.com/tojoryohei/kippu-navi/commit/3c6e0de03be2b23970eaa3879645bc4a22c11bac))
 
 
 ## [1.1.0](https://github.com/tojoryohei/kippu-navi/releases/tag/kippu-navi-v1.1.0) (2026-04-18)

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -56,7 +56,7 @@ const Header = () => {
 
             {openMenu && (
                 <div
-                    className="fixed inset-0 bg-slate-900/50 backdrop-blur-sm z-30 md:hidden transition-opacity"
+                    className="fixed top-16 inset-x-0 bottom-0 bg-slate-900/50 backdrop-blur-sm z-30 md:hidden transition-opacity"
                     onClick={handleMenuToggle}
                 />
             )}


### PR DESCRIPTION
## 概要
モバイル端末でのハンバーガーメニュー展開時において、グレーの半透明オーバーレイがヘッダー部分まで覆ってしまっていたUIを改善しました。
ヘッダー領域（`h-16`）にはオーバーレイをかけず、常に本来の明るさとすりガラス効果（backdrop-blur）を維持する仕様に変更しています。

## 変更内容
- `Header.tsx` 内のオーバーレイ用 `div` のTailwindクラスを変更。
  - 変更前: `fixed inset-0 ...` （画面全体を覆う）
  - 変更後: `fixed top-16 inset-x-0 bottom-0 ...` （ヘッダーのすぐ下から画面下部までを覆う）

## 変更理由・背景（UXへの寄与）
- **空間構造の明確化**: ヘッダーを常に最前面の明るい層として残し、その下の層（ボディ部分）だけを暗くすることで、「ヘッダーがサイトの基盤として固定されており、メニューがその上に展開されている」というUIの奥行き（Z軸の構造）をユーザーに直感的に伝えるため。
- **ブランド認知の維持**: サイトの顔である左上のロゴ（きっぷナビ）が暗く沈むのを防ぎ、クリーンな印象と安心感を提供するため。
- 開発者視点ではなく、実際のユーザー操作時の違和感を払拭する目的で本質的なUI改善を行いました。

## 確認手順
1. 本ブランチをローカルで起動（`npm run dev`）し、モバイル幅で表示。
2. ヘッダーのハンバーガーボタンをクリックし、メニューを展開。
3. 以下の視覚的変化を確認する。
   - [x] ヘッダー部分（ロゴとボタンの背景）は暗くならず、元の白さと `backdrop-blur` を保っていること。
   - [x] ヘッダーのすぐ下（`top-16`）から画面の最下部にかけて、グレーのオーバーレイが正しくかかっていること。
   - [x] オーバーレイ部分をクリックするとメニューが閉じること。