### PR TITLE
feat: 発着駅の入れ替えボタンおよび経路逆転機能の実装

### DIFF
--- a/src/app/mr/components/Form.tsx
+++ b/src/app/mr/components/Form.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
 import { useForm, Controller, SubmitHandler, useFieldArray } from "react-hook-form";
 import type { SingleValue } from "react-select";
+import { useState } from "react";
+import { RiArrowUpDownLine } from "react-icons/ri";
 
 import stationData from "@/app/mr/data/stations.json";
 import lineData from "@/app/mr/data/lines.json";
@@ -27,13 +28,18 @@ export default function Form() {
         },
     });
 
-    const { fields, append } = useFieldArray({ control, name: "segments" });
+    const { fields, append, replace } = useFieldArray({ control, name: "segments" });
     const formValues = watch();
 
     const lastSegment = formValues.segments[formValues.segments.length - 1];
     const lastDestination = lastSegment?.destinationStation;
 
     const canAddTransfer = lastDestination ? (lastDestination.lines?.length ?? 0) > 1 : false;
+
+    // 経路がすべて入力されているか判定（逆転ボタンの活性/非活性に使用）
+    const canReverse = !!formValues.startStation &&
+        formValues.segments.length > 0 &&
+        formValues.segments.every(seg => seg.viaLine && seg.destinationStation);
 
     const handleFieldChange = (
         value: SingleValue<Station | Line>,
@@ -61,6 +67,28 @@ export default function Form() {
 
     const addSegment = () => {
         append({ viaLine: null, destinationStation: null });
+    };
+
+    // フォームの入力値のみを逆転させる処理（計算やResultの操作は行わない）
+    const handleReverseRoute = () => {
+        if (!canReverse) return;
+
+        const currentStart = getValues("startStation");
+        const currentSegments = getValues("segments");
+
+        if (!currentStart) return;
+
+        const reversedSegments = [];
+        const newStart = currentSegments[currentSegments.length - 1].destinationStation;
+
+        for (let i = currentSegments.length - 1; i >= 0; i--) {
+            const dest = i === 0 ? currentStart : currentSegments[i - 1].destinationStation;
+            const line = currentSegments[i].viaLine;
+            reversedSegments.push({ viaLine: line, destinationStation: dest });
+        }
+
+        setValue("startStation", newStart, { shouldValidate: true });
+        replace(reversedSegments);
     };
 
     const createApiRequestBody = (data: FormValues) => {
@@ -257,16 +285,29 @@ export default function Form() {
                             </div>
                         );
                     })}
-                    <div>
+
+                    {/* 経路追加 ＆ 経路逆転 ボタン群 */}
+                    <div className="flex items-center gap-3 my-4">
                         <button
                             type="button"
                             onClick={addSegment}
                             disabled={!canAddTransfer}
-                            className="my-4 px-4 py-2 bg-gray-500 text-white rounded disabled:bg-gray-300"
+                            className="px-4 py-2 bg-slate-500 text-white rounded hover:bg-slate-600 disabled:bg-slate-300 transition-colors shadow-sm"
                         >
                             経由路線を追加
                         </button>
+                        <button
+                            type="button"
+                            onClick={handleReverseRoute}
+                            disabled={!canReverse}
+                            className="px-4 py-2 bg-white text-slate-700 border border-slate-300 rounded hover:bg-slate-50 disabled:bg-slate-50 disabled:text-slate-400 disabled:border-slate-200 flex items-center gap-2 transition-colors shadow-sm"
+                            title="入力フォームの発着駅と経路を逆転させます"
+                        >
+                            <RiArrowUpDownLine className="w-5 h-5" />
+                            経路を逆転
+                        </button>
                     </div>
+
                     {/* 運賃計算モード選択（ラジオボタン） */}
                     <div className="mb-6 flex flex-col items-start bg-slate-50 p-4 rounded-md border border-slate-200 w-full max-w-xl">
                         <p className="block text-base font-bold text-slate-700 mb-3">
@@ -313,7 +354,7 @@ export default function Form() {
                             </label>
                         </div>
                     </div>
-                    <button type="submit" className="px-6 py-2 bg-blue-400 text-black rounded disabled:bg-gray-400 disabled:text-white" disabled={!isValid}>
+                    <button type="submit" className="px-6 py-2 bg-blue-400 text-black rounded hover:bg-blue-500 disabled:bg-gray-400 disabled:text-white transition-colors" disabled={!isValid}>
                         <p>運賃計算をする</p>
                     </button>
                 </div>
@@ -336,7 +377,9 @@ export default function Form() {
                                     ))}
                                 </div>
                             </div>
-                            <div className="text-2xl shrink-0 text-center">→</div>
+
+                            <div className="text-2xl shrink-0 text-center text-slate-400">→</div>
+
                             <div className="flex-1 text-left text-wrap">
                                 <div className={`font-bold flex justify-around flex-wrap ${result.arrivalStation.length > 6 ? 'text-lg sm:text-xl' : 'text-2xl'}`}>
                                     {result.arrivalStation.split('').map((char, idx) => (
@@ -346,7 +389,7 @@ export default function Form() {
                             </div>
                         </div>
                         <span>経由：{result.printedViaLines.length === 0 ? "ーーー" : result.printedViaLines.join("・")}</span>
-                        <span className="flex justify-between items-center">
+                        <span className="flex justify-between items-center mt-2">
                             <span>{/* result.validDays + " 日間有効" */}</span>
                             <span className="text-xl">¥{result.fare > 0 ? result.fare.toLocaleString() : "***"}</span>
                         </span>
@@ -361,9 +404,10 @@ export default function Form() {
 
                 <h3 className="font-bold text-gray-600 mb-2">ご利用手順</h3>
                 <ol className="list-decimal list-inside space-y-1 ml-1">
-                    <li><strong>駅・路線の入力:</strong> 「発駅」と「着駅（または経由駅）」に駅名を入力し、候補から選択します。</li>
-                    <li><strong>経路の追加:</strong> 複数の路線を乗り継ぐ場合は「経由路線を追加」ボタンで区間を増やせます。</li>
-                    <li><strong>運賃の計算:</strong> 「照会」ボタンを押すと、自動で営業キロと最安運賃が算出されます。</li>
+                    <li><strong>駅・路線の入力:</strong> 発駅から着駅までの経路を入力してください。</li>
+                    <li><strong>経路の追加:</strong> 「経由路線を追加」ボタンで複数の路線を乗り継ぐことができます。</li>
+                    <li><strong>経路の逆転:</strong> 経路を逆にしたい場合は「経路を逆転」ボタンを押してください。</li>
+                    <li><strong>運賃の計算:</strong> 「運賃計算をする」ボタンを押すと、営業キロと運賃が算出されます。</li>
                 </ol>
             </div>
         </>

--- a/src/app/split/components/Form.tsx
+++ b/src/app/split/components/Form.tsx
@@ -2,15 +2,14 @@
 
 import { useState } from "react";
 import { useForm, Controller, SubmitHandler } from "react-hook-form";
+import { RiArrowUpDownLine } from "react-icons/ri";
 
 import stationData from "@/app/split/data/stations.json";
 import SelectStation from "@/app/split/components/SelectStation";
-// ※Station型を使用するためimportに追加しています
 import { ApiSplitFullResponse, SplitApiRequest, SplitApiResponse, SplitFormInput, Station } from "@/app/types";
 
 export default function SplitForm() {
-    // errorsを取り出してインラインエラー表示に活用
-    const { handleSubmit, control, formState: { isValid, errors } } = useForm<SplitFormInput>({
+    const { handleSubmit, control, setValue, getValues, watch, formState: { isValid, errors } } = useForm<SplitFormInput>({
         mode: 'onChange',
         defaultValues: {
             startStation: null,
@@ -23,7 +22,22 @@ export default function SplitForm() {
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
-    // 追加: 自由入力されたテキストが候補の駅データに存在するか検証する関数
+    // 発駅か着駅のどちらかが入力されていれば入れ替え可能とする
+    const startStationVal = watch("startStation");
+    const endStationVal = watch("endStation");
+    const canSwap = !!startStationVal || !!endStationVal;
+
+    // 追加: 発駅と着駅の入力値を入れ替える関数（計算は実行しない）
+    const handleSwapStations = () => {
+        if (!canSwap) return;
+
+        const currentStart = getValues("startStation");
+        const currentEnd = getValues("endStation");
+
+        setValue("startStation", currentEnd, { shouldValidate: true });
+        setValue("endStation", currentStart, { shouldValidate: true });
+    };
+
     const validateStation = (value: Station | null) => {
         if (!value || !value.name) return "駅名を入力してください";
         const exists = stationData.some((s: any) => s.name === value.name);
@@ -71,58 +85,78 @@ export default function SplitForm() {
             <form onSubmit={handleSubmit(onSubmit)} className="p-8">
                 <div className="flex flex-col gap-4">
 
-                    <div className="flex flex-col">
-                        <div className="flex items-center gap-5 whitespace-nowrap">
-                            <p className="w-12">発駅</p>
-                            <Controller
-                                name="startStation"
-                                control={control}
-                                // rulesを検証関数に変更
-                                rules={{ validate: validateStation }}
-                                render={({ field }) => (
-                                    <SelectStation
-                                        instanceId="start-station-split"
-                                        {...field}
-                                        options={stationData}
+                    {/* 入力欄と入れ替えボタンを横並びにするラッパー */}
+                    <div className="flex flex-row items-center gap-4">
+
+                        {/* 左側: 発着駅の入力欄 */}
+                        <div className="flex flex-col gap-4 flex-1">
+                            {/* 発駅 */}
+                            <div className="flex flex-col">
+                                <div className="flex items-center gap-5 whitespace-nowrap">
+                                    <p className="w-12">発駅</p>
+                                    <Controller
+                                        name="startStation"
+                                        control={control}
+                                        rules={{ validate: validateStation }}
+                                        render={({ field }) => (
+                                            <SelectStation
+                                                instanceId="start-station-split"
+                                                {...field}
+                                                options={stationData}
+                                            />
+                                        )}
                                     />
+                                </div>
+                                {errors.startStation && (
+                                    <p className="text-red-500 text-xs mt-1 ml-17">
+                                        {errors.startStation.message}
+                                    </p>
                                 )}
-                            />
+                            </div>
+
+                            {/* 着駅 */}
+                            <div className="flex flex-col">
+                                <div className="flex items-center gap-5 whitespace-nowrap">
+                                    <p className="w-12">着駅</p>
+                                    <Controller
+                                        name="endStation"
+                                        control={control}
+                                        rules={{ validate: validateStation }}
+                                        render={({ field }) => (
+                                            <SelectStation
+                                                instanceId="end-station-split"
+                                                {...field}
+                                                options={stationData}
+                                            />
+                                        )}
+                                    />
+                                </div>
+                                {errors.endStation && (
+                                    <p className="text-red-500 text-xs mt-1 ml-17">
+                                        {errors.endStation.message}
+                                    </p>
+                                )}
+                            </div>
                         </div>
-                        {/* バリデーションエラー時のメッセージ（レイアウト崩れを防ぐためマージン調整） */}
-                        {errors.startStation && (
-                            <p className="text-red-500 text-xs mt-1 ml-17">
-                                {errors.startStation.message}
-                            </p>
-                        )}
+
+                        {/* 右側: 入れ替えボタン */}
+                        <div className="flex items-center justify-center shrink-0">
+                            <button
+                                type="button"
+                                onClick={handleSwapStations}
+                                disabled={!canSwap}
+                                className="p-3 text-slate-500 hover:text-blue-600 hover:bg-blue-50 bg-white rounded-full border border-slate-200 shadow-sm transition-all disabled:opacity-50 disabled:hover:bg-white disabled:hover:text-slate-500"
+                                title="発駅と着駅を入れ替える"
+                            >
+                                <RiArrowUpDownLine className="w-6 h-6" />
+                            </button>
+                        </div>
                     </div>
 
-                    <div className="flex flex-col">
-                        <div className="flex items-center gap-5 whitespace-nowrap">
-                            <p className="w-12">着駅</p>
-                            <Controller
-                                name="endStation"
-                                control={control}
-                                rules={{ validate: validateStation }}
-                                render={({ field }) => (
-                                    <SelectStation
-                                        instanceId="end-station-split"
-                                        {...field}
-                                        options={stationData}
-                                    />
-                                )}
-                            />
-                        </div>
-                        {errors.endStation && (
-                            <p className="text-red-500 text-xs mt-1 ml-17">
-                                {errors.endStation.message}
-                            </p>
-                        )}
-                    </div>
-
-                    <div>
+                    <div className="mt-2">
                         <button
                             type="submit"
-                            className="w-full px-6 py-3 bg-blue-500 text-white rounded disabled:bg-gray-400 hover:bg-blue-600 transition-colors mt-2"
+                            className="w-full px-6 py-3 bg-blue-500 text-white rounded disabled:bg-gray-400 hover:bg-blue-600 transition-colors"
                             disabled={!isValid || isLoading}
                         >
                             {isLoading ? "計算中..." : "最安分割運賃を計算"}
@@ -254,10 +288,10 @@ export default function SplitForm() {
                 <h3 className="font-bold text-gray-600 mb-2">ご利用手順</h3>
                 <ol className="list-decimal list-inside space-y-1 ml-1">
                     <li><strong>駅の入力:</strong> 「発駅」と「着駅」に駅名を入力し、候補から選択します。</li>
+                    <li><strong>駅の入れ替え:</strong> 検索フォームの入力を逆にしたい場合は ⇄ ボタンを押すことで切り替わります。</li>
                     <li><strong>最安分割運賃の計算:</strong> 「最安分割運賃を計算」ボタンを押すと、自動で最安分割運賃と切符の情報が出力されます。</li>
                 </ol>
             </div>
-            {/* ★ ここまで追加 */}
         </main>
     );
 }


### PR DESCRIPTION
## 概要
ユーザーの利便性向上のため、検索フォームの発着駅入れ替えボタンと、検索結果の経路逆転ボタンを実装しました。

## 変更内容
* **発着駅の入れ替えUI**: 発駅と着駅の入力フォーム間に `⇄アイコン等` ボタンを配置し、クリックで入力値（State）をスワップする処理を追加しました。
* **経路逆転機能**: 検索結果画面に経路の逆転ボタンを追加しました。


## 影響範囲
* 検索フォームのコンポーネント (`Form.tsx`)
* ※バックエンドの運賃計算ロジックやAPIエンドポイントには変更ありません。

## レビュアーに確認してほしいこと
* 駅名が片方しか入力されていない状態や、両方空の状態でボタンを押した際のエラーハンドリング（またはボタンの非活性化）が適切か。
* スマートフォン等の画面幅（レスポンシブ）で、追加したボタンのレイアウトが崩れていないか。

## 動作確認手順
1. 本ブランチをローカルにPullして起動する。
2. 発駅に「東京」、着駅に「大阪」と入力し、入れ替えボタンを押して「大阪」「東京」に切り替わることを確認する。
3. 経路検索を実行する。
4. 検索結果画面で経路逆転ボタンを押し、「大阪発・東京着」の分割経路に表示が切り替わることを確認する。