### PR TITLE
fix: 山手線内発着における第114条適用の足切り閾値を適正化し、適用漏れを解消

### DIFF
--- a/src/app/utils/cheapestPath.ts
+++ b/src/app/utils/cheapestPath.ts
@@ -61,13 +61,13 @@ export function extendFromCity(originalPath: PathStep[]): PathStep[] {
     const currentDistance = calculateTotalGiseiKilo(currentSegments);
 
     // 発着駅が山手線内にあるか確認して足切りラインを決定
-    // 山手線内駅が含まれる場合は120km(1200)、それ以外は200km(2000)
+    // 山手線内駅が含まれる場合は100km(1000)、それ以外は200km(2000)
     const yamanote = load.getYamanote();
     const stationsInYamanote = new Set(yamanote.stations);
     const startInYamanote = stationsInYamanote.has(originalPath[0].stationName);
     const endInYamanote = stationsInYamanote.has(originalPath[originalPath.length - 1].stationName);
 
-    const pruneLimit = (startInYamanote || endInYamanote) ? 1200 : 2000;
+    const pruneLimit = (startInYamanote || endInYamanote) ? 1000 : 2000;
 
     if (currentDistance <= pruneLimit) {
         return originalPath;


### PR DESCRIPTION
## 概要
先行して修正した特定都区市内（200kmルール）の閾値適正化に続き、 **山手線内発着（100kmルール）** のケースにおける最安運賃計算（第114条適用）の経路探索漏れを修正しました。

## 原因（なぜ従来のロジックで漏れていたか）
特定都区市内のルールと同様に、山手線内発着の特例においても、延伸による運賃低減の恩恵を受けられるのは「元の運賃計算キロが、ルールの適用距離である100.0kmを既に超えている場合のみ」です。
前回の対応で特定都区市内向けの閾値は修正しましたが、山手線内向けの従来の足切り閾値（`1200`）がそのままになっており、「100km〜120km」の運賃帯で安くなる可能性のある経路が、探索処理に入る前に誤って弾かれてしまっていました。

## 修正内容
`extendFromCity` 関数内において、山手線内発着が含まれる場合の足切り閾値（`pruneLimit`）を、運賃の単調増加の原則に基づき以下のように修正しました。

* 山手線内発着が含まれる場合: `1200` → `1000` (100.0km)

## 期待される効果
* **適用漏れの完全解消**: 山手線内発着のケースにおいても、第114条の恩恵を受けられる可能性のあるすべての経路が、理論上漏れなく検出されるようになります。
* 先の特定都区市内の修正と合わせ、大都市周辺の特例に起因する探索漏れが完全に解消されます。

## 確認事項
* [x] 御徒町→谷峨（100.7km）などの入力で、延伸経路が正しく最安運賃として検出されることを確認しました。