### PR TITLE
fix: スマホ表示時のボタンテキストの意図しない改行を修正

### DIFF
--- a/src/app/mr/components/Form.tsx
+++ b/src/app/mr/components/Form.tsx
@@ -181,10 +181,12 @@ export default function Form() {
 
     return (
         <>
-            <form onSubmit={handleSubmit(onSubmit)} className="p-8">
-                <div className="flex flex-col">
-                    <div className="flex items-center gap-5 whitespace-nowrap">
-                        <p>発駅</p>
+            <form onSubmit={handleSubmit(onSubmit)} className="p-8 w-full">
+                <div className="flex flex-col gap-4 w-full">
+
+                    {/* 発駅 */}
+                    <div className="flex items-center gap-5 w-full whitespace-nowrap">
+                        <p className="w-12 shrink-0">発駅</p>
                         <Controller
                             name="startStation"
                             control={control}
@@ -197,19 +199,20 @@ export default function Form() {
                                 }
                             }}
                             render={({ field, fieldState }) => (
-                                <div>
+                                <div className="flex-1 min-w-0">
                                     <SelectStation
                                         instanceId="start-station"
                                         value={field.value}
                                         onChange={(value) => handleFieldChange(value, field.onChange, resetOnStartStationChange)}
                                         hideMenuWhenEmpty={true}
                                     />
-                                    {fieldState.error && <p className="text-red-500 text-xs">{fieldState.error.message}</p>}
+                                    {fieldState.error && <p className="text-red-500 text-xs mt-1">{fieldState.error.message}</p>}
                                 </div>
                             )}
                         />
                     </div>
 
+                    {/* 経由路線と着駅 */}
                     {fields.map((item, index) => {
                         const previousStation = index === 0
                             ? formValues.startStation
@@ -237,26 +240,31 @@ export default function Form() {
                         const stationLabel = isLastStation ? "着駅" : "経由";
 
                         return (
-                            <div key={item.id} >
-                                <Controller
-                                    name={`segments.${index}.viaLine`}
-                                    control={control}
-                                    rules={{ required: "経由路線を選択してください" }}
-                                    render={({ field, fieldState }) => (
-                                        <div>
-                                            <SelectLine
-                                                instanceId={`via-line-${index}`}
-                                                options={availableLines}
-                                                isDisabled={!previousStation}
-                                                value={field.value}
-                                                onChange={(value) => handleFieldChange(value, field.onChange, () => resetOnViaLineChange(index))}
-                                            />
-                                            {fieldState.error && <p className="text-red-500 text-xs">{fieldState.error.message}</p>}
-                                        </div>
-                                    )}
-                                />
-                                <div className="flex items-center gap-4 whitespace-nowrap">
-                                    <p>{stationLabel}</p>
+                            <div key={item.id} className="flex flex-col gap-4 w-full">
+                                {/* 路線（ラベルなしで、コンテナ幅いっぱいに広げる） */}
+                                <div className="w-full">
+                                    <Controller
+                                        name={`segments.${index}.viaLine`}
+                                        control={control}
+                                        rules={{ required: "経由路線を選択してください" }}
+                                        render={({ field, fieldState }) => (
+                                            <div className="w-full">
+                                                <SelectLine
+                                                    instanceId={`via-line-${index}`}
+                                                    options={availableLines}
+                                                    isDisabled={!previousStation}
+                                                    value={field.value}
+                                                    onChange={(value) => handleFieldChange(value, field.onChange, () => resetOnViaLineChange(index))}
+                                                />
+                                                {fieldState.error && <p className="text-red-500 text-xs mt-1">{fieldState.error.message}</p>}
+                                            </div>
+                                        )}
+                                    />
+                                </div>
+
+                                {/* 駅 */}
+                                <div className="flex items-center gap-5 w-full whitespace-nowrap">
+                                    <p className="w-12 shrink-0">{stationLabel}</p>
                                     <Controller
                                         name={`segments.${index}.destinationStation`}
                                         control={control}
@@ -269,7 +277,7 @@ export default function Form() {
                                             }
                                         }}
                                         render={({ field, fieldState }) => (
-                                            <div>
+                                            <div className="flex-1 min-w-0">
                                                 <SelectStation
                                                     instanceId={`dest-station-${index}`}
                                                     options={stationsOnLine}
@@ -277,7 +285,7 @@ export default function Form() {
                                                     value={field.value}
                                                     onChange={(value) => handleFieldChange(value, field.onChange, () => resetOnDestinationStationChange(index))}
                                                 />
-                                                {fieldState.error && <p className="text-red-500 text-xs">{fieldState.error.message}</p>}
+                                                {fieldState.error && <p className="text-red-500 text-xs mt-1">{fieldState.error.message}</p>}
                                             </div>
                                         )}
                                     />
@@ -287,12 +295,12 @@ export default function Form() {
                     })}
 
                     {/* 経路追加 ＆ 経路逆転 ボタン群 */}
-                    <div className="flex items-center gap-3 my-4">
+                    <div className="flex items-center flex-wrap gap-3 my-2 w-full">
                         <button
                             type="button"
                             onClick={addSegment}
                             disabled={!canAddTransfer}
-                            className="px-4 py-2 bg-slate-500 text-white rounded hover:bg-slate-600 disabled:bg-slate-300 transition-colors shadow-sm"
+                            className="px-4 py-2 bg-slate-500 text-white rounded hover:bg-slate-600 disabled:bg-slate-300 transition-colors shadow-sm whitespace-nowrap"
                         >
                             経由路線を追加
                         </button>
@@ -300,7 +308,7 @@ export default function Form() {
                             type="button"
                             onClick={handleReverseRoute}
                             disabled={!canReverse}
-                            className="px-4 py-2 bg-white text-slate-700 border border-slate-300 rounded hover:bg-slate-50 disabled:bg-slate-50 disabled:text-slate-400 disabled:border-slate-200 flex items-center gap-2 transition-colors shadow-sm"
+                            className="px-4 py-2 bg-white text-slate-700 border border-slate-300 rounded hover:bg-slate-50 disabled:bg-slate-50 disabled:text-slate-400 disabled:border-slate-200 flex items-center gap-2 transition-colors shadow-sm whitespace-nowrap"
                             title="入力フォームの発着駅と経路を逆転させます"
                         >
                             <RiArrowUpDownLine className="w-5 h-5" />
@@ -309,12 +317,11 @@ export default function Form() {
                     </div>
 
                     {/* 運賃計算モード選択（ラジオボタン） */}
-                    <div className="mb-6 flex flex-col items-start bg-slate-50 p-4 rounded-md border border-slate-200 w-full max-w-xl">
+                    <div className="my-4 flex flex-col items-start bg-slate-50 p-4 rounded-md border border-slate-200 w-full">
                         <p className="block text-base font-bold text-slate-700 mb-3">
                             運賃計算モード
                         </p>
-                        <div className="flex flex-col gap-3 w-full p-3">
-                            {/* ① 通常モード */}
+                        <div className="flex flex-col gap-3 w-full px-2">
                             <label className="inline-flex items-center cursor-pointer w-fit">
                                 <input
                                     type="radio"
@@ -327,7 +334,6 @@ export default function Form() {
                                 </span>
                             </label>
 
-                            {/* ② 最安探索モード */}
                             <label className="inline-flex items-center cursor-pointer w-fit">
                                 <input
                                     type="radio"
@@ -340,7 +346,6 @@ export default function Form() {
                                 </span>
                             </label>
 
-                            {/* ③ 補正禁止モード */}
                             <label className="inline-flex items-center cursor-pointer w-fit">
                                 <input
                                     type="radio"
@@ -354,11 +359,13 @@ export default function Form() {
                             </label>
                         </div>
                     </div>
-                    <button type="submit" className="px-6 py-2 bg-blue-400 text-black rounded hover:bg-blue-500 disabled:bg-gray-400 disabled:text-white transition-colors" disabled={!isValid}>
-                        <p>運賃計算をする</p>
+
+                    <button type="submit" className="w-full px-6 py-3 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:bg-gray-400 disabled:text-white transition-colors mt-2" disabled={!isValid}>
+                        運賃計算をする
                     </button>
                 </div>
             </form>
+
             <div className="my-8 p-4">
                 {isLoading && <p className="py-5 border-t">計算中...</p>}
                 {serverTime && <p className="text-right text-xs text-gray-400">計算時間: {serverTime}ms</p>}
@@ -406,7 +413,7 @@ export default function Form() {
                 <ol className="list-decimal list-inside space-y-1 ml-1">
                     <li><strong>駅・路線の入力:</strong> 発駅から着駅までの経路を入力してください。</li>
                     <li><strong>経路の追加:</strong> 「経由路線を追加」ボタンで複数の路線を乗り継ぐことができます。</li>
-                    <li><strong>経路の逆転:</strong> 経路を逆にしたい場合は「経路を逆転」ボタンを押してください。</li>
+                    <li><strong>経路の逆転:</strong> 経路を逆にしたい場合は「⇅ 経路を逆転」ボタンを押してください。</li>
                     <li><strong>運賃の計算:</strong> 「運賃計算をする」ボタンを押すと、営業キロと運賃が算出されます。</li>
                 </ol>
             </div>

--- a/src/app/mr/components/Form.tsx
+++ b/src/app/mr/components/Form.tsx
@@ -287,12 +287,12 @@ export default function Form() {
                     })}
 
                     {/* 経路追加 ＆ 経路逆転 ボタン群 */}
-                    <div className="flex items-center gap-3 my-4">
+                    <div className="flex items-center flex-wrap gap-3 my-4">
                         <button
                             type="button"
                             onClick={addSegment}
                             disabled={!canAddTransfer}
-                            className="px-4 py-2 bg-slate-500 text-white rounded hover:bg-slate-600 disabled:bg-slate-300 transition-colors shadow-sm"
+                            className="px-4 py-2 bg-slate-500 text-white rounded hover:bg-slate-600 disabled:bg-slate-300 transition-colors shadow-sm whitespace-nowrap"
                         >
                             経由路線を追加
                         </button>
@@ -300,7 +300,7 @@ export default function Form() {
                             type="button"
                             onClick={handleReverseRoute}
                             disabled={!canReverse}
-                            className="px-4 py-2 bg-white text-slate-700 border border-slate-300 rounded hover:bg-slate-50 disabled:bg-slate-50 disabled:text-slate-400 disabled:border-slate-200 flex items-center gap-2 transition-colors shadow-sm"
+                            className="px-4 py-2 bg-white text-slate-700 border border-slate-300 rounded hover:bg-slate-50 disabled:bg-slate-50 disabled:text-slate-400 disabled:border-slate-200 flex items-center gap-2 transition-colors shadow-sm whitespace-nowrap"
                             title="入力フォームの発着駅と経路を逆転させます"
                         >
                             <RiArrowUpDownLine className="w-5 h-5" />

--- a/src/app/mr/components/SelectLine.tsx
+++ b/src/app/mr/components/SelectLine.tsx
@@ -16,7 +16,7 @@ const CustomOption = (props: OptionProps<Line>) => (
 
 const SelectLine = ({ instanceId, value, onChange, options, isDisabled }: SelectLineProps) => {
     return (
-        <div className="my-2 w-47">
+        <div className="my-2 w-full">
             <Select
                 instanceId={instanceId}
                 value={value}

--- a/src/app/mr/components/SelectStation.tsx
+++ b/src/app/mr/components/SelectStation.tsx
@@ -62,7 +62,7 @@ const SelectStation = ({ instanceId, value, onChange, options, isDisabled, hideM
     const menuIsOpen = (hideMenuWhenEmpty && inputValue.length === 0) ? false : undefined;
 
     return (
-        <div className="my-2 w-47">
+        <div className="my-2 w-full">
             <Select
                 instanceId={safeInstanceId}
                 value={value}

--- a/src/app/split/components/Form.tsx
+++ b/src/app/split/components/Form.tsx
@@ -9,7 +9,7 @@ import SelectStation from "@/app/split/components/SelectStation";
 import { ApiSplitFullResponse, SplitApiRequest, SplitApiResponse, SplitFormInput, Station } from "@/app/types";
 
 export default function SplitForm() {
-    const { handleSubmit, control, setValue, getValues, watch, formState: { isValid, errors } } = useForm<SplitFormInput>({
+    const { handleSubmit, control, formState: { isValid, errors }, getValues, setValue, watch } = useForm<SplitFormInput>({
         mode: 'onChange',
         defaultValues: {
             startStation: null,
@@ -22,18 +22,15 @@ export default function SplitForm() {
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
-    // 発駅か着駅のどちらかが入力されていれば入れ替え可能とする
+    // 発駅と着駅の現在の値を監視し、どちらかが入力されているか判定
     const startStationVal = watch("startStation");
     const endStationVal = watch("endStation");
     const canSwap = !!startStationVal || !!endStationVal;
 
-    // 追加: 発駅と着駅の入力値を入れ替える関数（計算は実行しない）
+    // 駅を入れ替える関数
     const handleSwapStations = () => {
-        if (!canSwap) return;
-
         const currentStart = getValues("startStation");
         const currentEnd = getValues("endStation");
-
         setValue("startStation", currentEnd, { shouldValidate: true });
         setValue("endStation", currentStart, { shouldValidate: true });
     };
@@ -81,79 +78,75 @@ export default function SplitForm() {
     };
 
     return (
-        <main className="max-w-2xl mx-auto">
-            <form onSubmit={handleSubmit(onSubmit)} className="p-8">
-                <div className="flex flex-col gap-4">
+        <main className="max-w-2xl mx-auto w-full">
+            <form onSubmit={handleSubmit(onSubmit)} className="p-8 w-full">
+                {/* フォーム全体を w-full にして幅を統一 */}
+                <div className="flex flex-col gap-4 w-full">
 
-                    {/* 入力欄と入れ替えボタンを横並びにするラッパー */}
-                    <div className="flex flex-row items-center gap-4">
-
-                        {/* 左側: 発着駅の入力欄 */}
-                        <div className="flex flex-col gap-4 flex-1">
-                            {/* 発駅 */}
-                            <div className="flex flex-col">
-                                <div className="flex items-center gap-5 whitespace-nowrap">
-                                    <p className="w-12">発駅</p>
-                                    <Controller
-                                        name="startStation"
-                                        control={control}
-                                        rules={{ validate: validateStation }}
-                                        render={({ field }) => (
-                                            <SelectStation
-                                                instanceId="start-station-split"
-                                                {...field}
-                                                options={stationData}
-                                            />
-                                        )}
-                                    />
-                                </div>
-                                {errors.startStation && (
-                                    <p className="text-red-500 text-xs mt-1 ml-17">
-                                        {errors.startStation.message}
-                                    </p>
-                                )}
-                            </div>
-
-                            {/* 着駅 */}
-                            <div className="flex flex-col">
-                                <div className="flex items-center gap-5 whitespace-nowrap">
-                                    <p className="w-12">着駅</p>
-                                    <Controller
-                                        name="endStation"
-                                        control={control}
-                                        rules={{ validate: validateStation }}
-                                        render={({ field }) => (
-                                            <SelectStation
-                                                instanceId="end-station-split"
-                                                {...field}
-                                                options={stationData}
-                                            />
-                                        )}
-                                    />
-                                </div>
-                                {errors.endStation && (
-                                    <p className="text-red-500 text-xs mt-1 ml-17">
-                                        {errors.endStation.message}
-                                    </p>
-                                )}
+                    <div className="flex flex-col w-full">
+                        <div className="flex items-center gap-5 w-full">
+                            <p className="w-12 shrink-0 whitespace-nowrap">発駅</p>
+                            <div className="flex-1 w-full min-w-0">
+                                <Controller
+                                    name="startStation"
+                                    control={control}
+                                    rules={{ validate: validateStation }}
+                                    render={({ field }) => (
+                                        <SelectStation
+                                            instanceId="start-station-split"
+                                            {...field}
+                                            options={stationData}
+                                        />
+                                    )}
+                                />
                             </div>
                         </div>
-
-                        {/* 右側: 入れ替えボタン */}
-                        <div className="flex items-center justify-center shrink-0">
-                            <button
-                                type="button"
-                                onClick={handleSwapStations}
-                                disabled={!canSwap}
-                                className="p-3 text-slate-500 hover:text-blue-600 hover:bg-blue-50 bg-white rounded-full border border-slate-200 shadow-sm transition-all disabled:opacity-50 disabled:hover:bg-white disabled:hover:text-slate-500"
-                                title="発駅と着駅を入れ替える"
-                            >
-                                <RiArrowUpDownLine className="w-6 h-6" />
-                            </button>
-                        </div>
+                        {errors.startStation && (
+                            <p className="text-red-500 text-xs mt-1 ml-17">
+                                {errors.startStation.message}
+                            </p>
+                        )}
                     </div>
 
-                    <div className="mt-2">
+                    <div className="flex justify-center w-full -my-3 relative z-0">
+                        <button
+                            type="button"
+                            onClick={handleSwapStations}
+                            disabled={!canSwap}
+                            className="p-2 bg-white border border-gray-300 rounded-full shadow-sm text-gray-600 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+                            aria-label="発駅と着駅を入れ替える"
+                            title="駅を入れ替える"
+                        >
+                            <RiArrowUpDownLine className="text-xl" />
+                        </button>
+                    </div>
+
+                    <div className="flex flex-col w-full">
+                        <div className="flex items-center gap-5 w-full">
+                            <p className="w-12 shrink-0 whitespace-nowrap">着駅</p>
+                            <div className="flex-1 w-full min-w-0">
+                                <Controller
+                                    name="endStation"
+                                    control={control}
+                                    rules={{ validate: validateStation }}
+                                    render={({ field }) => (
+                                        <SelectStation
+                                            instanceId="end-station-split"
+                                            {...field}
+                                            options={stationData}
+                                        />
+                                    )}
+                                />
+                            </div>
+                        </div>
+                        {errors.endStation && (
+                            <p className="text-red-500 text-xs mt-1 ml-17">
+                                {errors.endStation.message}
+                            </p>
+                        )}
+                    </div>
+
+                    <div className="mt-2 w-full">
                         <button
                             type="submit"
                             className="w-full px-6 py-3 bg-blue-500 text-white rounded disabled:bg-gray-400 hover:bg-blue-600 transition-colors"
@@ -175,7 +168,6 @@ export default function SplitForm() {
                     <div className="border-t pt-8 space-y-8">
                         <h2 className="text-2xl font-bold text-center mb-6">計算結果</h2>
 
-                        {/* 1. 通し運賃の表示 */}
                         <section className="bg-gray-50 p-6 rounded-lg shadow-sm border border-gray-200">
                             <h3 className="font-bold text-lg mb-4 text-gray-700 border-b pb-2">通常の運賃（分割なし）</h3>
                             <div className="flex justify-between items-center">
@@ -198,7 +190,6 @@ export default function SplitForm() {
                             </div>
                         </section>
 
-                        {/* 2. 分割結果の表示エリア */}
                         {result.splitKippuDatasList.length > 0 ? (
                             <div className="space-y-6">
                                 {(() => {
@@ -229,7 +220,6 @@ export default function SplitForm() {
                                     );
                                 })()}
 
-                                {/* 3. 実際の分割パターンのリスト表示 */}
                                 <div className="space-y-8">
                                     {result.splitKippuDatasList.map((splitPlan, planIndex) => (
                                         <div key={planIndex} className="bg-gray-50 p-4 rounded-lg border border-gray-200">
@@ -288,7 +278,7 @@ export default function SplitForm() {
                 <h3 className="font-bold text-gray-600 mb-2">ご利用手順</h3>
                 <ol className="list-decimal list-inside space-y-1 ml-1">
                     <li><strong>駅の入力:</strong> 「発駅」と「着駅」に駅名を入力し、候補から選択します。</li>
-                    <li><strong>駅の入れ替え:</strong> 検索フォームの入力を逆にしたい場合は ⇄ ボタンを押すことで切り替わります。</li>
+                    <li><strong>駅の入れ替え:</strong> 検索フォームの入力を逆にしたい場合は ⇅ ボタンを押すことで切り替わります。</li>
                     <li><strong>最安分割運賃の計算:</strong> 「最安分割運賃を計算」ボタンを押すと、自動で最安分割運賃と切符の情報が出力されます。</li>
                 </ol>
             </div>

--- a/src/app/split/components/Form.tsx
+++ b/src/app/split/components/Form.tsx
@@ -86,29 +86,31 @@ export default function SplitForm() {
                 <div className="flex flex-col gap-4">
 
                     {/* 入力欄と入れ替えボタンを横並びにするラッパー */}
-                    <div className="flex flex-row items-center gap-4">
+                    <div className="flex flex-row items-center gap-2 sm:gap-4 w-full">
 
                         {/* 左側: 発着駅の入力欄 */}
-                        <div className="flex flex-col gap-4 flex-1">
+                        <div className="flex flex-col gap-4 flex-1 min-w-0">
                             {/* 発駅 */}
                             <div className="flex flex-col">
-                                <div className="flex items-center gap-5 whitespace-nowrap">
-                                    <p className="w-12">発駅</p>
-                                    <Controller
-                                        name="startStation"
-                                        control={control}
-                                        rules={{ validate: validateStation }}
-                                        render={({ field }) => (
-                                            <SelectStation
-                                                instanceId="start-station-split"
-                                                {...field}
-                                                options={stationData}
-                                            />
-                                        )}
-                                    />
+                                <div className="flex items-center gap-3 sm:gap-5 whitespace-nowrap">
+                                    <p className="w-10 sm:w-12 shrink-0">発駅</p>
+                                    <div className="flex-1 min-w-0">
+                                        <Controller
+                                            name="startStation"
+                                            control={control}
+                                            rules={{ validate: validateStation }}
+                                            render={({ field }) => (
+                                                <SelectStation
+                                                    instanceId="start-station-split"
+                                                    {...field}
+                                                    options={stationData}
+                                                />
+                                            )}
+                                        />
+                                    </div>
                                 </div>
                                 {errors.startStation && (
-                                    <p className="text-red-500 text-xs mt-1 ml-17">
+                                    <p className="text-red-500 text-xs mt-1 ml-13 sm:ml-17">
                                         {errors.startStation.message}
                                     </p>
                                 )}
@@ -116,23 +118,25 @@ export default function SplitForm() {
 
                             {/* 着駅 */}
                             <div className="flex flex-col">
-                                <div className="flex items-center gap-5 whitespace-nowrap">
-                                    <p className="w-12">着駅</p>
-                                    <Controller
-                                        name="endStation"
-                                        control={control}
-                                        rules={{ validate: validateStation }}
-                                        render={({ field }) => (
-                                            <SelectStation
-                                                instanceId="end-station-split"
-                                                {...field}
-                                                options={stationData}
-                                            />
-                                        )}
-                                    />
+                                <div className="flex items-center gap-3 sm:gap-5 whitespace-nowrap">
+                                    <p className="w-10 sm:w-12 shrink-0">着駅</p>
+                                    <div className="flex-1 min-w-0">
+                                        <Controller
+                                            name="endStation"
+                                            control={control}
+                                            rules={{ validate: validateStation }}
+                                            render={({ field }) => (
+                                                <SelectStation
+                                                    instanceId="end-station-split"
+                                                    {...field}
+                                                    options={stationData}
+                                                />
+                                            )}
+                                        />
+                                    </div>
                                 </div>
                                 {errors.endStation && (
-                                    <p className="text-red-500 text-xs mt-1 ml-17">
+                                    <p className="text-red-500 text-xs mt-1 ml-13 sm:ml-17">
                                         {errors.endStation.message}
                                     </p>
                                 )}
@@ -145,10 +149,10 @@ export default function SplitForm() {
                                 type="button"
                                 onClick={handleSwapStations}
                                 disabled={!canSwap}
-                                className="p-3 text-slate-500 hover:text-blue-600 hover:bg-blue-50 bg-white rounded-full border border-slate-200 shadow-sm transition-all disabled:opacity-50 disabled:hover:bg-white disabled:hover:text-slate-500"
+                                className="p-2 sm:p-3 text-slate-500 hover:text-blue-600 hover:bg-blue-50 bg-white rounded-full border border-slate-200 shadow-sm transition-all disabled:opacity-50 disabled:hover:bg-white disabled:hover:text-slate-500"
                                 title="発駅と着駅を入れ替える"
                             >
-                                <RiArrowUpDownLine className="w-6 h-6" />
+                                <RiArrowUpDownLine className="w-5 h-5 sm:w-6 sm:h-6" />
                             </button>
                         </div>
                     </div>

--- a/src/app/split/components/SelectStation.tsx
+++ b/src/app/split/components/SelectStation.tsx
@@ -56,7 +56,7 @@ const SelectStation = ({ instanceId, value, onChange, options, isDisabled }: Sel
     };
 
     return (
-        <div className="my-2 w-47">
+        <div className="my-2 w-full">
             <Select
                 instanceId={safeInstanceId}
                 value={value}


### PR DESCRIPTION
## 概要
スマートフォン等の画面幅が狭いデバイスで表示した際、「経由路線を追加」ボタンのテキストが意図せず改行されてしまう（「経由路線を追 / 加」となる）レイアウトの崩れを修正しました。

## 変更内容
*   **テキストの折り返し防止**: `Form.tsx` の「経由路線を追加」ボタンのクラスに `whitespace-nowrap` を追加し、テキストが常に1行で表示されるようにしました。
*   **コンテナの折り返し許可**: 隣接する「経路を逆転」ボタンを含め、画面幅に収まりきらない場合はボタン単位で縦に並ぶよう、親コンテナに `flex-wrap` を追加しました。

## 影響範囲
*   運賃計算プログラムと分割乗車券プログラムの検索フォーム画面 (`Form.tsx`) のレイアウトのみ。
*   機能的なロジックやAPIの呼び出し等には影響ありません。

## レビュアーに確認してほしいこと
*   Chromeのデベロッパーツール等で画面幅を狭く（iPhone SEサイズ等）した際、ボタンのテキストが改行されず、綺麗に表示・配置されるか。

## 動作確認手順
1.  本ブランチをローカルにPullして起動する。
2.  ブラウザのウィンドウ幅を狭める、またはモバイルビューに切り替える。
3.  「経由路線を追加」ボタンのテキストが「経由路線を追（改行）加」とならず、1行で表示されていることを確認する。
4.  さらに画面幅を狭めた際、ボタン自体が隣のボタンの下に折り返して配置されることを確認する。