### PR TITLE
fix: スマホ用メニューがヘッダーの背面からスライドインするようにz-indexを修正

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -35,9 +35,9 @@ const Header = () => {
     }, [openMenu]);
 
     return (
-        <header className="sticky top-0 z-20 border-b border-slate-200 flex items-center justify-between h-16 px-4 sm:px-6">
+        <header className="sticky top-0 z-50 border-b border-slate-200 flex items-center justify-between h-16 px-4 sm:px-6">
 
-            <div className="absolute inset-0 bg-white/80 backdrop-blur-md -z-10" />
+            <div className="absolute inset-0 bg-white/80 backdrop-blur-md z-40" />
 
             <h1>
                 <Link href="/" className="text-2xl font-bold tracking-tight text-blue-600 hover:opacity-80 transition-opacity font-logo relative z-50">
@@ -56,13 +56,13 @@ const Header = () => {
 
             {openMenu && (
                 <div
-                    className="fixed top-16 inset-x-0 bottom-0 bg-slate-900/50 backdrop-blur-sm z-30 md:hidden transition-opacity"
+                    className="fixed top-16 inset-x-0 bottom-0 bg-slate-900/50 backdrop-blur-sm z-20 md:hidden transition-opacity"
                     onClick={handleMenuToggle}
                 />
             )}
 
             <nav
-                className={`fixed top-0 right-0 h-screen w-64 bg-white shadow-2xl transform transition-transform duration-300 ease-in-out z-40
+                className={`fixed top-0 right-0 h-screen w-64 bg-white shadow-2xl transform transition-transform duration-300 ease-in-out z-30
                 ${openMenu ? "translate-x-0" : "translate-x-full"}
                 md:static md:flex md:h-auto md:w-auto md:translate-x-0 md:bg-transparent md:shadow-none md:z-auto`}
             >


### PR DESCRIPTION
## 概要
スマホ（モバイル）表示時において、ハンバーガーメニューを開いた際のドロワーメニューの重なり順（z-index）を修正しました。

現状はメニューバーがヘッダー（ロゴやボタン）よりも前面に表示され、UIとして少し不自然な状態になっていました。本PRにより、ヘッダーを最前面に固定し、メニューバーがヘッダーの「裏側」からスライドして引き出される自然な挙動に改善します。

## 変更内容
`src/components/Header.tsx` における `z-index` の階層を以下の通り再設計しました。

- `z-50`: ヘッダー全体、ロゴ、トグルボタン（常に最前面）
- `z-40`: ヘッダーのすりガラス背景
- `z-30`: メニューバー本体（ヘッダー背景の裏に潜り込む）
- `z-20`: 黒半透明のオーバーレイ背景

## 動作確認手順
1. スマホサイズ（mdブレイクポイント未満）で画面を表示する。
2. ヘッダー右上のハンバーガーメニューをクリックする。
3. メニューバーが画面右側からスライドインしてくる際、ヘッダー（きっぷナビのロゴや背景）の **裏側** を通って表示されることを確認する。
4. 各メニューリンクをクリックし、メニューが正常に閉じること、背面のスクロールロックが適切に解除されることを確認する。

## 備考
- `useEffect` による背景スクロールロックのロジックや、Next.jsの `<Link>` コンポーネントのルーティング挙動には影響を与えていません。純粋なスタイリング（Tailwind CSSクラス）の変更のみです。