### PR TITLE
fix: 上野～大宮を新幹線を使って70条区間を通過する際、最短経路で運賃計算されるように修正

### DIFF
--- a/src/app/utils/correctPath.ts
+++ b/src/app/utils/correctPath.ts
@@ -279,8 +279,13 @@ function correctSpecificSections(fullPath: PathStep[]): PathStep[] {
                 // 日暮里→北赤羽方面
                 if (idx === 0 &&
                     3 < fullPath.length &&
-                    (fullPath[2].lineName === "トウホ４" || fullPath[2].lineName === "トウホア") &&
-                    fullPath[3].stationName === "北赤羽"
+                    (
+                        (fullPath[2].lineName === "シヨシ" || fullPath[3].stationName === "大宮") &&
+                        (fullPath[2].lineName === "トウホ４" || fullPath[3].stationName === "北赤羽") &&
+                        (fullPath[2].lineName === "トウホア" || fullPath[3].stationName === "北赤羽") &&
+                        (fullPath[2].lineName === "トホシ" || fullPath[3].stationName === "大宮") &&
+                        (fullPath[2].lineName === "ホクシ" || fullPath[3].stationName === "大宮")
+                    )
                 ) {
                     fullPath = [
                         { stationName: "日暮里", lineName: "ホセイ" },
@@ -315,8 +320,8 @@ function correctSpecificSections(fullPath: PathStep[]): PathStep[] {
                 // 鶯谷方面→赤羽
                 if (0 < idx &&
                     (
-                        (fullPath[idx - 1].stationName === "鶯谷" && fullPath[idx - 1].lineName === "トウホ") ||
                         (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "シヨシ") ||
+                        (fullPath[idx - 1].stationName === "鶯谷" && fullPath[idx - 1].lineName === "トウホ") ||
                         (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "トホシ") ||
                         (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "ホクシ")
                     ) &&
@@ -339,8 +344,8 @@ function correctSpecificSections(fullPath: PathStep[]): PathStep[] {
                 // 鶯谷方面→川口方面
                 if (0 < idx &&
                     (
-                        (fullPath[idx - 1].stationName === "鶯谷" && fullPath[idx - 1].lineName === "トウホ") ||
                         (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "シヨシ") ||
+                        (fullPath[idx - 1].stationName === "鶯谷" && fullPath[idx - 1].lineName === "トウホ") ||
                         (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "トホシ") ||
                         (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "ホクシ")
                     ) &&
@@ -370,8 +375,13 @@ function correctSpecificSections(fullPath: PathStep[]): PathStep[] {
                         (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "ホクシ")
                     ) &&
                     idx + 3 < fullPath.length &&
-                    (fullPath[idx + 2].lineName === "トウホ４" || fullPath[idx + 2].lineName === "トウホア") &&
-                    fullPath[idx + 3].stationName === "北赤羽"
+                    (
+                        (fullPath[idx + 2].lineName === "シヨシ" && fullPath[idx + 3].stationName === "大宮") ||
+                        (fullPath[idx + 2].lineName === "トウホ４" && fullPath[idx + 3].stationName === "北赤羽") ||
+                        (fullPath[idx + 2].lineName === "トウホア" && fullPath[idx + 3].stationName === "北赤羽") ||
+                        (fullPath[idx + 2].lineName === "トホシ" && fullPath[idx + 3].stationName === "大宮") ||
+                        (fullPath[idx + 2].lineName === "ホクシ" && fullPath[idx + 3].stationName === "大宮")
+                    )
                 ) {
                     fullPath = [
                         ...fullPath.slice(0, idx),
@@ -389,8 +399,8 @@ function correctSpecificSections(fullPath: PathStep[]): PathStep[] {
                 // 鶯谷方面→十条方面
                 if (0 < idx &&
                     (
-                        (fullPath[idx - 1].stationName === "鶯谷" && fullPath[idx - 1].lineName === "トウホ") ||
                         (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "シヨシ") ||
+                        (fullPath[idx - 1].stationName === "鶯谷" && fullPath[idx - 1].lineName === "トウホ") ||
                         (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "トホシ") ||
                         (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "ホクシ")
                     ) &&
@@ -457,8 +467,13 @@ function correctSpecificSections(fullPath: PathStep[]): PathStep[] {
                     fullPath[idx - 1].stationName === "三河島" &&
                     (fullPath[idx - 1].lineName === "シヨハ" || fullPath[idx - 1].lineName === "シヨハニ") &&
                     idx + 3 < fullPath.length &&
-                    (fullPath[idx + 2].lineName === "トウホ４" || fullPath[idx + 2].lineName === "トウホア") &&
-                    fullPath[idx + 3].stationName === "北赤羽"
+                    (
+                        (fullPath[idx + 2].lineName === "シヨシ" || fullPath[idx + 3].stationName === "大宮") ||
+                        (fullPath[idx + 2].lineName === "トウホ４" || fullPath[idx + 3].stationName === "北赤羽") ||
+                        (fullPath[idx + 2].lineName === "トウホア" || fullPath[idx + 3].stationName === "北赤羽") ||
+                        (fullPath[idx + 2].lineName === "トホシ" || fullPath[idx + 3].stationName === "大宮") ||
+                        (fullPath[idx + 2].lineName === "ホクシ" || fullPath[idx + 3].stationName === "大宮")
+                    )
                 ) {
                     fullPath = [
                         ...fullPath.slice(0, idx),
@@ -526,8 +541,8 @@ function correctSpecificSections(fullPath: PathStep[]): PathStep[] {
                 if (idx === 0 &&
                     3 < fullPath.length &&
                     (
-                        (fullPath[2].lineName === "トウホ" && fullPath[3].stationName === "鶯谷") ||
                         (fullPath[2].lineName === "シヨシ" && fullPath[3].stationName === "上野") ||
+                        (fullPath[2].lineName === "トウホ" && fullPath[3].stationName === "鶯谷") ||
                         (fullPath[2].lineName === "トホシ" && fullPath[3].stationName === "上野") ||
                         (fullPath[2].lineName === "ホクシ" && fullPath[3].stationName === "上野")
                     )
@@ -588,8 +603,8 @@ function correctSpecificSections(fullPath: PathStep[]): PathStep[] {
                     (fullPath[idx - 1].lineName === "トウホ" || fullPath[idx - 1].lineName === "ホセイ") &&
                     idx + 3 < fullPath.length &&
                     (
-                        (fullPath[idx + 2].lineName === "トウホ" && fullPath[idx + 3].stationName === "鶯谷") ||
                         (fullPath[idx + 2].lineName === "シヨシ" && fullPath[idx + 3].stationName === "上野") ||
+                        (fullPath[idx + 2].lineName === "トウホ" && fullPath[idx + 3].stationName === "鶯谷") ||
                         (fullPath[idx + 2].lineName === "トホシ" && fullPath[idx + 3].stationName === "上野") ||
                         (fullPath[idx + 2].lineName === "ホクシ" && fullPath[idx + 3].stationName === "上野")
                     )
@@ -630,8 +645,13 @@ function correctSpecificSections(fullPath: PathStep[]): PathStep[] {
 
                 // 北赤羽方面→日暮里
                 if (0 < idx &&
-                    fullPath[idx - 1].stationName === "北赤羽" &&
-                    (fullPath[idx - 1].lineName === "トウホ４" || fullPath[idx - 1].lineName === "トウホア") &&
+                    (
+                        (fullPath[idx - 1].stationName === "大宮" && fullPath[idx - 1].lineName === "シヨシ") ||
+                        (fullPath[idx - 1].stationName === "北赤羽" && fullPath[idx - 1].lineName === "トウホ４") ||
+                        (fullPath[idx - 1].stationName === "北赤羽" && fullPath[idx - 1].lineName === "トウホア") ||
+                        (fullPath[idx - 1].stationName === "大宮" && fullPath[idx - 1].lineName === "トホシ") ||
+                        (fullPath[idx - 1].stationName === "大宮" && fullPath[idx - 1].lineName === "ホクシ")
+                    ) &&
                     idx + 2 < fullPath.length &&
                     fullPath[idx + 2].lineName === null
                 ) {
@@ -650,12 +670,17 @@ function correctSpecificSections(fullPath: PathStep[]): PathStep[] {
 
                 // 北赤羽方面→鶯谷方面
                 if (0 < idx &&
-                    fullPath[idx - 1].stationName === "北赤羽" &&
-                    (fullPath[idx - 1].lineName === "トウホ４" || fullPath[idx - 1].lineName === "トウホア") &&
+                    (
+                        (fullPath[idx - 1].stationName === "大宮" && fullPath[idx - 1].lineName === "シヨシ") ||
+                        (fullPath[idx - 1].stationName === "北赤羽" && fullPath[idx - 1].lineName === "トウホ４") ||
+                        (fullPath[idx - 1].stationName === "北赤羽" && fullPath[idx - 1].lineName === "トウホア") ||
+                        (fullPath[idx - 1].stationName === "大宮" && fullPath[idx - 1].lineName === "トホシ") ||
+                        (fullPath[idx - 1].stationName === "大宮" && fullPath[idx - 1].lineName === "ホクシ")
+                    ) &&
                     idx + 3 < fullPath.length &&
                     (
-                        (fullPath[idx + 2].lineName === "トウホ" && fullPath[idx + 3].stationName === "鶯谷") ||
                         (fullPath[idx + 2].lineName === "シヨシ" && fullPath[idx + 3].stationName === "上野") ||
+                        (fullPath[idx + 2].lineName === "トウホ" && fullPath[idx + 3].stationName === "鶯谷") ||
                         (fullPath[idx + 2].lineName === "トホシ" && fullPath[idx + 3].stationName === "上野") ||
                         (fullPath[idx + 2].lineName === "ホクシ" && fullPath[idx + 3].stationName === "上野")
                     )
@@ -675,8 +700,13 @@ function correctSpecificSections(fullPath: PathStep[]): PathStep[] {
 
                 // 北赤羽方面→三河島方面
                 if (0 < idx &&
-                    fullPath[idx - 1].stationName === "北赤羽" &&
-                    (fullPath[idx - 1].lineName === "トウホ４" || fullPath[idx - 1].lineName === "トウホア") &&
+                    (
+                        (fullPath[idx - 1].stationName === "大宮" && fullPath[idx - 1].lineName === "シヨシ") ||
+                        (fullPath[idx - 1].stationName === "北赤羽" && fullPath[idx - 1].lineName === "トウホ４") ||
+                        (fullPath[idx - 1].stationName === "北赤羽" && fullPath[idx - 1].lineName === "トウホア") ||
+                        (fullPath[idx - 1].stationName === "大宮" && fullPath[idx - 1].lineName === "トホシ") ||
+                        (fullPath[idx - 1].stationName === "大宮" && fullPath[idx - 1].lineName === "ホクシ")
+                    ) &&
                     idx + 3 < fullPath.length &&
                     (fullPath[idx + 2].lineName === "シヨハ" || fullPath[idx + 2].lineName === "シヨハニ") &&
                     fullPath[idx + 3].stationName === "三河島"
@@ -720,8 +750,8 @@ function correctSpecificSections(fullPath: PathStep[]): PathStep[] {
                     (fullPath[idx - 1].lineName === "アカハ" || fullPath[idx - 1].lineName === "アカハネ") &&
                     idx + 3 < fullPath.length &&
                     (
-                        (fullPath[idx + 2].lineName === "トウホ" && fullPath[idx + 3].stationName === "鶯谷") ||
                         (fullPath[idx + 2].lineName === "シヨシ" && fullPath[idx + 3].stationName === "上野") ||
+                        (fullPath[idx + 2].lineName === "トウホ" && fullPath[idx + 3].stationName === "鶯谷") ||
                         (fullPath[idx + 2].lineName === "トホシ" && fullPath[idx + 3].stationName === "上野") ||
                         (fullPath[idx + 2].lineName === "ホクシ" && fullPath[idx + 3].stationName === "上野")
                     )
@@ -893,8 +923,13 @@ function correctSpecificSections(fullPath: PathStep[]): PathStep[] {
 
                 // 尾久方面→大宮
                 if (0 < idx &&
-                    fullPath[idx - 1].stationName === "尾久" &&
-                    (fullPath[idx - 1].lineName === "トウホ" || fullPath[idx - 1].lineName === "オク") &&
+                    (
+                        (fullPath[idx - 1].stationName === "尾久" && fullPath[idx - 1].lineName === "オク") ||
+                        (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "シヨシ") ||
+                        (fullPath[idx - 1].stationName === "尾久" && fullPath[idx - 1].lineName === "トウホ") ||
+                        (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "トホシ") ||
+                        (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "ホクシ")
+                    ) &&
                     idx + 11 < fullPath.length &&
                     fullPath[idx + 11].lineName === null
                 ) {
@@ -916,8 +951,13 @@ function correctSpecificSections(fullPath: PathStep[]): PathStep[] {
 
                 // 尾久方面→土呂方面
                 if (0 < idx &&
-                    fullPath[idx - 1].stationName === "尾久" &&
-                    (fullPath[idx - 1].lineName === "トウホ" || fullPath[idx - 1].lineName === "オク") &&
+                    (
+                        (fullPath[idx - 1].stationName === "尾久" && fullPath[idx - 1].lineName === "オク") ||
+                        (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "シヨシ") ||
+                        (fullPath[idx - 1].stationName === "尾久" && fullPath[idx - 1].lineName === "トウホ") ||
+                        (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "トホシ") ||
+                        (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "ホクシ")
+                    ) &&
                     idx + 12 < fullPath.length &&
                     (
                         (fullPath[idx + 11].lineName === "トウホ" && fullPath[idx + 12].stationName === "土呂") ||
@@ -942,8 +982,13 @@ function correctSpecificSections(fullPath: PathStep[]): PathStep[] {
 
                 // 尾久方面→宮原方面
                 if (0 < idx &&
-                    fullPath[idx - 1].stationName === "尾久" &&
-                    (fullPath[idx - 1].lineName === "トウホ" || fullPath[idx - 1].lineName === "オク") &&
+                    (
+                        (fullPath[idx - 1].stationName === "尾久" && fullPath[idx - 1].lineName === "オク") ||
+                        (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "シヨシ") ||
+                        (fullPath[idx - 1].stationName === "尾久" && fullPath[idx - 1].lineName === "トウホ") ||
+                        (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "トホシ") ||
+                        (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "ホクシ")
+                    ) &&
                     idx + 12 < fullPath.length &&
                     (
                         (fullPath[idx + 11].lineName === "タカサ" && fullPath[idx + 12].stationName === "宮原") ||
@@ -969,8 +1014,13 @@ function correctSpecificSections(fullPath: PathStep[]): PathStep[] {
 
                 // 尾久方面→日進方面
                 if (0 < idx &&
-                    fullPath[idx - 1].stationName === "尾久" &&
-                    (fullPath[idx - 1].lineName === "トウホ" || fullPath[idx - 1].lineName === "オク") &&
+                    (
+                        (fullPath[idx - 1].stationName === "尾久" && fullPath[idx - 1].lineName === "オク") ||
+                        (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "シヨシ") ||
+                        (fullPath[idx - 1].stationName === "尾久" && fullPath[idx - 1].lineName === "トウホ") ||
+                        (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "トホシ") ||
+                        (fullPath[idx - 1].stationName === "日暮里" && fullPath[idx - 1].lineName === "ホクシ")
+                    ) &&
                     idx + 12 < fullPath.length &&
                     fullPath[idx + 11].lineName === "カワコ" &&
                     fullPath[idx + 12].stationName === "（川）日進"
@@ -1243,8 +1293,13 @@ function correctSpecificSections(fullPath: PathStep[]): PathStep[] {
                 // 大宮→尾久方面
                 if (idx === 0 &&
                     12 < fullPath.length &&
-                    (fullPath[11].lineName === "トウホ" || fullPath[11].lineName === "オク") &&
-                    fullPath[12].stationName === "尾久"
+                    (
+                        (fullPath[11].lineName === "オク" && fullPath[12].stationName === "尾久") ||
+                        (fullPath[11].lineName === "シヨシ" && fullPath[12].stationName === "日暮里") ||
+                        (fullPath[11].lineName === "トウホ" && fullPath[12].stationName === "尾久") ||
+                        (fullPath[11].lineName === "トホシ" && fullPath[12].stationName === "日暮里") ||
+                        (fullPath[11].lineName === "ホクシ" && fullPath[12].stationName === "日暮里")
+                    )
                 ) {
                     fullPath = [
                         { stationName: "大宮", lineName: "ホセイ" },
@@ -1335,8 +1390,13 @@ function correctSpecificSections(fullPath: PathStep[]): PathStep[] {
                         (fullPath[idx - 1].stationName === "小山" && fullPath[idx - 1].lineName === "トホシ")
                     ) &&
                     idx + 11 < fullPath.length &&
-                    (fullPath[idx + 11].lineName === "トウホ" || fullPath[idx + 11].lineName === "オク") &&
-                    fullPath[idx + 12].stationName === "尾久"
+                    (
+                        (fullPath[idx + 11].lineName === "オク" && fullPath[idx + 12].stationName === "尾久") ||
+                        (fullPath[idx + 11].lineName === "シヨシ" && fullPath[idx + 12].stationName === "日暮里") ||
+                        (fullPath[idx + 11].lineName === "トウホ" && fullPath[idx + 12].stationName === "尾久") ||
+                        (fullPath[idx + 11].lineName === "トホシ" && fullPath[idx + 12].stationName === "日暮里") ||
+                        (fullPath[idx + 11].lineName === "ホクシ" && fullPath[idx + 12].stationName === "日暮里")
+                    )
                 ) {
                     fullPath = [
                         ...fullPath.slice(0, idx),
@@ -1440,8 +1500,13 @@ function correctSpecificSections(fullPath: PathStep[]): PathStep[] {
                         (fullPath[idx - 1].stationName === "熊谷" && fullPath[idx - 1].lineName === "ホクシ")
                     ) &&
                     idx + 11 < fullPath.length &&
-                    (fullPath[idx + 11].lineName === "トウホ" || fullPath[idx + 11].lineName === "オク") &&
-                    fullPath[idx + 12].stationName === "尾久"
+                    (
+                        (fullPath[idx + 11].lineName === "オク" && fullPath[idx + 12].stationName === "尾久") ||
+                        (fullPath[idx + 11].lineName === "シヨシ" && fullPath[idx + 12].stationName === "日暮里") ||
+                        (fullPath[idx + 11].lineName === "トウホ" && fullPath[idx + 12].stationName === "尾久") ||
+                        (fullPath[idx + 11].lineName === "トホシ" && fullPath[idx + 12].stationName === "日暮里") ||
+                        (fullPath[idx + 11].lineName === "ホクシ" && fullPath[idx + 12].stationName === "日暮里")
+                    )
                 ) {
                     fullPath = [
                         ...fullPath.slice(0, idx),
@@ -1541,8 +1606,13 @@ function correctSpecificSections(fullPath: PathStep[]): PathStep[] {
                     fullPath[idx - 1].stationName === "（川）日進" &&
                     fullPath[idx - 1].lineName === "カワコ" &&
                     idx + 12 < fullPath.length &&
-                    (fullPath[idx + 11].lineName === "トウホ" || fullPath[idx + 11].lineName === "オク") &&
-                    fullPath[idx + 12].stationName === "尾久"
+                    (
+                        (fullPath[idx + 11].lineName === "オク" && fullPath[idx + 12].stationName === "尾久") ||
+                        (fullPath[idx + 11].lineName === "シヨシ" && fullPath[idx + 12].stationName === "日暮里") ||
+                        (fullPath[idx + 11].lineName === "トウホ" && fullPath[idx + 12].stationName === "尾久") ||
+                        (fullPath[idx + 11].lineName === "トホシ" && fullPath[idx + 12].stationName === "日暮里") ||
+                        (fullPath[idx + 11].lineName === "ホクシ" && fullPath[idx + 12].stationName === "日暮里")
+                    )
                 ) {
                     fullPath = [
                         ...fullPath.slice(0, idx),


### PR DESCRIPTION
## 概要
経路内に 上野～大宮の新幹線が含まれ、かつ旅客営業規則第70条の指定区間を「通過」する場合に、本来であれば最短経路で運賃計算されるべきところ、実際の乗車経路で計算されてしまう不具合を修正しました。

## 背景・原因
現在の運賃計算ロジックにおいて、70条区間の通過判定処理が、在来線のみの経路を前提として組まれていました。そのため、経路情報に「新幹線」の区間データが含まれると通過判定の条件から外れてしまい、特例による最短経路への補正が行われていませんでした。

## 修正内容
- 70条区間の通過判定において、経路内の新幹線を許容するように条件を修正しました。
- 70条区間を通過する条件を満たした場合、実経路ではなく、当該区間の最短経路で運賃を算出する補正ロジックを適用するようにしました。

## 影響範囲
- 東北・上越・北陸新幹線を利用し、70条区間を跨いで乗車する運賃計算機能全般

## 確認手順・テスト方法
1. 以下の経路において、運賃が実経路ではなく「最短経路」で計算されていることを確認する。
   - **テストケース:** 中野 -> (中央線) -> 東京 -> (新幹線) -> 大宮
2. 上記の経路について、運賃が、JRの公式の運賃計算結果と一致することを確認する。