### PR TITLE
feat: 比較基準となる非分割乗車券を「最短経路」から「最安経路」に変更

### DIFF
--- a/src/app/api/split/route.ts
+++ b/src/app/api/split/route.ts
@@ -23,7 +23,7 @@ export async function POST(request: NextRequest) {
         const result = await getOptimalSplitWithCache(startStationName, endStationName);
 
         // 3. 結果の判定
-        if (result === null || result.shortestData.fare === Infinity) {
+        if (result === null || result.cheapestKippuData.fare === Infinity) {
             return NextResponse.json({ error: '経路が見つかりませんでした。' }, { status: 404 });
         }
 

--- a/src/app/split/components/Form.tsx
+++ b/src/app/split/components/Form.tsx
@@ -173,19 +173,19 @@ export default function SplitForm() {
                             <div className="flex justify-between items-center">
                                 <div>
                                     <div className="text-lg font-bold">
-                                        <span>{result.shortestData.departureStation}</span>
+                                        <span>{result.cheapestKippuData.departureStation}</span>
                                         <span className="text-gray-400 mx-2">→</span>
-                                        <span>{result.shortestData.arrivalStation}</span>
+                                        <span>{result.cheapestKippuData.arrivalStation}</span>
                                         <span className="text-sm font-normal text-gray-600 ml-1">
-                                            （{(result.shortestData.totalEigyoKilo / 10).toFixed(1)}km）
+                                            （{(result.cheapestKippuData.totalEigyoKilo / 10).toFixed(1)}km）
                                         </span>
                                     </div>
                                     <div className="text-sm text-gray-600 mt-1">
-                                        経由：{result.shortestData.printedViaLines.join('・') || '---'}
+                                        経由：{result.cheapestKippuData.printedViaLines.join('・') || '---'}
                                     </div>
                                 </div>
                                 <div className="text-3xl font-bold text-gray-800">
-                                    ¥{result.shortestData.fare.toLocaleString()}
+                                    ¥{result.cheapestKippuData.fare.toLocaleString()}
                                 </div>
                             </div>
                         </section>
@@ -194,7 +194,7 @@ export default function SplitForm() {
                             <div className="space-y-6">
                                 {(() => {
                                     const bestFare = result.splitKippuDatasList[0].totalFare;
-                                    const diff = result.shortestData.fare - bestFare;
+                                    const diff = result.cheapestKippuData.fare - bestFare;
                                     const isCheaper = diff > 0;
 
                                     return (

--- a/src/app/split/lib/calcSplit.ts
+++ b/src/app/split/lib/calcSplit.ts
@@ -1,7 +1,7 @@
 import { load } from '@/app/utils/load';
 import { loadSplit } from '@/app/split/lib/loadSplit';
 import { generateKippu } from '@/app/split/lib/generateKippu';
-import { PathStep, SplitApiResponse, SplitKippuData, SplitKippuDatas } from '@/app/types';
+import { KippuData, PathStep, SplitApiResponse, SplitKippuData, SplitKippuDatas } from '@/app/types';
 import { cheapestPathAndFare } from '@/app/utils/cheapestPath';
 import { getFareForPath } from '@/app/utils/calc';
 
@@ -65,12 +65,17 @@ export class CalculatorSplit {
         }
 
         let allSplitPatterns: SplitKippuDatas[] = [];
+        let cheapestKippuData: KippuData = generateKippu(candidates[0]);
 
         // フェーズ2: 各候補ルートに対する1次元DPでの最適分割の並列評価
         for (const path of candidates) {
             const splitPatterns = this.calculateOptimalSplitForPath(path);
             if (splitPatterns) {
                 allSplitPatterns = allSplitPatterns.concat(splitPatterns);
+            }
+            const candidateKippuData = generateKippu(path)
+            if (candidateKippuData.fare < cheapestKippuData.fare) {
+                cheapestKippuData = candidateKippuData
             }
         }
 
@@ -94,8 +99,8 @@ export class CalculatorSplit {
         let uniqueSplitPatterns = Array.from(uniquePatternsMap.values());
 
         if (uniqueSplitPatterns.length === 0) {
-            // 分割のメリットが一切ない場合は、最短経路の通し切符を返す
-            return { shortestData: generateKippu(candidates[0]), splitKippuDatasList: [] };
+            // 分割のメリットが一切ない場合は、最安経路の通し切符を返す
+            return { cheapestKippuData: cheapestKippuData, splitKippuDatasList: [] };
         }
 
         // 全候補の中で最も安い「大域的最適解」を抽出（同額の別パターンも全て含む）
@@ -103,7 +108,7 @@ export class CalculatorSplit {
         const optimalPatterns = uniqueSplitPatterns.filter(p => p.totalFare === globalMinFare);
 
         return {
-            shortestData: generateKippu(this.clonePath(candidates[0])),
+            cheapestKippuData: cheapestKippuData,
             splitKippuDatasList: optimalPatterns
         };
     }

--- a/src/app/split/lib/calcSplit.ts
+++ b/src/app/split/lib/calcSplit.ts
@@ -325,7 +325,7 @@ export class CalculatorSplit {
             if (currentCost > (costs.get(currentStation) || Infinity)) continue;
             if (currentStation === endStationName) return { pathFound: true, previous };
 
-            const neighbors = loadSplit.getNeighbors(currentStation);
+            const neighbors = load.getAdjacentStations(currentStation);
             for (const neighborStation of neighbors) {
                 if (excludedNodes.has(neighborStation)) continue;
                 const edgeKey = this.getEdgeKey(currentStation, neighborStation);
@@ -340,7 +340,7 @@ export class CalculatorSplit {
                 }
                 if (isLoop) continue;
 
-                const segments = loadSplit.getSegmentsForStationPair(currentStation, neighborStation);
+                const segments = load.getSegmentsForStationPair(currentStation, neighborStation);
                 if (segments.length === 0) continue;
                 const representativeSegment = segments[0];
                 let weight = representativeSegment.giseiKilo;

--- a/src/app/split/lib/loadSplit.ts
+++ b/src/app/split/lib/loadSplit.ts
@@ -1,13 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { load } from '@/app/utils/load';
-import { RouteSegment } from '@/app/types';
-
 class LoadSplit {
-    private adjacencyList: Map<string, string[]> = new Map();
-    private stationPairRoutes: Map<string, RouteSegment[]> = new Map();
-    private distanceToCityCenterList: { stationName: string, kilo: number }[] = [];
     private distancesToCityCenter: Map<string, number> = new Map();
 
     constructor () {
@@ -16,49 +10,15 @@ class LoadSplit {
 
     private loadData() {
         try {
-            const routesData = load.getRoutesList();
-            for (const route of routesData) {
-                const station0 = route.station0;
-                const station1 = route.station1;
+            const distancesToCityCenterData = path.join(process.cwd(), 'src', 'app', 'split', 'data', 'distancesToCityCenter.json');
+            const distanceToCityCenterList: { stationName: string, kilo: number }[] = JSON.parse(fs.readFileSync(distancesToCityCenterData, 'utf-8'));
 
-                // 1. 隣接リストの構築
-                if (!this.adjacencyList.has(station0)) this.adjacencyList.set(station0, []);
-                if (!this.adjacencyList.has(station1)) this.adjacencyList.set(station1, []);
-                // 重複を避ける（厳密には不要だが安全のため）
-                if (!this.adjacencyList.get(station0)!.includes(station1)) {
-                    this.adjacencyList.get(station0)!.push(station1);
-                }
-                if (!this.adjacencyList.get(station1)!.includes(station0)) {
-                    this.adjacencyList.get(station1)!.push(station0);
-                }
-
-                // 2. 駅ペア検索Mapの構築
-                const pairKey = [station0, station1].sort().join('-');
-                if (!this.stationPairRoutes.has(pairKey)) {
-                    this.stationPairRoutes.set(pairKey, []);
-                }
-                this.stationPairRoutes.get(pairKey)!.push(route);
-
-                const distancesToCityCenterData = path.join(process.cwd(), 'src', 'app', 'split', 'data', 'distancesToCityCenter.json');
-                this.distanceToCityCenterList = JSON.parse(fs.readFileSync(distancesToCityCenterData, 'utf-8'));
-
-                for (const distanceToCityCenter of this.distanceToCityCenterList) {
-                    this.distancesToCityCenter.set(distanceToCityCenter.stationName, distanceToCityCenter.kilo);
-                }
-
+            for (const distanceToCityCenter of distanceToCityCenterList) {
+                this.distancesToCityCenter.set(distanceToCityCenter.stationName, distanceToCityCenter.kilo);
             }
         } catch (error) {
             console.error('データ読み込みエラー：', error);
         }
-    }
-
-    public getNeighbors(stationName: string): string[] {
-        return this.adjacencyList.get(stationName) || [];
-    }
-
-    public getSegmentsForStationPair(stationName0: string, stationName1: string): RouteSegment[] {
-        const pairKey = [stationName0, stationName1].sort().join('-');
-        return this.stationPairRoutes.get(pairKey) || [];
     }
 
     public getdistancesToCityCenter(stationName: string): number {

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -135,6 +135,15 @@ export interface TrainSpecificSection {
     名古屋附近: Set<string>;
     電車大環状線: Set<string>;
 }
+
+export interface MajorCitySuburbanSection {
+    東京近郊区間: Set<string>;
+    新潟近郊区間: Set<string>;
+    仙台近郊区間: Set<string>;
+    大阪近郊区間: Set<string>;
+    福岡近郊区間: Set<string>;
+}
+
 export interface BoldLineAreaRoute {
     key: string;
     route: PathStep[];

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -83,7 +83,7 @@ export interface SplitKippuDatas {
 }
 
 export interface SplitApiResponse {
-    shortestData: KippuData;
+    cheapestKippuData: KippuData;
     splitKippuDatasList: SplitKippuDatas[];
 }
 

--- a/src/app/utils/calc.ts
+++ b/src/app/utils/calc.ts
@@ -34,6 +34,10 @@ export function getFareForPath(path: PathStep[]): number {
     return fare;
 }
 
+export function createPairKey(stationName0: string, stationName1: string): string {
+    return [stationName0, stationName1].sort().join('-');
+}
+
 export function createRouteKey(line: string, stationName0: string, stationName1: string): string {
     return [line, ...[stationName0, stationName1].sort()].join('-');
 }

--- a/src/app/utils/cheapestPath.ts
+++ b/src/app/utils/cheapestPath.ts
@@ -1,5 +1,4 @@
 import { load } from "@/app/utils/load";
-import { loadSplit } from "@/app/split/lib/loadSplit";
 import { calculateTotalEigyoKilo, calculateTotalGiseiKilo, convertPathStepsToRouteSegments, getFareForPath } from "@/app/utils/calc";
 import { correctPath } from "@/app/utils/correctPath";
 
@@ -199,13 +198,13 @@ function searchExtension(
             searchNodeName = currentPath[0].stationName;
         }
 
-        const neighbors = loadSplit.getNeighbors(searchNodeName);
+        const neighbors = load.getAdjacentStations(searchNodeName);
 
         for (const neighborName of neighbors) {
             if (visitedStations.has(neighborName)) continue;
             if (currentPath.some(p => p.stationName === neighborName)) continue;
 
-            const segmentsInfo = loadSplit.getSegmentsForStationPair(searchNodeName, neighborName);
+            const segmentsInfo = load.getSegmentsForStationPair(searchNodeName, neighborName);
             if (segmentsInfo.length === 0) continue;
 
             const lineName = segmentsInfo[0].line;
@@ -389,3 +388,4 @@ export function extendTheRearOfSections(path: PathStep[]): PathStep[] | null {
     }
     return null;
 }
+

--- a/src/app/utils/load.ts
+++ b/src/app/utils/load.ts
@@ -1,30 +1,38 @@
 import fs from 'fs';
 import path from 'path';
 
-import { createRouteKey } from '@/app/utils/calc';
-import { City, OuterSection, PathStep, Printing, RouteSegment, Section, SpecificFare, TrainSpecificSection } from '@/app/types';
+import { createPairKey, createRouteKey } from '@/app/utils/calc';
+import { City, MajorCitySuburbanSection, OuterSection, PathStep, Printing, RouteSegment, Section, SpecificFare, TrainSpecificSection } from '@/app/types';
 
 class Load {
-    private passingBoldLineAreaRoutes: Map<string, PathStep[]> = new Map();
-    private fromBoldLineAreaRoutes: Map<string, PathStep[]> = new Map();
-    private toBoldLineAreaRoutes: Map<string, PathStep[]> = new Map();
+    private adjacentStationsList: Map<string, string[]> = new Map();
     private cities: City[] = [];
+    private fromBoldLineAreaRoutes: Map<string, PathStep[]> = new Map();
+    private majorCitySuburbanSections!: MajorCitySuburbanSection;
+    private passingBoldLineAreaRoutes: Map<string, PathStep[]> = new Map();
     private printings: Map<string, string> = new Map();
     private routes: Map<string, RouteSegment> = new Map();
-    private routeList: RouteSegment[] = [];
-    private specificFares: SpecificFare[] = [];
-    private specificFareMap = new Map<string, number>();
+    private specificFares = new Map<string, number>();
+    private toBoldLineAreaRoutes: Map<string, PathStep[]> = new Map();
+    private stationPairRoutes: Map<string, RouteSegment[]> = new Map();
     private trainSpecificSections!: TrainSpecificSection;
-    private yamanote!: City;
     private specificSections: OuterSection[] = [];
     private selectionSections: OuterSection[] = [];
-
+    private yamanote!: City;
     constructor () {
         this.loadData();
     }
 
     private loadData() {
         try {
+
+            // additionalRoutes.jsonの読み込み
+            const additionalRoutesData = path.join(process.cwd(), 'src', 'data', 'additionalRoutes.json');
+            const additionalRoutesList = JSON.parse(fs.readFileSync(additionalRoutesData, 'utf-8'));
+            for (const route of additionalRoutesList) {
+                const key = createRouteKey(route.line, route.station0, route.station1);
+                this.routes.set(key, route);
+            }
 
             // boldLineAreaRoutes.jsonの読み込み
             const boldLineAreaRoutesData = path.join(process.cwd(), 'src', 'data', 'boldLineAreaRoutes.json');
@@ -43,6 +51,22 @@ class Load {
             const citiesData = path.join(process.cwd(), 'src', 'data', 'cities.json');
             this.cities = JSON.parse(fs.readFileSync(citiesData, 'utf-8'));
 
+            // majorCitySuburbanSections.jsonの読み込み
+            const majorCitySuburbanSectionsData = path.join(process.cwd(), 'src', 'data', 'majorCitySuburbanSections.json');
+            const rawmajorCitySuburbanSectionsData: Record<string, Section[]> = JSON.parse(fs.readFileSync(majorCitySuburbanSectionsData, 'utf-8'));
+            const transformedmajorCitySuburbanSections = {} as MajorCitySuburbanSection;
+            for (const sectionName in rawmajorCitySuburbanSectionsData) {
+                if (Object.prototype.hasOwnProperty.call(rawmajorCitySuburbanSectionsData, sectionName)) {
+                    const key = sectionName as keyof MajorCitySuburbanSection;
+                    const segments = rawmajorCitySuburbanSectionsData[key];
+                    const routeKeys = segments.map(segment =>
+                        createRouteKey(segment.line, segment.station0, segment.station1)
+                    );
+                    transformedmajorCitySuburbanSections[key] = new Set(routeKeys);
+                }
+            }
+            this.majorCitySuburbanSections = transformedmajorCitySuburbanSections;
+
             // printings.jsonの読み込み
             const printingsData = path.join(process.cwd(), 'src', 'data', 'printings.json');
             const printingsList: Printing[] = JSON.parse(fs.readFileSync(printingsData, 'utf-8'));
@@ -52,59 +76,92 @@ class Load {
 
             // routes.jsonの読み込み
             const routesData = path.join(process.cwd(), 'src', 'data', 'routes.json');
-            this.routeList = JSON.parse(fs.readFileSync(routesData, 'utf-8'));
-            for (const route of this.routeList) {
+            const routesList: RouteSegment[] = JSON.parse(fs.readFileSync(routesData, 'utf-8'));
+            for (const route of routesList) {
                 const key = createRouteKey(route.line, route.station0, route.station1);
                 this.routes.set(key, route);
-            }
 
-            // additionalRoutes.jsonの読み込み
-            const additionalRoutesData = path.join(process.cwd(), 'src', 'data', 'additionalRoutes.json');
-            const additionalRoutesist = JSON.parse(fs.readFileSync(additionalRoutesData, 'utf-8'));
-            for (const route of additionalRoutesist) {
-                const key = createRouteKey(route.line, route.station0, route.station1);
-                this.routes.set(key, route);
-            }
-
-            // specificFares.jsonの読み込み
-            const specificFaresData = path.join(process.cwd(), 'src', 'data', 'specificFares.json');
-            this.specificFares = JSON.parse(fs.readFileSync(specificFaresData, 'utf-8'));
-            for (const specificFare of this.specificFares) {
-                this.specificFareMap.set(specificFare.sections.map(seg => `${seg.stationName}`)
-                    .join("-"), specificFare.fare);
-            }
-
-            // trainSpecificSections.jsonの読み込み
-            const trainSpecificSectionsData = path.join(process.cwd(), 'src', 'data', 'trainSpecificSections.json');
-            const rawData: Record<string, Section[]> = JSON.parse(fs.readFileSync(trainSpecificSectionsData, 'utf-8'));
-            const transformedSections = {} as TrainSpecificSection;
-            for (const sectionName in rawData) {
-                if (Object.prototype.hasOwnProperty.call(rawData, sectionName)) {
-                    const key = sectionName as keyof TrainSpecificSection;
-                    const segments = rawData[key];
-                    const routeKeys = segments.map(segment =>
-                        createRouteKey(segment.line, segment.station0, segment.station1)
-                    );
-                    transformedSections[key] = new Set(routeKeys);
+                // 1. 隣接リストの構築
+                if (!this.adjacentStationsList.has(route.station0)) this.adjacentStationsList.set(route.station0, []);
+                if (!this.adjacentStationsList.has(route.station1)) this.adjacentStationsList.set(route.station1, []);
+                if (!this.adjacentStationsList.get(route.station0)!.includes(route.station1)) {
+                    this.adjacentStationsList.get(route.station0)!.push(route.station1);
                 }
+                if (!this.adjacentStationsList.get(route.station1)!.includes(route.station0)) {
+                    this.adjacentStationsList.get(route.station1)!.push(route.station0);
+                }
+
+                // 2. 駅ペア検索Mapの構築
+                const pairKey = createPairKey(route.station0, route.station1);
+                if (!this.stationPairRoutes.has(pairKey)) {
+                    this.stationPairRoutes.set(pairKey, []);
+                }
+                this.stationPairRoutes.get(pairKey)!.push(route);
             }
-            this.trainSpecificSections = transformedSections;
-
-            // yamanote.jsonの読み込み
-            const yamanotePath = path.join(process.cwd(), 'src', 'data', 'yamanote.json');
-            this.yamanote = JSON.parse(fs.readFileSync(yamanotePath, 'utf-8'));
-
-            // specificSections.jsonの読み込み
-            const specificSectionsList = path.join(process.cwd(), 'src', 'data', 'specificSections.json');
-            this.specificSections = JSON.parse(fs.readFileSync(specificSectionsList, 'utf-8'));
 
             // selectionSections.jsonの読み込み
             const selectionSectionsList = path.join(process.cwd(), 'src', 'data', 'selectionSections.json');
             this.selectionSections = JSON.parse(fs.readFileSync(selectionSectionsList, 'utf-8'));
 
+            // specificFares.jsonの読み込み
+            const specificFaresData = path.join(process.cwd(), 'src', 'data', 'specificFares.json');
+            const specificFaresList: SpecificFare[] = JSON.parse(fs.readFileSync(specificFaresData, 'utf-8'));
+            for (const specificFare of specificFaresList) {
+                this.specificFares.set(specificFare.sections.map(seg => `${seg.stationName}`)
+                    .join("-"), specificFare.fare);
+            }
+
+            // specificSections.jsonの読み込み
+            const specificSectionsList = path.join(process.cwd(), 'src', 'data', 'specificSections.json');
+            this.specificSections = JSON.parse(fs.readFileSync(specificSectionsList, 'utf-8'));
+
+            // trainSpecificSections.jsonの読み込み
+            const trainSpecificSectionsData = path.join(process.cwd(), 'src', 'data', 'trainSpecificSections.json');
+            const rawTrainSpecificSectionsData: Record<string, Section[]> = JSON.parse(fs.readFileSync(trainSpecificSectionsData, 'utf-8'));
+            const transformedTrainSpecificSections = {} as TrainSpecificSection;
+            for (const sectionName in rawTrainSpecificSectionsData) {
+                if (Object.prototype.hasOwnProperty.call(rawTrainSpecificSectionsData, sectionName)) {
+                    const key = sectionName as keyof TrainSpecificSection;
+                    const segments = rawTrainSpecificSectionsData[key];
+                    const routeKeys = segments.map(segment =>
+                        createRouteKey(segment.line, segment.station0, segment.station1)
+                    );
+                    transformedTrainSpecificSections[key] = new Set(routeKeys);
+                }
+            }
+            this.trainSpecificSections = transformedTrainSpecificSections;
+
+            // yamanote.jsonの読み込み
+            const yamanotePath = path.join(process.cwd(), 'src', 'data', 'yamanote.json');
+            this.yamanote = JSON.parse(fs.readFileSync(yamanotePath, 'utf-8'));
+
         } catch (error) {
             console.error('データ読み込みエラー：', error);
         }
+    }
+
+    public getAdjacentStations(stationName: string): string[] {
+        return this.adjacentStationsList.get(stationName) || [];
+    }
+
+    public getCities(): City[] {
+        return this.cities;
+    }
+
+    public getFromBoldLineAreaRoute(key: string): PathStep[] | null {
+        return this.fromBoldLineAreaRoutes.get(key) ?? null;
+    }
+
+    public getMajorCitySuburbanSections(majorCitySuburbanSectionName: keyof MajorCitySuburbanSection): Set<string> {
+        return this.majorCitySuburbanSections[majorCitySuburbanSectionName];
+    }
+
+    public getPassingBoldLineAreaRoute(key: string): PathStep[] | null {
+        return this.passingBoldLineAreaRoutes.get(key) ?? null;
+    }
+
+    public getPrinting(kana: string): string | null {
+        return this.printings.get(kana) ?? null;
     }
 
     public getRouteSegment(line: string, stationName0: string, stationName1: string): RouteSegment {
@@ -116,53 +173,37 @@ class Load {
         return routesSegment;
     }
 
-    public getRoutesList(): RouteSegment[] {
-        return this.routeList;
-    }
-
     public getSpecificFares(fullPath: PathStep[]): number | null {
         const key = fullPath
             .map(seg => `${seg.stationName}`)
             .join("-");
-        return this.specificFareMap.get(key) ?? null;
-    }
-
-    public getTrainSpecificSections(specificSectionName: keyof TrainSpecificSection): Set<string> {
-        return this.trainSpecificSections[specificSectionName];
-    }
-
-    public getPassingBoldLineAreaRoute(key: string): PathStep[] | null {
-        return this.passingBoldLineAreaRoutes.get(key) ?? null;
-    }
-
-    public getFromBoldLineAreaRoute(key: string): PathStep[] | null {
-        return this.fromBoldLineAreaRoutes.get(key) ?? null;
+        return this.specificFares.get(key) ?? null;
     }
 
     public getToBoldLineAreaRoute(key: string): PathStep[] | null {
         return this.toBoldLineAreaRoutes.get(key) ?? null;
     }
 
-    public getCities(): City[] {
-        return this.cities;
-    }
-
-    public getYamanote(): City {
-        return this.yamanote;
-    }
-
-    public getPrinting(kana: string): string | null {
-        return this.printings.get(kana) ?? null;
+    public getTrainSpecificSections(trainSpecificSectionName: keyof TrainSpecificSection): Set<string> {
+        return this.trainSpecificSections[trainSpecificSectionName];
     }
 
     public getSpecificSections(): OuterSection[] {
         return this.specificSections;
     }
 
+    public getSegmentsForStationPair(stationName0: string, stationName1: string): RouteSegment[] {
+        const pairKey = createPairKey(stationName0, stationName1);
+        return this.stationPairRoutes.get(pairKey) || [];
+    }
+
     public getSelectionSections(): OuterSection[] {
         return this.selectionSections;
     }
 
+    public getYamanote(): City {
+        return this.yamanote;
+    }
 }
 
 // シングルトンインスタンスとしてエクスポートし、アプリ全体で一つのインスタンスを共有する


### PR DESCRIPTION
## 概要
分割乗車券の割引額を比較・提示するためのベースラインである「分割しない乗車券（通常の乗車券）」の算出ロジックを、最短経路から最安経路に変更しました。

## 変更の目的・背景
これまで比較対象として「最短経路」の乗車券を表示していましたが、旅客営業規則上、最短経路が必ずしも最安とは限らないため、分割による純粋なお得度（差額）を示すアンカーとして適切ではないケースがありました。
ユーザーが窓口や券売機で何も工夫せずに購入する「通常の最も安い購入方法」を正確な比較基準とするため、「最安経路」の非分割乗車券を表示するように改修します。

※注：ここでの「最安経路」は、あくまで入力された発着駅間の最安値です。目的地の外側へ延長する（前途放棄を前提とした）乗車券は、通常の買い方からの逸脱となるため、比較基準の純粋性を保つ目的で意図的にベースラインから除外しています。

## 変更内容
- 比較用ベースライン乗車券の取得ロジックにおいて、抽出条件を距離優先（最短）から運賃優先（最安）に変更
- 検索結果画面のUIおよび差額（〇〇円お得）の計算ロジックが、新しいベースライン運賃を正しく参照するように修正

## 影響範囲
- 検索結果画面における「通常の乗車券」の金額・経路表示
- 分割乗車券との差額（割引額）の計算結果表示

## 確認事項（テスト項目）
- [ ] 最短経路と最安経路が異なる区間で検索した場合、正しく最安経路の運賃がベースラインとして表示されること
- [ ] 分割乗車券による差額計算が、新しいベースライン運賃を用いて正確に行われていること
- [ ] 目的地の外側へ延長した場合の運賃が、ベースラインの最安値ロジックに誤って混入していないこと