### PR TITLE
fix: 鉄道駅バリアフリー料金が運賃に加算されない不具合の修正

### DIFF
--- a/src/app/utils/calcFare.ts
+++ b/src/app/utils/calcFare.ts
@@ -35,11 +35,11 @@ export function calculateFareFromPath(fullPath: PathStep[]): number {
     // 第78条 電車特定区間内等の大人片道普通旅客運賃
     // 電車特定区間内相互発着の場合
     if (isAllTrainSpecificSections("電車特定区間", routeKeys)) {
-        fare = calculateFareInTrainSpecificSection(routeSegments);
+        fare += calculateFareInTrainSpecificSection(routeSegments);
     }
 
     // 第85条 他の旅客鉄道会社線を連続して乗車する場合の大人片道普通旅客運賃
-    else fare = calculateFare(routeSegments);
+    else fare += calculateFare(routeSegments);
 
     // （1）北海道旅客鉄道会社線の乗車区間に対する普通旅客運賃の加算額
     if (0 < routeSegmentsByCompany[1].length) {


### PR DESCRIPTION
## 概要
運賃計算ロジックにおいて、算出済みの鉄道駅バリアフリー料金が基本運賃によって上書きされ、最終的な運賃（fare）に反映されていなかった致命的な不具合を修正しました。

## 変更内容
- `src/app/utils/calcFare.ts` の `calculateFareFromPath` 関数内を修正。
- `calculateBarrierFreeFeeFromPath` で取得した鉄道駅バリアフリー料金を保持する変数 `fare` に対し、第78条（電車特定区間）および第85条（その他の計算）の基本運賃を算出する際、代入（`=`）ではなく加算代入（`+=`）を行うよう演算子を変更しました。

## 原因
鉄道駅バリアフリー料金を `fare` に初期格納した後、後続の基本運賃計算ロジックが `fare = ...` となっていたため、鉄道駅バリアフリー料金の加算分（10円）がメモリ上で消失していました。

## 影響範囲
- `calculateFareFromPath` を呼び出す全運賃計算処理。
- 鉄道駅バリアフリー料金の対象となる区間内完結の場合において、運賃が正しく上乗せされて出力されるようになります。

## テスト・確認事項
- [x] 鉄道駅バリアフリー料金加算対象の区間の運賃が、修正前と比較して正しく加算されていること。
- [x] 鉄道駅バリアフリー料金対象外の区間の運賃計算に影響が出ていないこと。