### PR TITLE
fix: 新大阪・大阪〜姫路以遠の特例判定から「JR西日本完結」の誤条件を削除

### DIFF
--- a/src/app/utils/correctPath.ts
+++ b/src/app/utils/correctPath.ts
@@ -7434,16 +7434,6 @@ export function applyYamanoteRule(fullPath: PathStep[]): PathStep[] {
 // 第88条 新大阪駅又は大阪駅発又は着となる片道普通旅客運賃の計算方
 export function applyOsakaRule(fullPath: PathStep[]): PathStep[] {
 
-    // 西日本旅客鉄道会社内完結であるかの確認
-    for (let i = 0; i < fullPath.length - 1; i++) {
-        const line = fullPath[i].lineName;
-        if (line === null) throw new Error(`applyOsakaRuleでエラーが発生しました.`);
-        const routeSegment = load.getRouteSegment(line, fullPath[i].stationName, fullPath[i + 1].stationName);
-        if (routeSegment.company !== 4) {
-            return fullPath;
-        }
-    }
-
     // 着駅判定
     if (fullPath[fullPath.length - 1].stationName === "大阪" || fullPath[fullPath.length - 1].stationName === "新大阪") {
         const changingIdx: number[] = [];


### PR DESCRIPTION
## 概要
旅客営業規則 第88条（新大阪駅又は大阪駅発又は着となる普通旅客運賃の計算方）の適用判定ロジックのバグ修正です。
新大阪・大阪駅と姫路駅以遠の相互間（姫路経由）の運賃計算において、他社線へ跨るルートで特例が適用されていない不具合を修正しました。

## 原因
第88条の適用条件として、プログラム内で独自に「JR西日本管内完結であること（自社線完結）」という判定条件を含めてしまっていたため。
実際には本特例はJR西日本管内で完結するかどうかにかかわらず適用されるのが正しい仕様です。

（例：岡山から姫路を経由して、JR東海の紀勢本線を通って新大阪まで通しで購入する場合等でも、大阪駅を起点としてキロ程を計算する必要があります）

## 修正内容
* 運賃計算クラス（または該当のモジュール/関数）における第88条の適用判定処理から、「JR西日本管内完結」を要求する条件式を削除しました。

## 影響範囲・確認事項
* 新大阪駅・大阪駅発着で、姫路駅を経由し、**他社線を経由**する経路の運賃計算が、大阪駅起点（または終点）の営業キロ・運賃計算キロで正しく計算されるようになります。
* 既存のJR西日本管内完結のルート（例：新大阪〜岡山 など）の計算結果にデグレが発生していないことをテストで確認済みです。