### PR TITLE
fix: 経路が存在しない(経路数1未満)場合の運賃計算でエラーを投げる仕様変更

### DIFF
--- a/src/app/utils/calcFare.ts
+++ b/src/app/utils/calcFare.ts
@@ -4,9 +4,10 @@ import { createRouteKey, calculateTotalEigyoKilo, calculateTotalGiseiKilo, isAll
 import { PathStep, RouteSegment } from '@/app/types';
 
 export function calculateFareFromPath(fullPath: PathStep[]): number {
+    if (fullPath.length < 2) throw new Error(`calculateFareFromPath: 経路が不正です。運賃計算には2駅以上の経路が必要です。`);
+
     let fare: number = calculateBarrierFreeFeeFromPath(fullPath);
 
-    if (fullPath.length <= 1) return fare;
     // 第79条 東京附近等の特定区間等における大人片道普通旅客運賃の特定
     const specificFare = load.getSpecificFares(fullPath);
     if (specificFare !== null) {
@@ -21,7 +22,7 @@ export function calculateFareFromPath(fullPath: PathStep[]): number {
 
     for (let i = 0; i < fullPath.length - 1; i++) {
         const line = fullPath[i].lineName;
-        if (line === null) throw new Error(`calculateFareFromCorrectedPathでエラーが発生しました。`);
+        if (line === null) throw new Error(`calculateFareFromPath: 経路が不正です。経路の途中でlineNameにnullは使えません。`);
         const routeSegment = load.getRouteSegment(line, fullPath[i].stationName, fullPath[i + 1].stationName);
 
         // 全ての駅間のデータを取得


### PR DESCRIPTION
## 概要
運賃計算の根幹である `calculateFareFromPath` において、有効な経路が存在しない（経路の要素数が2未満の）配列が渡された場合の挙動を、`0` を返す仕様から `Error` を投げる仕様に変更しました。

## 変更の背景と理由
これまで経路がない（駅数が0または1）場合でも、エラーを出さずに一律で `0`を返す挙動になっていました。
旅客営業規則においては最短距離の運賃規定は存在しますが、「経路が存在しない」場合の運賃という概念自体が存在しません。
アルゴリズムの過程でこのような無効な経路が渡された場合に `0` として正常終了してしまうと、後続の処理で論理破綻や潜在的なバグを引き起こすリスクが高いため、早期にエラー（Fail Fast）として検知できるよう仕様を変更しました。

## 変更内容
- `calculateFareFromPath` の先頭にバリデーションを追加
- `fullPath.length < 2` の場合、原因を含めた具体的な `Error` を投げるように修正

## 影響範囲・確認事項
- [x] 呼び出し元の関数（経路探索アルゴリズムなど）で、このエラーが意図せずクラッシュを引き起こさないか（必要に応じて呼び出し元での `try-catch` を別PRで検討、または本PR内でハンドリングを追加）
- この変更により既存のテストが落ちていないか確認

## 備考
本PRは仕様変更のみを含みます。