### PR TITLE
feat(ui): 長い計算結果一覧のナビゲーション改善（トップへ戻るボタンの追加）

### DIFF
--- a/src/app/split/page.tsx
+++ b/src/app/split/page.tsx
@@ -1,6 +1,7 @@
 import Form from "@/app/split/components/Form";
 import type { Metadata } from "next";
 import { RiScissorsFill } from "react-icons/ri";
+import ScrollToTopButton from "@/components/ScrollToTopButton";
 
 export const metadata: Metadata = {
   title: "分割乗車券プログラム",
@@ -11,8 +12,6 @@ export default function Page() {
   return (
     <div className="py-12 px-4 sm:px-6 lg:px-8">
       <main className="max-w-xl mx-auto">
-
-        {/* ページヘッダー領域 */}
         <div className="text-center mb-8">
           <div className="inline-flex items-center justify-center p-4 bg-blue-100 rounded-full mb-4 shadow-sm">
             <RiScissorsFill className="w-8 h-8 text-blue-600" />
@@ -25,13 +24,11 @@ export default function Page() {
             在来線において最もお得な分割ルートを計算します。
           </p>
         </div>
-
-        {/* フォーム領域（カードスタイル） */}
         <div className="bg-white p-6 sm:p-10 rounded-2xl shadow-sm border border-slate-200">
           <Form />
         </div>
-
       </main>
+      <ScrollToTopButton />
     </div>
   );
 }

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { HiArrowUp } from "react-icons/hi";
+import { animateScroll as scroll } from "react-scroll";
+
+export default function ScrollToTopButton() {
+    const [showScrollTop, setShowScrollTop] = useState(false);
+
+    useEffect(() => {
+        const handleScroll = () => {
+            if (window.scrollY > 300) {
+                setShowScrollTop(true);
+            } else {
+                setShowScrollTop(false);
+            }
+        };
+
+        window.addEventListener("scroll", handleScroll);
+        return () => window.removeEventListener("scroll", handleScroll);
+    }, []);
+
+    const scrollToTop = () => {
+        scroll.scrollToTop({
+            duration: 500,
+            smooth: "easeInOutQuad",
+        });
+    };
+
+    return (
+        <button
+            type="button"
+            onClick={scrollToTop}
+            aria-label="ページの上部へ戻る"
+            className={`
+                fixed right-4 bottom-20 sm:right-8 sm:bottom-8 z-50
+                flex items-center justify-center w-12 h-12 
+                bg-slate-800 text-white rounded-full shadow-lg 
+                hover:bg-slate-700 hover:scale-105 active:scale-95
+                transition-all duration-300
+                ${showScrollTop ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10 pointer-events-none'}
+            `}
+        >
+            <HiArrowUp className="text-xl" />
+        </button>
+    );
+}

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -35,8 +35,8 @@ export default function ScrollToTopButton() {
             className={`
                 fixed right-4 bottom-20 sm:right-8 sm:bottom-8 z-50
                 flex items-center justify-center w-12 h-12 
-                bg-slate-800 text-white rounded-full shadow-lg 
-                hover:bg-slate-700 hover:scale-105 active:scale-95
+                bg-blue-600 backdrop-blur-sm text-white rounded-full shadow-md 
+                hover:bg-blue-600 hover:scale-105 active:scale-95
                 transition-all duration-300
                 ${showScrollTop ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10 pointer-events-none'}
             `}


### PR DESCRIPTION
## 概要
分割乗車券の最適解パターンが多数表示された際、ページが縦に長く伸びてしまい、ユーザーが条件変更のために検索フォーム（ページ上部）へ戻る際のスクロール負荷が高くなる問題を解決します。

## 変更内容
- `react-scroll` を利用した独立したクライアントコンポーネント `ScrollToTopButton.tsx` の新規作成
- ユーザーのスクロール量（300px以上）を検知し、アニメーションを伴ってフェードイン・フェードアウトする表示制御の実装
- モバイル端末のセーフエリア（画面下部のホームインジケーター等）および、リスト内の金額表示との重なりを回避するための配置調整
- HTMLのセマンティクスを考慮し、`page.tsx` 内の `<main>` タグ外に独立したナビゲーション要素として配置