### PR TITLE
chore: uuidパッケージを非推奨のv8からv11へアップグレード

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "react-hook-form": "^7.65.0",
         "react-icons": "^5.5.0",
         "react-scroll": "^1.9.3",
-        "react-select": "^5.10.2"
+        "react-select": "^5.10.2",
+        "uuid": "^11.1.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
@@ -1799,6 +1800,17 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -10553,14 +10565,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
-      "optional": true,
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react-hook-form": "^7.65.0",
     "react-icons": "^5.5.0",
     "react-scroll": "^1.9.3",
-    "react-select": "^5.10.2"
+    "react-select": "^5.10.2",
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",


### PR DESCRIPTION
## 概要
Cloud Buildにて出力されていた `uuid` パッケージの非推奨警告を解消するため、パッケージのメジャーアップデートを行いました。

**発生していた警告:**
> npm warn deprecated uuid@8.3.2: uuid@10 and below is no longer supported. For ESM codebases, update to uuid@latest. For CommonJS codebases, use uuid@11...

## 変更内容
- `uuid` を `v8.3.2` から `v11.x` へアップグレード

## 影響範囲と確認事項
- 依存関係（`package.json`, `package-lock.json`）の更新のみです。
- `uuid` v8 から v11 へのアップデートにおいて、一般的なID生成用途（`uuidv4()` など）における基本的なAPIの破壊的変更はありません。
- アプリケーション内でID生成が正常に行われていること、およびビルドログから該当の警告が消えていることを確認済みです。

## 備考
本PRは依存関係の更新のみを含みます。