### PR TITLE
build: Artifact Registry を利用したリモートキャッシュの導入によるビルド高速化

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-# 環境変数の定義 (ビルド時に埋め込まれる値)
+# 環境変数の定義
 ARG NEXT_PUBLIC_GOOGLE_ANALYTICS_ID
 ENV NEXT_PUBLIC_GOOGLE_ANALYTICS_ID=$NEXT_PUBLIC_GOOGLE_ANALYTICS_ID
 ARG NEXT_PUBLIC_FIREBASE_API_KEY

--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -1,5 +1,5 @@
 steps:
-  # 1. 秘匿バケットから DB・JSON データをダウンロードし、所定のディレクトリに配置する（本番と同様）
+  # 1. 秘匿バケットからのデータダウンロード
   - name: 'gcr.io/cloud-builders/gsutil'
     entrypoint: 'bash'
     args:
@@ -13,13 +13,20 @@ steps:
         mkdir -p src/app/split/data
         gsutil -m cp gs://kippu-navi-build-secrets/split/data/*.json ./src/app/split/data/
 
-  # 2. JSON が揃った状態で Docker ビルドを実行する（タグを PR 番号に変更）
+  # 2. Buildx ビルダーのセットアップ
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['buildx', 'create', '--name', 'mybuilder', '--use']
+
+  # 3. Docker ビルドと Push
   - name: 'gcr.io/cloud-builders/docker'
     args: 
+      - 'buildx'
       - 'build'
+      - '--push'
       - '-t'
-      # $SHORT_SHA の代わりに、組み込み変数 $_PR_NUMBER を使用してイメージを識別します
       - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi:pr-$_PR_NUMBER'
+      - '--cache-from=type=registry,ref=asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi-cache:main'
+      - '--cache-to=type=registry,ref=asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi-cache:pr-$_PR_NUMBER,mode=max'
       - '--build-arg'
       - 'NEXT_PUBLIC_GOOGLE_ANALYTICS_ID=${_NEXT_PUBLIC_GOOGLE_ANALYTICS_ID}'
       - '--build-arg'
@@ -36,13 +43,7 @@ steps:
       - 'NEXT_PUBLIC_FIREBASE_APP_ID=${_NEXT_PUBLIC_FIREBASE_APP_ID}'
       - '.'
 
-  # 3. ビルドしたプレビュー用イメージを Artifact Registry に Push
-  - name: 'gcr.io/cloud-builders/docker'
-    args: 
-      - 'push'
-      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi:pr-$_PR_NUMBER'
-
-  # 4. Cloud Run へデプロイし、プレビュー用の仮URLを発行する
+  # 4. Cloud Run へプレビューデプロイ
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: gcloud
     args:
@@ -53,14 +54,9 @@ steps:
       - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi:pr-$_PR_NUMBER'
       - '--region'
       - 'asia-northeast1'
-      # ▼ ここから下がプレビュー環境のための追加設定 ▼
       - '--tag'
-      - 'pr-$_PR_NUMBER' # リビジョンに「pr-12」のようなタグを付与
-      - '--no-traffic'   # 本番環境（main）へのトラフィック割り当てを0%に保つ
-
-# 正常終了の条件（検証対象のイメージ名をPR用に合わせる）
-images:
-  - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi:pr-$_PR_NUMBER'
+      - 'pr-$_PR_NUMBER'
+      - '--no-traffic'
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-  # 1. 秘匿バケットから DB・JSON データをダウンロードし、所定のディレクトリに配置する
+  # 1. 秘匿バケットからのデータダウンロード
   - name: 'gcr.io/cloud-builders/gsutil'
     entrypoint: 'bash'
     args:
@@ -13,12 +13,20 @@ steps:
         mkdir -p src/app/split/data
         gsutil -m cp gs://kippu-navi-build-secrets/split/data/*.json ./src/app/split/data/
 
-  # 2. JSON が揃った状態で Docker ビルドを実行する
+  # 2. Buildx ビルダーのセットアップ
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['buildx', 'create', '--name', 'mybuilder', '--use']
+
+  # 3. Docker ビルドと Push
   - name: 'gcr.io/cloud-builders/docker'
     args: 
+      - 'buildx'
       - 'build'
+      - '--push'
       - '-t'
       - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi:$SHORT_SHA'
+      - '--cache-from=type=registry,ref=asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi-cache:main'
+      - '--cache-to=type=registry,ref=asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi-cache:main,mode=max'
       - '--build-arg'
       - 'NEXT_PUBLIC_GOOGLE_ANALYTICS_ID=${_NEXT_PUBLIC_GOOGLE_ANALYTICS_ID}'
       - '--build-arg'
@@ -35,31 +43,17 @@ steps:
       - 'NEXT_PUBLIC_FIREBASE_APP_ID=${_NEXT_PUBLIC_FIREBASE_APP_ID}'
       - '.'
 
-  # 3. ビルドしたイメージを Artifact Registry に Push
-  - name: 'gcr.io/cloud-builders/docker'
-    args: 
-      - 'push'
-      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi:$SHORT_SHA'
-
-  # 4. 本番の Cloud Run へデプロイし、トラフィックを100%向ける
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: 'bash'
     args:
       - '-c'
       - |
-        # ① 新しいイメージをデプロイ
         gcloud run deploy kippu-navi \
           --image asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi:$SHORT_SHA \
           --region asia-northeast1
-        
-        # ② 強制的にトラフィックを最新リビジョン(100%)に切り替える
         gcloud run services update-traffic kippu-navi \
           --to-latest \
           --region asia-northeast1
-
-# 正常終了の条件として、指定したイメージが正しくビルド・プッシュされたか検証する
-images:
-  - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi:$SHORT_SHA'
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## 概要
Cloud Build の実行ごとにVMが破棄される仕様による「毎回ゼロから `npm ci` が実行される」という非効率を解決するため、Artifact Registry をキャッシュストレージとして利用するリモートキャッシュ機構を導入しました。

## 変更内容
1. **Docker Buildx の有効化**
   - Cloud Build の各パイプラインに、Buildx ビルダーをセットアップするステップ（`docker buildx create`）を追加しました。
2. **キャッシュ戦略の構築**
   - **本番（main）**: `kippu-navi-cache:main` タグに対してキャッシュの読み書きを行います。
   - **PRプレビュー**: main のキャッシュをインポートしてビルドを高速化しつつ、書き込みは `kippu-navi-cache:pr-$_PR_NUMBER` に制限し、main のキャッシュを汚染しないように分離しました。
3. **ビルドステップの集約**
   - Buildx の `--push` オプションを利用し、ビルド完了と同時にレジストリへ転送する構成に変更しました。これにより、従来の独立した `docker push` ステップを削減しています。

## メリット
- `package.json` や `package-lock.json` に変更がない場合、最も時間のかかる `npm ci` のレイヤーが完全にスキップされます。
- パイプライン全体の実行時間が短縮され、CI/CD のリソース消費が削減されます。

## 動作確認方法
- [x] 初回ビルドが正常に完了し、Artifact Registry 内にキャッシュ用イメージ（`kippu-navi-cache`）が生成されること。
- [ ] 2回目以降のビルド（依存関係に変更がない場合）で、`deps` ステージ（`npm ci`）がキャッシュから復元され、ビルド時間が大幅に短縮されること。