### PR TITLE
Revert "build: Artifact Registry を利用したリモートキャッシュの導入によるビルド高速化"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-# 環境変数の定義
+# 環境変数の定義 (ビルド時に埋め込まれる値)
 ARG NEXT_PUBLIC_GOOGLE_ANALYTICS_ID
 ENV NEXT_PUBLIC_GOOGLE_ANALYTICS_ID=$NEXT_PUBLIC_GOOGLE_ANALYTICS_ID
 ARG NEXT_PUBLIC_FIREBASE_API_KEY

--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -1,5 +1,5 @@
 steps:
-  # 1. 秘匿バケットからのデータダウンロード
+  # 1. 秘匿バケットから DB・JSON データをダウンロードし、所定のディレクトリに配置する（本番と同様）
   - name: 'gcr.io/cloud-builders/gsutil'
     entrypoint: 'bash'
     args:
@@ -13,20 +13,13 @@ steps:
         mkdir -p src/app/split/data
         gsutil -m cp gs://kippu-navi-build-secrets/split/data/*.json ./src/app/split/data/
 
-  # 2. Buildx ビルダーのセットアップ
-  - name: 'gcr.io/cloud-builders/docker'
-    args: ['buildx', 'create', '--name', 'mybuilder', '--use']
-
-  # 3. Docker ビルドと Push
+  # 2. JSON が揃った状態で Docker ビルドを実行する（タグを PR 番号に変更）
   - name: 'gcr.io/cloud-builders/docker'
     args: 
-      - 'buildx'
       - 'build'
-      - '--push'
       - '-t'
+      # $SHORT_SHA の代わりに、組み込み変数 $_PR_NUMBER を使用してイメージを識別します
       - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi:pr-$_PR_NUMBER'
-      - '--cache-from=type=registry,ref=asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi-cache:main'
-      - '--cache-to=type=registry,ref=asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi-cache:pr-$_PR_NUMBER,mode=max'
       - '--build-arg'
       - 'NEXT_PUBLIC_GOOGLE_ANALYTICS_ID=${_NEXT_PUBLIC_GOOGLE_ANALYTICS_ID}'
       - '--build-arg'
@@ -43,7 +36,13 @@ steps:
       - 'NEXT_PUBLIC_FIREBASE_APP_ID=${_NEXT_PUBLIC_FIREBASE_APP_ID}'
       - '.'
 
-  # 4. Cloud Run へプレビューデプロイ
+  # 3. ビルドしたプレビュー用イメージを Artifact Registry に Push
+  - name: 'gcr.io/cloud-builders/docker'
+    args: 
+      - 'push'
+      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi:pr-$_PR_NUMBER'
+
+  # 4. Cloud Run へデプロイし、プレビュー用の仮URLを発行する
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: gcloud
     args:
@@ -54,9 +53,14 @@ steps:
       - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi:pr-$_PR_NUMBER'
       - '--region'
       - 'asia-northeast1'
+      # ▼ ここから下がプレビュー環境のための追加設定 ▼
       - '--tag'
-      - 'pr-$_PR_NUMBER'
-      - '--no-traffic'
+      - 'pr-$_PR_NUMBER' # リビジョンに「pr-12」のようなタグを付与
+      - '--no-traffic'   # 本番環境（main）へのトラフィック割り当てを0%に保つ
+
+# 正常終了の条件（検証対象のイメージ名をPR用に合わせる）
+images:
+  - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi:pr-$_PR_NUMBER'
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-  # 1. 秘匿バケットからのデータダウンロード
+  # 1. 秘匿バケットから DB・JSON データをダウンロードし、所定のディレクトリに配置する
   - name: 'gcr.io/cloud-builders/gsutil'
     entrypoint: 'bash'
     args:
@@ -13,20 +13,12 @@ steps:
         mkdir -p src/app/split/data
         gsutil -m cp gs://kippu-navi-build-secrets/split/data/*.json ./src/app/split/data/
 
-  # 2. Buildx ビルダーのセットアップ
-  - name: 'gcr.io/cloud-builders/docker'
-    args: ['buildx', 'create', '--name', 'mybuilder', '--use']
-
-  # 3. Docker ビルドと Push
+  # 2. JSON が揃った状態で Docker ビルドを実行する
   - name: 'gcr.io/cloud-builders/docker'
     args: 
-      - 'buildx'
       - 'build'
-      - '--push'
       - '-t'
       - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi:$SHORT_SHA'
-      - '--cache-from=type=registry,ref=asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi-cache:main'
-      - '--cache-to=type=registry,ref=asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi-cache:main,mode=max'
       - '--build-arg'
       - 'NEXT_PUBLIC_GOOGLE_ANALYTICS_ID=${_NEXT_PUBLIC_GOOGLE_ANALYTICS_ID}'
       - '--build-arg'
@@ -43,17 +35,31 @@ steps:
       - 'NEXT_PUBLIC_FIREBASE_APP_ID=${_NEXT_PUBLIC_FIREBASE_APP_ID}'
       - '.'
 
+  # 3. ビルドしたイメージを Artifact Registry に Push
+  - name: 'gcr.io/cloud-builders/docker'
+    args: 
+      - 'push'
+      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi:$SHORT_SHA'
+
+  # 4. 本番の Cloud Run へデプロイし、トラフィックを100%向ける
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: 'bash'
     args:
       - '-c'
       - |
+        # ① 新しいイメージをデプロイ
         gcloud run deploy kippu-navi \
           --image asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi:$SHORT_SHA \
           --region asia-northeast1
+        
+        # ② 強制的にトラフィックを最新リビジョン(100%)に切り替える
         gcloud run services update-traffic kippu-navi \
           --to-latest \
           --region asia-northeast1
+
+# 正常終了の条件として、指定したイメージが正しくビルド・プッシュされたか検証する
+images:
+  - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi:$SHORT_SHA'
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
## 概要
マージ済みのPR（Artifact Registryを用いたリモートキャッシュの導入）をリバートします。

## リバートの理由
本番環境での運用前に、Artifact Registryのストレージ使用量が無料枠（1GB）を超過し、課金が発生している状態を確認したためです。

## 影響範囲
- `cloudbuild.yaml` および `cloudbuild-pr.yaml` がキャッシュ導入前の状態に戻ります。
- （以前あった）末尾の `images:` ブロックが復活します。
- **パフォーマンスへの影響:** リモートキャッシュが効かなくなるため、CI/CDのビルド時間（特に `npm ci` の実行時間）がマージ前の状態に戻ります。

## 今後の対応
1. Artifact Registryにて、古いPR用キャッシュや旧世代のキャッシュを自動で削除するクリーンアップポリシーを設定する。
2. インフラ側の安全）が担保されたことを確認した後、改めて同等のキャッシュ最適化PRを作成し、再導入する。