### PR TITLE
Revert "chore: uuidパッケージを非推奨のv8からv11へアップグレード"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,7 @@
         "react-hook-form": "^7.65.0",
         "react-icons": "^5.5.0",
         "react-scroll": "^1.9.3",
-        "react-select": "^5.10.2",
-        "uuid": "^11.1.1"
+        "react-select": "^5.10.2"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
@@ -1800,17 +1799,6 @@
       "optional": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@google-cloud/storage/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -10565,16 +10553,14 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "license": "MIT",
+      "optional": true,
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "react-hook-form": "^7.65.0",
     "react-icons": "^5.5.0",
     "react-scroll": "^1.9.3",
-    "react-select": "^5.10.2",
-    "uuid": "^11.1.1"
+    "react-select": "^5.10.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",


### PR DESCRIPTION
## 概要
マージ済みのPR（`uuid` パッケージのv11へのアップグレード）をリバートします。

## リバートの理由
Cloud Build上で発生していた非推奨警告（`uuid@8.3.2` 等）は、当プロジェクトの直接の依存関係ではなく、`firebase-admin` 内部パッケージからの推移的依存（Transitive Dependency）に起因するものであることが判明したためです。

プロジェクト内で直接使用していないパッケージを警告解消の目的だけで `package.json` に明示的に追加することは、依存関係の汚染（技術的負債）につながります。また、Firebase内部が想定している `uuid` のバージョンと強制的に乖離させることで、予期せぬ不具合を引き起こすリスクを回避するため、元のクリーンな状態へ巻き戻します。

## 影響範囲
- `package.json` および `package-lock.json` から `uuid` の明示的な依存関係を削除し、マージ前の状態に戻します。
- 本リバート以降、再度CI/CDのログに `uuid` に関する非推奨警告が出力されるようになりますが、これは外部ライブラリに起因する「安全に無視できる警告」として許容します。