### PR TITLE
ci: GitHub ActionsのNode.jsランタイムを24へアップグレード

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
-
-      - name: Update npm
-        run: npm install -g npm@11.14.1
 
       - name: Setup Takumi Guard
         uses: flatt-security/setup-takumi-guard-npm@v1
@@ -51,11 +48,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
-
-      - name: Update npm
-        run: npm install -g npm@11.14.1
 
       - name: Setup Takumi Guard
         uses: flatt-security/setup-takumi-guard-npm@v1
@@ -77,7 +71,7 @@ jobs:
             src/data/*.json
             src/app/mr/data/*.json
             src/app/split/data/*.json
-          key: kippu-navi-data-v20260509-${{ hashFiles('.github/workflows/test.yml') }}
+          key: kippu-navi-data-v20260516-${{ hashFiles('.github/workflows/test.yml') }}
 
       # キャッシュが無い場合のみGCP認証
       - name: Authenticate to Google Cloud


### PR DESCRIPTION
## 概要
ローカル環境および本番環境（Docker）の Node.js 24 移行に伴い、CI（GitHub Actions）環境のランタイムも Node 24 へ更新しました。あわせて、パイプラインの不要なステップを削減し最適化を行いました。

## 変更内容
1. **Node.js バージョンの統一**
   - `test.yml` 内の `lint` ジョブ、`test` ジョブそれぞれの `setup-node` アクションにおける `node-version` を `'20'` から `'24'` に更新しました。これにより、開発・テスト・運用の全フェーズで環境の差異を無くし、バージョン依存のバグを未然に防ぎます。
2. **無駄なビルドステップのクリーンアップ**
   - 各ジョブで明示的に実行していた `npm install -g npm@11.14.1` （npm自体のグローバルアップデート）のステップを削除しました。Node 24 標準のパッケージマネージャーに委ねることで、CI のオーバーヘッドを削減しています。

## 影響範囲と確認事項
- **キャッシュの再生成:** `test.yml` 自体を変更したため、`test` ジョブのデータ復元時に使用しているキャッシュキー（`${{ hashFiles('.github/workflows/test.yml') }}`）が変わり、初回のみ GCS からのデータ再ダウンロードが走ります（意図通りの挙動です）。
- [x] PR作成後、本CIがフックされ、`Run ESLint`（Lintジョブ）および `Run Vitest`（Testジョブ）が双方とも Node 24 上で正常にパスすることを確認する。