### PR TITLE
fix: トップページFAQの「仕組み」リンク先を修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -250,7 +250,7 @@ export default async function Home() {
               <div className="mt-3 flex items-start">
                 <span className="shrink-0 bg-slate-200 text-slate-600 w-7 h-7 rounded-full flex items-center justify-center mr-3 text-sm">A</span>
                 <div className="mt-0.5 text-slate-600 leading-relaxed">
-                  <Link href="/about" className="text-blue-600 underline decoration-blue-600 underline-offset-2 mr-1">
+                  <Link href="/logic" className="text-blue-600 underline decoration-blue-600 underline-offset-2 mr-1">
                     仕組み
                   </Link>
                   をご覧ください。


### PR DESCRIPTION
## 概要
トップページのFAQセクション（「なぜ運賃が安くなるのですか？」）内にある「仕組み」ページのリンク先が、誤って `/about` に設定されており、正しいページに遷移しない状態になっていたため修正します。

## 修正内容
- `src/app/page.tsx` 
  - `<Link href="/about">` を `<Link href="/logic">` に修正

## 動作確認
- [x] ローカル環境にて、トップページの「仕組み」リンクをクリックし、正しくページが遷移することを確認した。
- [x] Lintエラーやビルドエラーが発生していないことを確認した。