### PR TITLE
feat: 経路計算の負荷制限を「直線距離」から計算量に直結する「経由駅数（200駅）」へ変更

### DIFF
--- a/src/app/api/split/route.ts
+++ b/src/app/api/split/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getOptimalSplitWithCache } from '@/app/split/lib/getOptimalSplitWithCache';
 
 import { SplitApiRequest } from '@/app/types';
-import { DistanceLimitExceededError, RouteNotFoundError } from '@/app/utils/errors';
+import { StationCountLimitExceededError, RouteNotFoundError } from '@/app/utils/errors';
 
 export async function POST(request: NextRequest) {
     let startStationName: string | undefined;
@@ -42,8 +42,8 @@ export async function POST(request: NextRequest) {
         const safeStart = startStationName ?? '不明';
         const safeEnd = endStationName ?? '不明';
 
-        if (error instanceof DistanceLimitExceededError) {
-            console.warn(`[API/DistanceLimit]: ${error.message} (Request: ${safeStart} -> ${safeEnd})`);
+        if (error instanceof StationCountLimitExceededError) {
+            console.warn(`[API/StationCountLimit]: ${error.message} (Request: ${safeStart} -> ${safeEnd})`);
             return NextResponse.json({ error: error.message }, { status: 422 });
         }
 

--- a/src/app/split/lib/calcSplit.ts
+++ b/src/app/split/lib/calcSplit.ts
@@ -5,7 +5,7 @@ import { KippuData, PathStep, SplitApiResponse, SplitKippuData, SplitKippuDatas 
 import { cheapestPathAndFare } from '@/app/utils/cheapestPath';
 import { calculateTotalGiseiKilo, convertPathStepsToRouteSegments, createPairKey, round1000, round10000, whichMajorCitySuburbanSections } from '@/app/utils/calc';
 import { calculateFareFromPath } from '@/app/utils/calcFare';
-import { DistanceLimitExceededError, RouteNotFoundError } from '@/app/utils/errors';
+import { StationCountLimitExceededError, RouteNotFoundError } from '@/app/utils/errors';
 
 class PriorityQueue {
     private heap: { stationName: string; cost: number }[] = [];
@@ -56,13 +56,6 @@ export class CalculatorSplit {
     private splitMemo: Map<string, SplitKippuDatas[] | null> = new Map();
 
     public findOptimalSplitByShortestGiseiKiloPath(startStationName: string, endStationName: string): SplitApiResponse {
-
-        const DISTANCE_LIMIT = 300;
-
-        const distance = loadSplit.getDistanceBetween(startStationName, endStationName);
-        if (distance > DISTANCE_LIMIT) {
-            throw new DistanceLimitExceededError(distance, DISTANCE_LIMIT);
-        }
 
         this.kippuMemo.clear();
         this.splitMemo.clear();
@@ -135,6 +128,9 @@ export class CalculatorSplit {
     }
 
     private yensAlgorithm(startStation: string, endStation: string): PathStep[][] {
+        // 【追加】駅数の上限（ノード数制限）
+        const STATIONS_LIMIT = 200;
+
         const A: PathStep[][] = [];
         const B: { path: PathStep[]; cost: number; signature: string }[] = [];
         const bSignatures = new Set<string>();
@@ -146,6 +142,11 @@ export class CalculatorSplit {
 
         const firstPath = this.reconstructPath(firstPathResult.previous, startStation, endStation);
         if (!firstPath) return [];
+
+        // 【追加】最短経路の時点で上限駅数を超えている場合、計算が爆発するため即座にエラーを投げる
+        if (firstPath.length > STATIONS_LIMIT) {
+            throw new StationCountLimitExceededError(firstPath.length, STATIONS_LIMIT);
+        }
 
         A.push(firstPath);
 

--- a/src/app/split/page.tsx
+++ b/src/app/split/page.tsx
@@ -29,7 +29,7 @@ export default function Page() {
           <div className="text-sm text-amber-800 leading-relaxed">
             <span className="font-bold block mb-1">【お知らせ】長距離区間の計算制限について</span>
             <p>
-              システム負荷軽減のため、<strong>発着駅間の直線距離が300kmを超える場合</strong>の新規計算を一時的に停止しております。
+              システム負荷軽減のため、<strong>発着駅間の運賃計算キロが最短となる経路上に駅数が200を超える場合</strong>の新規計算を一時的に停止しております。
             </p>
           </div>
         </div>

--- a/src/app/utils/errors.ts
+++ b/src/app/utils/errors.ts
@@ -1,7 +1,7 @@
-export class DistanceLimitExceededError extends Error {
-    constructor (distance: number, limit: number) {
-        super(`発着駅間の距離が上限の${limit}kmを超えています。`);
-        this.name = 'DistanceLimitExceededError';
+export class StationCountLimitExceededError extends Error {
+    constructor (stationCount: number, limit: number) {
+        super(`発着駅間の駅数が上限の${limit}を超えています。`);
+        this.name = 'StationCountLimitExceededError';
     }
 }
 


### PR DESCRIPTION
## 概要
経路探索アルゴリズムにおけるCloud Runの計算リソース枯渇対策として、制限の指標を「直線距離」から、実際の計算量（O(N^2)）に直結する「経由駅数（ノード数）」へと変更しました。

## 背景と目的
前回のPRで「直線距離での制限」を導入しましたが、距離と実際の計算量は必ずしも比例しない（例：地方の一本道は一瞬で計算できるが、首都圏は経路分岐が多すぎて爆発する）というアーキテクチャ上の欠陥がありました。
これを解消し、本来計算できるはずの長距離ルートを救済しつつ、真に計算負荷の高い「複雑なルート」だけを正確に弾くため、アルゴリズム内部での駅数制限にシフトしました。

## 変更内容
- **制限ロジックの変更:**
  - `calc.ts` にて、探索したルートの経由駅数が `200駅` を超えた場合に `StationCountLimitExceededError` をスローする処理を追加しました。
- **デッドコードの削除:**
  - 距離による判定が不要になったため、前回の距離計算ロジックや `DistanceLimitExceededError` を完全に削除しました。
- **UIの修正:**
  - 画面上部の制限に関する注意書きを、「発着駅間の運賃計算キロが最短となる経路上に駅数が200を超える場合」という表現に修正しました。

## 影響範囲
- 分割乗車券の検索機能全般。
- 直線距離が長くても、乗り換えや分岐の少ない一本道ルートの検索が再び可能になります。
- 逆に、短距離であっても無駄に迂回を繰り返すような200駅超えの異常なルートは計算前に遮断されます。

## 備考 / 確認事項
- `release-please` の運用上、前回の距離制限のコミットはrevertせず、本PRにて上書きとデッドコードの削除（リファクタリング）を行っています。
- インフラ側での「60秒タイムアウト設定」は、本PRのロジックをすり抜けた異常データへの最終防衛線として引き続き有効です。