### PR TITLE
fix: 経路分割ロジックでの TypeError を防止し、バグ調査用のJSONダンプを出力するガード節を追加

### DIFF
--- a/src/app/api/split/route.ts
+++ b/src/app/api/split/route.ts
@@ -59,7 +59,7 @@ export async function POST(request: NextRequest) {
             return NextResponse.json({ error: error.message }, { status: 404 });
         }
 
-        console.error('[API/Split Route Error]:', error);
+        console.error(`[API/Split Route Error] (Request: ${safeStart} -> ${safeEnd}):`, error);
         return NextResponse.json(
             { error: 'サーバー内部でエラーが発生しました。' },
             { status: 500 }

--- a/src/app/split/lib/calcSplit.ts
+++ b/src/app/split/lib/calcSplit.ts
@@ -308,6 +308,9 @@ class CalculatorSplit {
 
                 const subPath = fullPath.slice(j, i + 1);
                 const segmentKippu = this.getMemoizedKippuData(subPath);
+
+                if (!segmentKippu) continue;
+
                 const newTotalFare = dp[j] + segmentKippu.fare;
 
                 if (newTotalFare < dp[i]) {
@@ -322,6 +325,11 @@ class CalculatorSplit {
         const resultPatterns: SplitKippuDatas[] = [];
         const totalFare = dp[n - 1];
 
+        if (totalFare === Infinity) {
+            this.splitMemo.set(key, null);
+            return null;
+        }
+
         const reconstruct = (currentIndex: number, currentSegments: SplitKippuData[]) => {
             if (currentIndex === 0) {
                 resultPatterns.push({
@@ -335,11 +343,14 @@ class CalculatorSplit {
             for (let pIdx = 0; pIdx < parents.length; pIdx++) {
                 const prevIndex = parents[pIdx];
                 const segmentPath = fullPath.slice(prevIndex, currentIndex + 1);
+                const kippuData = this.getMemoizedKippuData(segmentPath);
+
+                if (!kippuData) continue;
 
                 const newSegment = {
                     departureStation: fullPath[prevIndex].stationName,
                     arrivalStation: fullPath[currentIndex].stationName,
-                    kippuData: this.getMemoizedKippuData(segmentPath)
+                    kippuData: kippuData
                 };
 
                 reconstruct(prevIndex, [newSegment, ...currentSegments]);
@@ -457,11 +468,22 @@ class CalculatorSplit {
         return finalPath;
     }
 
-    private getMemoizedKippuData(path: PathStep[]): KippuData {
+    private getMemoizedKippuData(path: PathStep[]): KippuData | null {
+        if (!path || path.length === 0) {
+            throw new Error(`[API/Bug] getMemoizedKippuData: Received empty or undefined path.`);
+        }
+
         let key = "";
         for (let k = 0; k < path.length; k++) {
-            const line = (k === path.length - 1) ? "null" : path[k].lineName;
-            key += `${path[k].stationName}-${line}`;
+            const step = path[k];
+
+            if (!step || typeof step !== 'object' || !('stationName' in step)) {
+                const dumpedPath = JSON.stringify(path);
+                throw new Error(`[API/Bug] getMemoizedKippuData: path[${k}] is undefined or invalid. Dump: ${dumpedPath}`);
+            }
+
+            const line = (k === path.length - 1) ? "null" : step.lineName;
+            key += `${step.stationName}-${line}`;
             if (k < path.length - 1) key += "-";
         }
 


### PR DESCRIPTION
## 概要
Issue #115  に対応。
本番環境の経路計算ロジック（`getMemoizedKippuData`）にて発生している、配列内要素の `undefined` 参照によるクラッシュを未然に防ぎ、原因を特定しやすくするための改修です。

## 変更内容
- `calculate.ts` の `getMemoizedKippuData` メソッドの冒頭にバリデーション（ガード節）を追加しました。
- `path` 配列の中に `undefined` や異常なオブジェクトが混入していた場合、システムをサイレントにクラッシュさせるのではなく、配列全体の中身を `JSON.stringify` した文字列を含むエラーを `throw` するようにしました。
- `calculateOptimalSplitForPath` にて、万が一不正なデータが返された場合も処理が止まらないよう、オプショナルな挙動をサポートしました。

## 期待される効果
- 本番環境で同様のエラーが発生した場合、Cloud Run のエラーログに「なぜ配列が壊れたのか」の手がかりとなるパスの完全な構成データが残るようになります。
- これにより、上流（Yen's Algorithm の配列結合処理やダイクストラ法の再構築処理など）のどこに根本的なバグがあるかの特定が可能になります。

## 備考
- これは一次対応（フェイルセーフとログ強化）であり、根本的なバグ修正はログ収集後に別PRにて行います。