### PR TITLE
feat: セキュリティヘッダ（CSP, HSTS等）の導入

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,39 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'SAMEORIGIN',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=(), browsing-topics=()',
+          },
+          {
+            key: 'Content-Security-Policy',
+            value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.google-analytics.com https://www.googletagmanager.com https://pagead2.googlesyndication.com https://partner.googleadservices.com https://tpc.googlesyndication.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://*.firebaseio.com https://*.googleapis.com https://www.google-analytics.com https://region1.google-analytics.com https://pagead2.googlesyndication.com; frame-src 'self' https://googleads.g.doubleclick.net https://tpc.googlesyndication.com https://docs.google.com;",
+          }
+        ],
+      },
+    ];
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
## 目的
Closes #131 
Webアプリケーションのセキュリティベースラインを引き上げるため、`next.config.js` にセキュリティヘッダの設定を追加しました。

## 変更内容
- `headers()` を追加し、全ルート(`/:path*`)に対して以下のヘッダを付与
  - `X-Content-Type-Options`
  - `X-Frame-Options`
  - `Referrer-Policy`
  - `Strict-Transport-Security`
  - `Permissions-Policy`
  - `Content-Security-Policy` (CSP)
- CSPは、Google Analytics, Google AdSense, Firebase 等の動作に必要な外部ドメインを許可するように調整済み。

## 確認事項
- [x] ページ遷移や外部APIとの通信が正常に行われるか
- [x] ブラウザの Console タブに `Content-Security-Policy` に関する赤文字のエラーが出ていないか
- [x] 正常にレンダリングされているか