### PR TITLE
chore: X-Powered-Byヘッダの隠蔽によるセキュリティ微修正

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -50,6 +50,7 @@ const nextConfig: NextConfig = {
     ]
   },
   output: 'standalone',
+  poweredByHeader: false,
   eslint: {
     ignoreDuringBuilds: true,
   },


### PR DESCRIPTION
## 目的
Closes #134 
レスポンスヘッダに自動付与される `X-Powered-By: Next.js` を無効化し、不必要な技術スタックの露出を減らします。

## 変更内容
- `next.config.js` に `poweredByHeader: false` を追加