### PR TITLE
fix: 検索ボタン押下時のURL即時反映

### DIFF
--- a/src/app/split/components/Form.tsx
+++ b/src/app/split/components/Form.tsx
@@ -75,8 +75,11 @@ export default function SplitForm({
         if (data.startStation?.name) searchParams.set("from", data.startStation.name);
         if (data.endStation?.name) searchParams.set("to", data.endStation.name);
 
+        const newUrl = `?${searchParams.toString()}`;
+        window.history.pushState(null, "", newUrl);
+
         startTransition(() => {
-            router.push(`?${searchParams.toString()}`, { scroll: false });
+            router.replace(newUrl, { scroll: false });
         });
     };
 


### PR DESCRIPTION
## 変更内容
検索ボタン押下と同時にURLクエリパラメーターが反映されるよう修正。

## 変更の背景
従来は `startTransition` 内の `router.push` がURL更新を行っていたため、
サーバー計算の完了まで（最大数秒）アドレスバーのURLが更新されなかった。

## 対応方法
`window.history.pushState` をトランジション開始前に呼び出し、
ボタン押下と同時にURLを更新するようにした。
また、履歴の二重登録を避けるため `router.push` を `router.replace` に変更した。

## 修正ファイル
- `app/split/components/SplitForm.tsx`

## 関連Issue
Closed #146 

## 動作確認
- [x] 検索ボタン押下と同時にアドレスバーのURLが更新される
- [x] 計算中にURLをコピーしても正しいパラメーターが含まれている
- [x] ブラウザバック・フォワードが正常に動作する
- [x] 計算結果が正しく表示される