### PR TITLE
fix: Int32ArrayのInfinityキャストによる運賃計算破綻の緊急修正

### DIFF
--- a/src/app/split/lib/calcSplit.ts
+++ b/src/app/split/lib/calcSplit.ts
@@ -141,7 +141,8 @@ class CalculatorSplit {
             return { cheapestKippuData: cheapestKippuData, splitKippuDatasList: [] };
         }
 
-        let globalMinFare = Infinity;
+        const MAX_FARE_INFINITY = 2147483647;
+        let globalMinFare = MAX_FARE_INFINITY;
         for (let i = 0; i < uniqueSplitPatterns.length; i++) {
             if (uniqueSplitPatterns[i].totalFare < globalMinFare) {
                 globalMinFare = uniqueSplitPatterns[i].totalFare;
@@ -286,7 +287,8 @@ class CalculatorSplit {
         }
 
         const dp = new Int32Array(n);
-        dp.fill(Infinity);
+        const MAX_GISEIKILO_INFINITY = 2147483647;
+        dp.fill(MAX_GISEIKILO_INFINITY);
         const from: number[][] = Array.from({ length: n }, () => []);
 
         dp[0] = 0;
@@ -326,7 +328,8 @@ class CalculatorSplit {
         const resultPatterns: SplitKippuDatas[] = [];
         const totalFare = dp[n - 1];
 
-        if (totalFare === Infinity) {
+        const MAX_FARE_INFINITY = 2147483647;
+        if (totalFare === MAX_FARE_INFINITY) {
             this.splitMemo.set(key, null);
             return null;
         }


### PR DESCRIPTION
## 概要
本番環境で発生している、分割運賃計算が正しく行われないクリティカルバグの緊急修正（Hotfix）です。

## 原因と課題
前回の最適化PRにてDP配列を `Int32Array` に変更しましたが、初期化に `dp.fill(Infinity)` を使用したため、内部ですべての初期値が `0` に変換されていました。結果として、いかなる運賃を計算しても `0` より小さくなることはなく、DPによる経路探索と運賃合算が機能していませんでした。

## 解決策・変更内容
- DP配列の初期化（`fill`）および終了時のエラー判定に使用している値を `Infinity` から、到達不可能な十分大きな定数 `2147483647` に置換しました。

## 影響範囲
- 分割運賃計算ロジック全体（本番障害の解消）

## 関連Issue
- Closes #148 