### PR TITLE
ci: Dependabotのフロントエンド関連パッケージグループ化とPR上限緩和

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     groups:
-      react-ecosystem:
+      frontend-framework:
         patterns:
+          - "next"
+          - "@next/*"
+          - "eslint-config-next"
           - "react"
           - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"


### PR DESCRIPTION
## 関連Issue
Resolves #154 

## 変更の目的と詳細
Dependabotによる依存関係更新時に発生していた `ERESOLVE` エラーを防止するための設定変更です。

- **パッケージのグループ化:**
  `next`, `@next/*`, `react`, `react-dom` 等の密結合なフレームワーク群を `frontend-framework` としてグループ化しました。これにより、メジャーアップデート時もすべての関連パッケージが同期して更新され、不整合を防ぎます。
- **PR上限の緩和:**
  `open-pull-requests-limit` を 1 から 5 に変更しました。これにより、特定パッケージの更新が滞留した場合でも、他の独立したパッケージ（セキュリティアップデート等）の更新がブロックされないように改善しています。

## 影響範囲と確認方法
- アプリケーションのコードへの影響はありません。
- マージ後、既存の壊れたDependabot PRをクローズし、手動でDependabotの更新をトリガーして正しいまとまりでPRが生成されるか確認します。