### PR TITLE
ci: DependabotのPRにおけるGCP認証エラー回避とテスト実行条件の修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,21 +98,21 @@ jobs:
             src/app/split/data/*.json
           key: kippu-navi-data-v20260516-${{ hashFiles('.github/workflows/test.yml') }}
 
-      # キャッシュが無い場合のみGCP認証
+      # キャッシュが無い、かつDependabotではない場合のみGCP認証
       - name: Authenticate to Google Cloud
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit != 'true' && github.actor != 'dependabot[bot]'
         uses: google-github-actions/auth@v2
         with:
           credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
 
-      # キャッシュが無い場合のみSDKセットアップ
+      # キャッシュが無い、かつDependabotではない場合のみSDKセットアップ
       - name: Set up Cloud SDK
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit != 'true' && github.actor != 'dependabot[bot]'
         uses: google-github-actions/setup-gcloud@v2
 
-      # キャッシュが無い場合のみGCSからダウンロード
+      # キャッシュが無い、かつDependabotではない場合のみGCSからダウンロード
       - name: Download data from private GCS
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit != 'true' && github.actor != 'dependabot[bot]'
         run: |
           gsutil -m cp gs://kippu-navi-build-secrets/data/*.db ./src/data/
           gsutil -m cp gs://kippu-navi-build-secrets/data/*.json ./src/data/
@@ -122,5 +122,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # データが存在する（キャッシュヒットした、またはDependabot以外でDLされた）場合のみテストを実行
       - name: Run Vitest
+        if: steps.cache.outputs.cache-hit == 'true' || github.actor != 'dependabot[bot]'
         run: npm run test


### PR DESCRIPTION
## 関連Issue
Resolves #161 

## 変更の目的と詳細
DependabotのPR実行時にGCPのシークレットを取得できず、CIが `Auth failed` で落ちる問題を解決するための修正です。
単に認証をスキップするだけでは、テストデータが存在しない状態で `npm run test` が実行され確実にクラッシュしてしまうため、キャッシュの状態に応じた条件分岐を追加しました。

**具体的な変更点:**
- `actions/cache` の結果を判定し、キャッシュミス時かつDependabotによる実行の場合のみ以下のステップをスキップするように `if` 条件を追加。
  - `Authenticate to Google Cloud`
  - `Set up Cloud SDK`
  - `Download data from private GCS`
  - `Run Vitest`

## 影響範囲と確認方法
- アプリケーションのビジネスロジックには影響しません。
- DependabotによるアップデートPRが、GCP認証エラーでブロックされずにCIを通過するようになります。