### PR TITLE
build: Next.js 16で非推奨となったeslint設定をnext.config.tsから削除

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -51,9 +51,6 @@ const nextConfig: NextConfig = {
   },
   output: 'standalone',
   poweredByHeader: false,
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
 };
 
 export default nextConfig;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## 関連Issue
Resolves #168 

## 変更の目的と詳細
Next.js 16系へのアップデートに伴い発生していたCloud Buildのデプロイエラー（型エラー）を修正するための対応です。

**具体的な変更点:**
- `next.config.ts` から廃止された `eslint: { ignoreDuringBuilds: true }` の記述を削除しました。

## 影響範囲と確認方法
- アプリケーションの動作には影響しません。
- 本リポジトリのCIでは `npm run lint` を独立したジョブとして実行しており、Next.js 16自体もビルド時のLintをデフォルトでスキップする仕様になったため、この設定削除による運用上の悪影響はありません。
- マージ後、対象のDependabot PRのCIが正常に完走することを確認します。