### PR TITLE
feat: 定期運賃計算の基盤となる型定義と共通計算ロジックを実装

### DIFF
--- a/split-pass-api/internal/domain/types.go
+++ b/split-pass-api/internal/domain/types.go
@@ -1,0 +1,57 @@
+package domain
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrNegativeDistance = errors.New("距離は0以上でなければなりません")
+)
+
+// DeciKilo は距離を10倍した整数（0.1km単位での誤差を防ぐため）
+type DeciKilo int
+
+// ToCeiledKm はDeciKiloをinteger kilometerに変換します。
+// Examples:
+//
+//	15 -> 2
+//	10 -> 1
+//	 1 -> 1
+func (d DeciKilo) ToCeiledKm() (int, error) {
+	if d < 0 {
+		return 0, fmt.Errorf("types: %w", ErrNegativeDistance)
+	}
+
+	return (int(d) + 9) / 10, nil
+}
+
+// CompanyID は鉄道会社ID
+type CompanyID int
+
+// 会社IDの定数
+const (
+	Other CompanyID = iota
+	JRHokkaido
+	JREast
+	JRCentral
+	JRWest
+	JRShikoku
+	JRKyushu
+)
+
+// Station は駅データです
+type Station struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// Edge は駅間データです
+type Edge struct {
+	FromID    int
+	ToID      int
+	EigyoKilo DeciKilo
+	GiseiKilo DeciKilo
+	IsLocal   bool
+	Company   CompanyID
+}

--- a/split-pass-api/internal/fare/common.go
+++ b/split-pass-api/internal/fare/common.go
@@ -1,0 +1,108 @@
+package fare
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrInvalidRouteType = errors.New("不正なRouteTypeです")
+	ErrInvalidTable     = errors.New("運賃表が不正です")
+	ErrInvalidKilo      = errors.New("営業キロまたは運賃計算キロが0以下です")
+	ErrInvalidMonths    = errors.New("不正な月数です（1, 3, 6のいずれかを指定してください）")
+)
+
+// calculateBaseFare は、幹線と地方交通線の運賃表を使い分ける本州・北海道向けの運賃計算ロジックです。
+func calculateBaseFare(params PassFareParams, trunkTable, localTable *[101]PassFare) (int, error) {
+	var targetKm int
+	var useTrunkTable bool
+	var err error
+
+	switch params.RouteType {
+	case RouteTypeTrunkOnly:
+		targetKm, err = params.EigyoKilo.ToCeiledKm()
+		if err != nil {
+			return 0, fmt.Errorf("calculateBaseFare: %w", err)
+		}
+		useTrunkTable = true
+	case RouteTypeLocalOnly:
+		targetKm, err = params.EigyoKilo.ToCeiledKm()
+		if err != nil {
+			return 0, fmt.Errorf("calculateBaseFare: %w", err)
+		}
+		useTrunkTable = false
+	case RouteTypeMixed:
+		eigyoKm, err := params.EigyoKilo.ToCeiledKm()
+		if err != nil {
+			return 0, fmt.Errorf("calculateBaseFare: %w", err)
+		}
+		// 旅客営業規則第86条の特例：
+		// 幹線・地方交通線を乗り通す場合でも、全区間の営業キロが10km以下であれば
+		// 地方交通線の運賃表を適用する
+		if eigyoKm <= 10 {
+			targetKm = eigyoKm
+			useTrunkTable = false
+		} else {
+			targetKm, err = params.GiseiKilo.ToCeiledKm()
+			if err != nil {
+				return 0, fmt.Errorf("calculateBaseFare: %w", err)
+			}
+			useTrunkTable = true
+		}
+	default:
+		return 0, fmt.Errorf("calculateBaseFare: %w", ErrInvalidRouteType)
+	}
+
+	table := trunkTable
+	if !useTrunkTable && localTable != nil {
+		table = localTable
+	}
+
+	if table == nil {
+		return 0, fmt.Errorf("calculateBaseFare: %w", ErrInvalidTable)
+	}
+
+	if targetKm <= 0 {
+		return 0, fmt.Errorf("calculateBaseFare: %w", ErrInvalidKilo)
+	}
+
+	return calculateFromTable(targetKm, params.Months, table)
+}
+
+// calculateSingleTableFare は、常に擬制キロを使用し単一の運賃表を用いる九州・四国向けの運賃計算ロジックです。
+func calculateSingleTableFare(params PassFareParams, table *[101]PassFare) (int, error) {
+	targetKm, err := params.GiseiKilo.ToCeiledKm()
+	if err != nil {
+		return 0, fmt.Errorf("calculateSingleTableFare: %w", err)
+	}
+	return calculateFromTable(targetKm, params.Months, table)
+}
+
+// calculateFromTable は運賃表（100kmごとに折り返し）から月数に応じた運賃を抽出する純粋な計算処理です。
+func calculateFromTable(targetKm int, months int, table *[101]PassFare) (int, error) {
+	if table == nil {
+		return 0, fmt.Errorf("calculateFromTable: %w", ErrInvalidTable)
+	}
+
+	if targetKm <= 0 {
+		return 0, fmt.Errorf("calculateFromTable: %w", ErrInvalidKilo)
+	}
+
+	// 運賃表は100kmごとに折り返す構造のため、100の商と余りに分割する
+	hundredsKm := targetKm / 100
+	subHundredKm := targetKm % 100
+
+	baseFare := table[100]
+	remFare := table[subHundredKm]
+
+	switch months {
+	case 1:
+		return (baseFare.OneMonth * hundredsKm) + remFare.OneMonth, nil
+	case 3:
+		return (baseFare.ThreeMonth * hundredsKm) + remFare.ThreeMonth, nil
+	case 6:
+		return (baseFare.SixMonth * hundredsKm) + remFare.SixMonth, nil
+	default:
+		return 0, fmt.Errorf("calculateFromTable: %w", ErrInvalidMonths)
+	}
+}

--- a/split-pass-api/internal/fare/params.go
+++ b/split-pass-api/internal/fare/params.go
@@ -1,0 +1,26 @@
+package fare
+
+import "split-pass-api/internal/domain"
+
+type RouteType int
+
+const (
+	RouteTypeTrunkOnly RouteType = iota // 幹線のみ
+	RouteTypeLocalOnly                  // 地方交通線のみ
+	RouteTypeMixed                      // 幹線と地方交通線をまたぐ
+)
+
+// PassFareParams は定期運賃計算のパラメータです
+type PassFareParams struct {
+	RouteType RouteType
+	EigyoKilo domain.DeciKilo // 営業キロ
+	GiseiKilo domain.DeciKilo // 運賃計算キロ
+	Months    int             // 1, 3, 6
+}
+
+// PassFare は各月数の運賃をまとめた構造体です
+type PassFare struct {
+	OneMonth   int
+	ThreeMonth int
+	SixMonth   int
+}


### PR DESCRIPTION
## 概要
定期運賃計算機能の基盤となる型定義と、JR旅客営業規則に基づく共通計算ロジックを実装します。

## 変更内容

### feat(domain): 型定義
- `DeciKilo` 型を導入し、0.1km単位の距離を整数で扱うことで浮動小数点誤差を排除
- `ToCeiledKm` による切り上げ変換を実装し、単体テストを追加
- `RouteType`・`PassFareParams`・`PassFare` を定義し、後続の各社Calculator実装のインターフェースを確立

### feat(fare): 共通計算ロジック
- `calculateBaseFare`：幹線・地方交通線を使い分ける本州・北海道向けロジック
- `calculateSingleTableFare`：単一テーブルを使う九州・四国向けロジック
- `calculateFromTable`：100km折り返し構造に基づく純粋な計算処理
- 旅客営業規則第86条の特例（営業キロ10km以下は地方交通線テーブルを適用）を実装済み

## スコープ外
各社の `Calculator` 実装・運賃JSONマスタ・`Registry` は次のPRで追加します。

## テスト
- `DeciKilo.ToCeiledKm` の境界値テストを含む
- `calculateBaseFare` / `calculateFromTable` はモックデータを用いた `common_test.go` でカバー
- 各社の実運賃を用いたテストは次のPRに含めます