### PR TITLE
feat: 駅グラフ構築とDijkstra法による最短経路探索の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ src/data/*.db
 src/data/*.json
 src/app/mr/data/*.json
 src/app/split/data/*.json
+split-pass-api/internal/graph/data/*.json

--- a/split-pass-api/cmd/convert-graph/main.go
+++ b/split-pass-api/cmd/convert-graph/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"log"
+	"os"
+	"split-pass-api/internal/graph"
+)
+
+func main() {
+	if len(os.Args) < 3 {
+		log.Fatal("Usage: convert-graph <input_json> <output_gob>")
+	}
+
+	inputJSON := os.Args[1]
+	outputGOB := os.Args[2]
+
+	g := graph.NewGraph(10000)
+
+	log.Printf("JSONファイルを読み込んでいます: %s", inputJSON)
+	if err := g.LoadFromJSON(inputJSON); err != nil {
+		log.Fatalf("JSONの読み込みに失敗しました: %v", err)
+	}
+
+	log.Printf("バイナリファイルを保存しています: %s", outputGOB)
+	if err := g.SaveBinary(outputGOB); err != nil {
+		log.Fatalf("バイナリの保存に失敗しました: %v", err)
+	}
+
+	log.Println("変換が完了しました。")
+
+	// 検証
+	log.Printf("検証のためにバイナリを再読み込みします...")
+	g2, err := graph.LoadGraphBinary(outputGOB)
+	if err != nil {
+		log.Fatalf("バイナリの再読み込みに失敗しました: %v", err)
+	}
+	log.Printf("読み込み完了: 駅数 = %d", len(g2.IDToName))
+}

--- a/split-pass-api/internal/graph/dijkstra.go
+++ b/split-pass-api/internal/graph/dijkstra.go
@@ -1,0 +1,227 @@
+package graph
+
+import (
+	"container/heap"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"split-pass-api/internal/domain"
+)
+
+// PathResult は経路探索の結果を保持します。
+type PathResult struct {
+	Stations  []string
+	GiseiKilo domain.DeciKilo
+	EigyoKilo domain.DeciKilo
+}
+
+// node はダイクストラ法で用いる優先度付きキューの要素です。
+type node struct {
+	stationID int
+	giseiKilo domain.DeciKilo
+	index     int
+}
+
+// priorityQueue は node の最小ヒープです。
+type priorityQueue []*node
+
+func (pq priorityQueue) Len() int           { return len(pq) }
+func (pq priorityQueue) Less(i, j int) bool { return pq[i].giseiKilo < pq[j].giseiKilo }
+func (pq priorityQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+func (pq *priorityQueue) Push(x interface{}) {
+	n := len(*pq)
+	item := x.(*node)
+	item.index = n
+	*pq = append(*pq, item)
+}
+func (pq *priorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	item.index = -1
+	*pq = old[0 : n-1]
+	return item
+}
+
+// FindShortestPathGisei はダイクストラ法を用いて最短擬制キロ経路を検索します。
+func (g *Graph) FindShortestPathGisei(startName, endName string) (*PathResult, error) {
+	startID, ok := g.NameToID[startName]
+	if !ok {
+		return nil, fmt.Errorf("開始駅が見つかりません: %s", startName)
+	}
+	endID, ok := g.NameToID[endName]
+	if !ok {
+		return nil, fmt.Errorf("目的駅が見つかりません: %s", endName)
+	}
+
+	numStations := len(g.IDToName)
+	dist := make([]domain.DeciKilo, numStations)
+	eigyoDist := make([]domain.DeciKilo, numStations)
+	prev := make([]int, numStations)
+	for i := range dist {
+		dist[i] = domain.DeciKilo(1<<31 - 1) // math.MaxInt32
+		prev[i] = -1
+	}
+
+	dist[startID] = 0
+	pq := &priorityQueue{}
+	heap.Init(pq)
+	heap.Push(pq, &node{stationID: startID, giseiKilo: 0})
+
+	for pq.Len() > 0 {
+		curr := heap.Pop(pq).(*node)
+
+		if curr.stationID == endID {
+			break
+		}
+		if curr.giseiKilo > dist[curr.stationID] {
+			continue
+		}
+
+		for _, edge := range g.Edges[curr.stationID] {
+			newDist := dist[curr.stationID] + edge.GiseiKilo
+			if newDist < dist[edge.ToID] {
+				dist[edge.ToID] = newDist
+				eigyoDist[edge.ToID] = eigyoDist[curr.stationID] + edge.EigyoKilo
+				prev[edge.ToID] = curr.stationID
+				heap.Push(pq, &node{stationID: edge.ToID, giseiKilo: newDist})
+			}
+		}
+	}
+
+	if prev[endID] == -1 && startID != endID {
+		return nil, errors.New("経路が見つかりませんでした")
+	}
+
+	// 経路の復元
+	path := []string{}
+	for i := endID; i != -1; i = prev[i] {
+		path = append([]string{g.GetName(i)}, path...)
+	}
+
+	return &PathResult{
+		Stations:  path,
+		GiseiKilo: dist[endID],
+		EigyoKilo: eigyoDist[endID],
+	}, nil
+}
+
+// FindAllCandidatePaths は指定された最短擬制キロ以内に収まる全ての合理的な経路を探索します。
+// これにより、分割購入で安くなる可能性がある経路を網羅します。
+func (g *Graph) FindAllCandidatePaths(startName, endName string, maxGisei domain.DeciKilo) ([]*PathResult, error) {
+	startID, ok := g.NameToID[startName]
+	if !ok {
+		return nil, fmt.Errorf("開始駅が見つかりません: %s", startName)
+	}
+	endID, ok := g.NameToID[endName]
+	if !ok {
+		return nil, fmt.Errorf("目的駅が見つかりません: %s", endName)
+	}
+
+	var results []*PathResult
+	visited := make([]bool, len(g.IDToName))
+
+	// 探索中の状態を保持するスタック用の変数
+	currentPath := []int{startID}
+	visited[startID] = true
+
+	var dfs func(currID int, currGisei, currEigyo domain.DeciKilo)
+	dfs = func(currID int, currGisei, currEigyo domain.DeciKilo) {
+		// 目的地に到達
+		if currID == endID {
+			pathNames := make([]string, len(currentPath))
+			for i, id := range currentPath {
+				pathNames[i] = g.GetName(id)
+			}
+			results = append(results, &PathResult{
+				Stations:  pathNames,
+				GiseiKilo: currGisei,
+				EigyoKilo: currEigyo,
+			})
+			return
+		}
+
+		// 隣接駅を探索
+		for _, edge := range g.Edges[currID] {
+			nextID := edge.ToID
+			nextGisei := currGisei + edge.GiseiKilo
+			nextEigyo := currEigyo + edge.EigyoKilo
+
+			// 枝切り条件:
+			// 1. 既に訪問済み（ループ防止）
+			// 2. 累積擬制キロが制限(maxGisei)を超過
+			if !visited[nextID] && nextGisei <= maxGisei {
+				visited[nextID] = true
+				currentPath = append(currentPath, nextID)
+
+				dfs(nextID, nextGisei, nextEigyo)
+
+				// バックトラッキング
+				currentPath = currentPath[:len(currentPath)-1]
+				visited[nextID] = false
+			}
+		}
+	}
+
+	dfs(startID, 0, 0)
+
+	if len(results) == 0 {
+		return nil, errors.New("候補経路が見つかりませんでした")
+	}
+
+	return results, nil
+}
+
+// LoadFromJSON は JSON ファイルからグラフを読み込みます。
+func (g *Graph) LoadFromJSON(path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	type rawEdge struct {
+		Station0  string           `json:"station0"`
+		Station1  string           `json:"station1"`
+		EigyoKilo domain.DeciKilo  `json:"eigyoKilo"`
+		GiseiKilo domain.DeciKilo  `json:"giseiKilo"`
+		IsLocal   bool             `json:"isLocal"`
+		Company   domain.CompanyID `json:"company"`
+	}
+
+	var edges []rawEdge
+	if err := json.NewDecoder(file).Decode(&edges); err != nil {
+		return err
+	}
+
+	for _, re := range edges {
+		id0 := g.GetOrAddID(re.Station0)
+		id1 := g.GetOrAddID(re.Station1)
+
+		// 双方向エッジとして追加（鉄道網の場合、通常は双方向）
+		g.AddEdge(domain.Edge{
+			FromID:    id0,
+			ToID:      id1,
+			EigyoKilo: re.EigyoKilo,
+			GiseiKilo: re.GiseiKilo,
+			IsLocal:   re.IsLocal,
+			Company:   re.Company,
+		})
+		g.AddEdge(domain.Edge{
+			FromID:    id1,
+			ToID:      id0,
+			EigyoKilo: re.EigyoKilo,
+			GiseiKilo: re.GiseiKilo,
+			IsLocal:   re.IsLocal,
+			Company:   re.Company,
+		})
+	}
+
+	return nil
+}

--- a/split-pass-api/internal/graph/graph.go
+++ b/split-pass-api/internal/graph/graph.go
@@ -1,0 +1,117 @@
+package graph
+
+import (
+	"encoding/gob"
+	"os"
+	"split-pass-api/internal/domain"
+)
+
+// FastGraph は高速な探索に最適化された駅ネットワークを表します。
+type FastGraph struct {
+	Edges [][]domain.Edge
+}
+
+// StationNameIDMapper は駅名(文字列)と数値ID間の変換を処理します。
+type StationNameIDMapper struct {
+	NameToID map[string]int
+	IDToName []string
+}
+
+// Graph は駅データとネットワーク構造を統合して管理します。
+type Graph struct {
+	*FastGraph
+	*StationNameIDMapper
+}
+
+// NewGraph は空のグラフインスタンスを作成します。
+func NewGraph(numStations int) *Graph {
+	return &Graph{
+		FastGraph:           NewFastGraph(numStations),
+		StationNameIDMapper: NewStationNameIDMapper(),
+	}
+}
+
+// SaveBinary はグラフ全体をバイナリ形式で保存します。
+func (g *Graph) SaveBinary(path string) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	encoder := gob.NewEncoder(file)
+	return encoder.Encode(g)
+}
+
+// LoadGraphBinary はバイナリ形式からグラフを読み込みます。
+func LoadGraphBinary(path string) (*Graph, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var g Graph
+	decoder := gob.NewDecoder(file)
+	if err := decoder.Decode(&g); err != nil {
+		return nil, err
+	}
+	return &g, nil
+}
+
+// NewFastGraph は指定された駅数の容量を持つ新しい FastGraph インスタンスを作成します。
+func NewFastGraph(numStations int) *FastGraph {
+	return &FastGraph{
+		Edges: make([][]domain.Edge, numStations),
+	}
+}
+
+// AddEdge は駅間に有向エッジを追加します。
+func (g *FastGraph) AddEdge(edge domain.Edge) {
+	// 必要に応じてスライスを拡張
+	maxID := edge.FromID
+	if edge.ToID > maxID {
+		maxID = edge.ToID
+	}
+	if maxID >= len(g.Edges) {
+		newEdges := make([][]domain.Edge, maxID+1)
+		copy(newEdges, g.Edges)
+		g.Edges = newEdges
+	}
+	g.Edges[edge.FromID] = append(g.Edges[edge.FromID], edge)
+}
+
+// NewStationNameIDMapper は新しいマッパーを作成します。
+func NewStationNameIDMapper() *StationNameIDMapper {
+	return &StationNameIDMapper{
+		NameToID: make(map[string]int),
+		IDToName: make([]string, 0),
+	}
+}
+
+// GetOrAddID は指定された駅名の数値IDを返します。
+func (m *StationNameIDMapper) GetOrAddID(name string) int {
+	if id, exists := m.NameToID[name]; exists {
+		return id
+	}
+	newID := len(m.IDToName)
+	m.NameToID[name] = newID
+	m.IDToName = append(m.IDToName, name)
+	return newID
+}
+
+// GetName は指定された数値IDに対応する駅名(文字列)を返します。
+func (m *StationNameIDMapper) GetName(id int) string {
+	if id < 0 || id >= len(m.IDToName) {
+		return ""
+	}
+	return m.IDToName[id]
+}
+
+// GetStation は指定されたIDの domain.Station オブジェクトを返します。
+func (m *StationNameIDMapper) GetStation(id int) domain.Station {
+	return domain.Station{
+		ID:   id,
+		Name: m.GetName(id),
+	}
+}

--- a/split-pass-api/internal/graph/graph_test.go
+++ b/split-pass-api/internal/graph/graph_test.go
@@ -1,0 +1,92 @@
+package graph_test
+
+import (
+	"os"
+	"testing"
+
+	"split-pass-api/internal/domain"
+	"split-pass-api/internal/graph"
+)
+
+func TestFindShortestPathGisei(t *testing.T) {
+	g := graph.NewGraph(10)
+
+	// テストデータの構築
+	// A --(10km)--> B --(20km)--> C
+	// A --(40km)----------------> C
+	g.AddEdge(domain.Edge{FromID: g.GetOrAddID("A"), ToID: g.GetOrAddID("B"), GiseiKilo: 100, EigyoKilo: 100})
+	g.AddEdge(domain.Edge{FromID: g.GetOrAddID("B"), ToID: g.GetOrAddID("C"), GiseiKilo: 200, EigyoKilo: 200})
+	g.AddEdge(domain.Edge{FromID: g.GetOrAddID("A"), ToID: g.GetOrAddID("C"), GiseiKilo: 400, EigyoKilo: 400})
+
+	// ダイクストラのテスト
+	res, err := g.FindShortestPathGisei("A", "C")
+	if err != nil {
+		t.Fatalf("経路探索に失敗しました: %v", err)
+	}
+
+	if res.GiseiKilo != 300 {
+		t.Errorf("最短距離が不正です: got %v, want 300", res.GiseiKilo)
+	}
+
+	expectedPath := []string{"A", "B", "C"}
+	if len(res.Stations) != len(expectedPath) {
+		t.Fatalf("経路の長さが不正です: got %d, want %d", len(res.Stations), len(expectedPath))
+	}
+	for i, s := range res.Stations {
+		if s != expectedPath[i] {
+			t.Errorf("経路が不正です [%d]: got %s, want %s", i, s, expectedPath[i])
+		}
+	}
+}
+
+func TestSaveAndLoadBinary(t *testing.T) {
+	g := graph.NewGraph(10)
+	g.AddEdge(domain.Edge{FromID: g.GetOrAddID("A"), ToID: g.GetOrAddID("B"), GiseiKilo: 100, EigyoKilo: 100})
+	g.AddEdge(domain.Edge{FromID: g.GetOrAddID("B"), ToID: g.GetOrAddID("C"), GiseiKilo: 200, EigyoKilo: 200})
+	g.AddEdge(domain.Edge{FromID: g.GetOrAddID("A"), ToID: g.GetOrAddID("C"), GiseiKilo: 400, EigyoKilo: 400})
+
+	// シリアライズのテスト
+	tmpFile := "test_graph.gob"
+	defer os.Remove(tmpFile)
+
+	if err := g.SaveBinary(tmpFile); err != nil {
+		t.Fatalf("バイナリ保存に失敗しました: %v", err)
+	}
+
+	g2, err := graph.LoadGraphBinary(tmpFile)
+	if err != nil {
+		t.Fatalf("バイナリ読み込みに失敗しました: %v", err)
+	}
+
+	// 読み込んだグラフで再度テスト
+	res2, err := g2.FindShortestPathGisei("A", "C")
+	if err != nil {
+		t.Fatalf("読み込み後の経路探索に失敗しました: %v", err)
+	}
+
+	if res2.GiseiKilo != 300 {
+		t.Errorf("読み込み後の最短距離が不正です: got %v, want 300", res2.GiseiKilo)
+	}
+}
+
+func TestFindAllCandidatePaths(t *testing.T) {
+	g := graph.NewGraph(10)
+
+	// テストデータの構築
+	// A --(10km)--> B --(20km)--> C
+	// A --(40km)----------------> C
+	g.AddEdge(domain.Edge{FromID: g.GetOrAddID("A"), ToID: g.GetOrAddID("B"), GiseiKilo: 100, EigyoKilo: 100})
+	g.AddEdge(domain.Edge{FromID: g.GetOrAddID("B"), ToID: g.GetOrAddID("C"), GiseiKilo: 200, EigyoKilo: 200})
+	g.AddEdge(domain.Edge{FromID: g.GetOrAddID("A"), ToID: g.GetOrAddID("C"), GiseiKilo: 400, EigyoKilo: 400})
+
+	// 候補経路探索のテスト (maxGisei = 400)
+	// A-B-C (300) と A-C (400) が見つかるはず
+	allPaths, err := g.FindAllCandidatePaths("A", "C", 400)
+	if err != nil {
+		t.Fatalf("候補経路探索に失敗しました: %v", err)
+	}
+
+	if len(allPaths) != 2 {
+		t.Errorf("候補経路の数が不正です: got %d, want 2", len(allPaths))
+	}
+}


### PR DESCRIPTION
## 関連Issue
- Closes #177 

## 変更内容
分割運賃を計算するためのコア基盤となる、駅ネットワークのグラフ構造と探索アルゴリズムを追加しました。

1. **ドメインモデルとグラフ構造 (`graph.go`)**
   - 探索のオーバーヘッドを極限まで減らすため、スライスベースの隣接リスト (`FastGraph`) を採用。
2. **探索アルゴリズム (`dijkstra.go`)**
   - 優先度付きキュー(Heap)を利用した $O((V+E) \log V)$ のDijkstra法を実装。
   - 分割候補抽出のため、最大擬制キロを上限とした DFS (深さ優先探索) を実装。
3. **事前変換CLI (`cmd/server/main.go`)**
   - 起動時のJSONパース時間を削減するため、グラフを事前構築してGOB形式でシリアライズするツールを追加。

## アーキテクチャ上の工夫
- 距離計算による浮動小数点誤差を防ぐため、重みには `domain.DeciKilo` を使用。
- 探索空間を絞るため、`FindAllCandidatePaths` には累積キロによる枝刈りを導入。