### PR TITLE
refactor: internal/domain/types.goでの型定義を概念ごとにファイルを分割

### DIFF
--- a/split-pass-api/internal/domain/company.go
+++ b/split-pass-api/internal/domain/company.go
@@ -1,0 +1,15 @@
+package domain
+
+// CompanyID は鉄道会社ID
+type CompanyID int
+
+// 会社IDの定数
+const (
+	Other CompanyID = iota
+	JRHokkaido
+	JREast
+	JRCentral
+	JRWest
+	JRShikoku
+	JRKyushu
+)

--- a/split-pass-api/internal/domain/distance.go
+++ b/split-pass-api/internal/domain/distance.go
@@ -25,33 +25,3 @@ func (d DeciKilo) ToCeiledKm() (int, error) {
 
 	return (int(d) + 9) / 10, nil
 }
-
-// CompanyID は鉄道会社ID
-type CompanyID int
-
-// 会社IDの定数
-const (
-	Other CompanyID = iota
-	JRHokkaido
-	JREast
-	JRCentral
-	JRWest
-	JRShikoku
-	JRKyushu
-)
-
-// Station は駅データです
-type Station struct {
-	ID   int    `json:"id"`
-	Name string `json:"name"`
-}
-
-// Edge は駅間データです
-type Edge struct {
-	FromID    int
-	ToID      int
-	EigyoKilo DeciKilo
-	GiseiKilo DeciKilo
-	IsLocal   bool
-	Company   CompanyID
-}

--- a/split-pass-api/internal/domain/edge.go
+++ b/split-pass-api/internal/domain/edge.go
@@ -1,0 +1,11 @@
+package domain
+
+// Edge は駅間データです
+type Edge struct {
+	FromID    int
+	ToID      int
+	EigyoKilo DeciKilo
+	GiseiKilo DeciKilo
+	IsLocal   bool
+	Company   CompanyID
+}

--- a/split-pass-api/internal/domain/split_pass.go
+++ b/split-pass-api/internal/domain/split_pass.go
@@ -1,0 +1,13 @@
+package domain
+
+// SplitPassRequest は分割乗車券計算のリクエストペイロードです
+type SplitPassRequest struct {
+	OriginID      string `json:"origin_id"`
+	DestinationID string `json:"destination_id"`
+}
+
+// SplitPassResponse は分割乗車券計算の結果です
+type SplitPassResponse struct {
+	TotalCost int       `json:"total_cost"`
+	Path      []Station `json:"path"` // 順番に並んだ駅のIDと名前
+}

--- a/split-pass-api/internal/domain/station.go
+++ b/split-pass-api/internal/domain/station.go
@@ -1,0 +1,7 @@
+package domain
+
+// Station は駅データです
+type Station struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}


### PR DESCRIPTION
## 関連Issue
Closes #180 

## 変更の目的
`internal/domain/types.go` の肥大化を防ぎ、ドメインモデルの凝集度とコードの可読性を高めるため。

## 変更内容
- `types.go` を廃止し、ドメインの概念ごとに以下の5ファイルに分割しました。
  - `company.go`
  - `distance.go`
  - `edge.go`
  - `split_pass.go`
  - `station.go`

## レビュー時の注意点
- 単なるファイルの分割と移動のみであり、構造体やインターフェースの内部ロジックに変更はありません。
- 全てのパッケージでビルドが通り、テストが通過することを確認済みです。