### PR TITLE
perf: 運賃計算の経路入力を駅名(string)から駅ID(int)に変更

### DIFF
--- a/split-pass-api/internal/graph/dijkstra.go
+++ b/split-pass-api/internal/graph/dijkstra.go
@@ -11,9 +11,9 @@ import (
 
 // PathResult は経路探索の結果を保持します。
 type PathResult struct {
-	Stations  []string
-	GiseiKilo domain.DeciKilo
-	EigyoKilo domain.DeciKilo
+	StationIDs []int
+	GiseiKilo  domain.DeciKilo
+	EigyoKilo  domain.DeciKilo
 }
 
 // node はダイクストラ法で用いる優先度付きキューの要素です。
@@ -50,14 +50,12 @@ func (pq *priorityQueue) Pop() interface{} {
 }
 
 // FindShortestPathGisei はダイクストラ法を用いて最短擬制キロ経路を検索します。
-func (g *Graph) FindShortestPathGisei(startName, endName string) (*PathResult, error) {
-	startID, ok := g.NameToID[startName]
-	if !ok {
-		return nil, fmt.Errorf("開始駅が見つかりません: %s", startName)
+func (g *Graph) FindShortestPathGisei(startID, endID int) (*PathResult, error) {
+	if startID < 0 || startID >= len(g.IDToName) {
+		return nil, fmt.Errorf("開始駅が見つかりません: ID %d", startID)
 	}
-	endID, ok := g.NameToID[endName]
-	if !ok {
-		return nil, fmt.Errorf("目的駅が見つかりません: %s", endName)
+	if endID < 0 || endID >= len(g.IDToName) {
+		return nil, fmt.Errorf("目的駅が見つかりません: ID %d", endID)
 	}
 
 	numStations := len(g.IDToName)
@@ -100,28 +98,26 @@ func (g *Graph) FindShortestPathGisei(startName, endName string) (*PathResult, e
 	}
 
 	// 経路の復元
-	path := []string{}
+	path := []int{}
 	for i := endID; i != -1; i = prev[i] {
-		path = append([]string{g.GetName(i)}, path...)
+		path = append([]int{i}, path...)
 	}
 
 	return &PathResult{
-		Stations:  path,
-		GiseiKilo: dist[endID],
-		EigyoKilo: eigyoDist[endID],
+		StationIDs: path,
+		GiseiKilo:  dist[endID],
+		EigyoKilo:  eigyoDist[endID],
 	}, nil
 }
 
 // FindAllCandidatePaths は指定された最短擬制キロ以内に収まる全ての合理的な経路を探索します。
 // これにより、分割購入で安くなる可能性がある経路を網羅します。
-func (g *Graph) FindAllCandidatePaths(startName, endName string, maxGisei domain.DeciKilo) ([]*PathResult, error) {
-	startID, ok := g.NameToID[startName]
-	if !ok {
-		return nil, fmt.Errorf("開始駅が見つかりません: %s", startName)
+func (g *Graph) FindAllCandidatePaths(startID, endID int, maxGisei domain.DeciKilo) ([]*PathResult, error) {
+	if startID < 0 || startID >= len(g.IDToName) {
+		return nil, fmt.Errorf("開始駅が見つかりません: ID %d", startID)
 	}
-	endID, ok := g.NameToID[endName]
-	if !ok {
-		return nil, fmt.Errorf("目的駅が見つかりません: %s", endName)
+	if endID < 0 || endID >= len(g.IDToName) {
+		return nil, fmt.Errorf("目的駅が見つかりません: ID %d", endID)
 	}
 
 	var results []*PathResult
@@ -135,14 +131,12 @@ func (g *Graph) FindAllCandidatePaths(startName, endName string, maxGisei domain
 	dfs = func(currID int, currGisei, currEigyo domain.DeciKilo) {
 		// 目的地に到達
 		if currID == endID {
-			pathNames := make([]string, len(currentPath))
-			for i, id := range currentPath {
-				pathNames[i] = g.GetName(id)
-			}
+			pathIDs := make([]int, len(currentPath))
+			copy(pathIDs, currentPath)
 			results = append(results, &PathResult{
-				Stations:  pathNames,
-				GiseiKilo: currGisei,
-				EigyoKilo: currEigyo,
+				StationIDs: pathIDs,
+				GiseiKilo:  currGisei,
+				EigyoKilo:  currEigyo,
 			})
 			return
 		}
@@ -177,6 +171,7 @@ func (g *Graph) FindAllCandidatePaths(startName, endName string, maxGisei domain
 
 	return results, nil
 }
+
 
 // LoadFromJSON は JSON ファイルからグラフを読み込みます。
 func (g *Graph) LoadFromJSON(path string) error {

--- a/split-pass-api/internal/graph/graph_test.go
+++ b/split-pass-api/internal/graph/graph_test.go
@@ -11,15 +11,18 @@ import (
 func TestFindShortestPathGisei(t *testing.T) {
 	g := graph.NewGraph(10)
 
+	startID := g.GetOrAddID("A")
+	midID := g.GetOrAddID("B")
+	endID := g.GetOrAddID("C")
+
 	// テストデータの構築
 	// A --(10km)--> B --(20km)--> C
 	// A --(40km)----------------> C
-	g.AddEdge(domain.Edge{FromID: g.GetOrAddID("A"), ToID: g.GetOrAddID("B"), GiseiKilo: 100, EigyoKilo: 100})
-	g.AddEdge(domain.Edge{FromID: g.GetOrAddID("B"), ToID: g.GetOrAddID("C"), GiseiKilo: 200, EigyoKilo: 200})
-	g.AddEdge(domain.Edge{FromID: g.GetOrAddID("A"), ToID: g.GetOrAddID("C"), GiseiKilo: 400, EigyoKilo: 400})
+	g.AddEdge(domain.Edge{FromID: startID, ToID: midID, GiseiKilo: 100, EigyoKilo: 100})
+	g.AddEdge(domain.Edge{FromID: midID, ToID: endID, GiseiKilo: 200, EigyoKilo: 200})
+	g.AddEdge(domain.Edge{FromID: startID, ToID: endID, GiseiKilo: 400, EigyoKilo: 400})
 
-	// ダイクストラのテスト
-	res, err := g.FindShortestPathGisei("A", "C")
+	res, err := g.FindShortestPathGisei(startID, endID)
 	if err != nil {
 		t.Fatalf("経路探索に失敗しました: %v", err)
 	}
@@ -28,22 +31,30 @@ func TestFindShortestPathGisei(t *testing.T) {
 		t.Errorf("最短距離が不正です: got %v, want 300", res.GiseiKilo)
 	}
 
-	expectedPath := []string{"A", "B", "C"}
-	if len(res.Stations) != len(expectedPath) {
-		t.Fatalf("経路の長さが不正です: got %d, want %d", len(res.Stations), len(expectedPath))
+	expectedPath := []int{startID, midID, endID}
+	if len(res.StationIDs) != len(expectedPath) {
+		t.Fatalf("経路の長さが不正です: got %d, want %d", len(res.StationIDs), len(expectedPath))
 	}
-	for i, s := range res.Stations {
-		if s != expectedPath[i] {
-			t.Errorf("経路が不正です [%d]: got %s, want %s", i, s, expectedPath[i])
+	for i, id := range res.StationIDs {
+		if id != expectedPath[i] {
+			t.Errorf("経路が不正です [%d]: got %v, want %v", i, id, expectedPath[i])
 		}
 	}
 }
 
 func TestSaveAndLoadBinary(t *testing.T) {
 	g := graph.NewGraph(10)
-	g.AddEdge(domain.Edge{FromID: g.GetOrAddID("A"), ToID: g.GetOrAddID("B"), GiseiKilo: 100, EigyoKilo: 100})
-	g.AddEdge(domain.Edge{FromID: g.GetOrAddID("B"), ToID: g.GetOrAddID("C"), GiseiKilo: 200, EigyoKilo: 200})
-	g.AddEdge(domain.Edge{FromID: g.GetOrAddID("A"), ToID: g.GetOrAddID("C"), GiseiKilo: 400, EigyoKilo: 400})
+
+	startID := g.GetOrAddID("A")
+	midID := g.GetOrAddID("B")
+	endID := g.GetOrAddID("C")
+
+	// テストデータの構築
+	// A --(10km)--> B --(20km)--> C
+	// A --(40km)----------------> C
+	g.AddEdge(domain.Edge{FromID: startID, ToID: midID, GiseiKilo: 100, EigyoKilo: 100})
+	g.AddEdge(domain.Edge{FromID: midID, ToID: endID, GiseiKilo: 200, EigyoKilo: 200})
+	g.AddEdge(domain.Edge{FromID: startID, ToID: endID, GiseiKilo: 400, EigyoKilo: 400})
 
 	// シリアライズのテスト
 	tmpFile := "test_graph.gob"
@@ -59,7 +70,7 @@ func TestSaveAndLoadBinary(t *testing.T) {
 	}
 
 	// 読み込んだグラフで再度テスト
-	res2, err := g2.FindShortestPathGisei("A", "C")
+	res2, err := g2.FindShortestPathGisei(g2.GetOrAddID("A"), g2.GetOrAddID("C"))
 	if err != nil {
 		t.Fatalf("読み込み後の経路探索に失敗しました: %v", err)
 	}
@@ -68,20 +79,21 @@ func TestSaveAndLoadBinary(t *testing.T) {
 		t.Errorf("読み込み後の最短距離が不正です: got %v, want 300", res2.GiseiKilo)
 	}
 }
-
 func TestFindAllCandidatePaths(t *testing.T) {
 	g := graph.NewGraph(10)
+
+	startID := g.GetOrAddID("A")
+	midID := g.GetOrAddID("B")
+	endID := g.GetOrAddID("C")
 
 	// テストデータの構築
 	// A --(10km)--> B --(20km)--> C
 	// A --(40km)----------------> C
-	g.AddEdge(domain.Edge{FromID: g.GetOrAddID("A"), ToID: g.GetOrAddID("B"), GiseiKilo: 100, EigyoKilo: 100})
-	g.AddEdge(domain.Edge{FromID: g.GetOrAddID("B"), ToID: g.GetOrAddID("C"), GiseiKilo: 200, EigyoKilo: 200})
-	g.AddEdge(domain.Edge{FromID: g.GetOrAddID("A"), ToID: g.GetOrAddID("C"), GiseiKilo: 400, EigyoKilo: 400})
+	g.AddEdge(domain.Edge{FromID: startID, ToID: midID, GiseiKilo: 100, EigyoKilo: 100})
+	g.AddEdge(domain.Edge{FromID: midID, ToID: endID, GiseiKilo: 200, EigyoKilo: 200})
+	g.AddEdge(domain.Edge{FromID: startID, ToID: endID, GiseiKilo: 400, EigyoKilo: 400})
 
-	// 候補経路探索のテスト (maxGisei = 400)
-	// A-B-C (300) と A-C (400) が見つかるはず
-	allPaths, err := g.FindAllCandidatePaths("A", "C", 400)
+	allPaths, err := g.FindAllCandidatePaths(startID, endID, 400)
 	if err != nil {
 		t.Fatalf("候補経路探索に失敗しました: %v", err)
 	}


### PR DESCRIPTION
## 関連Issue
Closes #184 

## 変更の目的
経路最適化処理における計算ループ内のボトルネック（ハッシュマップ検索のオーバーヘッドと不要なメモリアロケーション）を解消するため。

## 変更内容
- `CalculateFare` のシグネチャを変更し、引数に `[]int` (Station IDs) を受け取るように修正しました。
- 計算ループ内部で行っていた `NameToID` による文字列解決を完全に排除しました。
- 呼び出し元における経路の取り回しもIDベースへリファクタリングしました。

## レビュー時の注意点
- パフォーマンスチューニングが主目的です。運賃計算のビジネスルール（ドメインロジック）自体に変更が加わっていないか、テストコードと合わせて確認をお願いします。