### PR TITLE
refactor: グラフデータのI/O処理をインフラ層へ分離

### DIFF
--- a/split-pass-api/cmd/convert-graph/main.go
+++ b/split-pass-api/cmd/convert-graph/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 	"os"
-	"split-pass-api/internal/graph"
+	"split-pass-api/internal/infra/graphio"
 )
 
 func main() {
@@ -14,23 +14,23 @@ func main() {
 	inputJSON := os.Args[1]
 	outputGOB := os.Args[2]
 
-	g := graph.NewGraph(10000)
-
 	log.Printf("JSONファイルを読み込んでいます: %s", inputJSON)
-	if err := g.LoadFromJSON(inputJSON); err != nil {
+	jsonLoader := &graphio.JSONLoader{}
+	g, err := jsonLoader.Load(inputJSON)
+	if err != nil {
 		log.Fatalf("JSONの読み込みに失敗しました: %v", err)
 	}
 
 	log.Printf("バイナリファイルを保存しています: %s", outputGOB)
-	if err := g.SaveBinary(outputGOB); err != nil {
+	if err := graphio.SaveBinary(g, outputGOB); err != nil {
 		log.Fatalf("バイナリの保存に失敗しました: %v", err)
 	}
 
 	log.Println("変換が完了しました。")
 
-	// 検証
 	log.Printf("検証のためにバイナリを再読み込みします...")
-	g2, err := graph.LoadGraphBinary(outputGOB)
+	gobLoader := &graphio.GobLoader{}
+	g2, err := gobLoader.Load(outputGOB)
 	if err != nil {
 		log.Fatalf("バイナリの再読み込みに失敗しました: %v", err)
 	}

--- a/split-pass-api/internal/graph/dijkstra.go
+++ b/split-pass-api/internal/graph/dijkstra.go
@@ -2,10 +2,8 @@ package graph
 
 import (
 	"container/heap"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"split-pass-api/internal/domain"
 )
 
@@ -170,53 +168,4 @@ func (g *Graph) FindAllCandidatePaths(startID, endID int, maxGisei domain.DeciKi
 	}
 
 	return results, nil
-}
-
-
-// LoadFromJSON は JSON ファイルからグラフを読み込みます。
-func (g *Graph) LoadFromJSON(path string) error {
-	file, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	type rawEdge struct {
-		Station0  string           `json:"station0"`
-		Station1  string           `json:"station1"`
-		EigyoKilo domain.DeciKilo  `json:"eigyoKilo"`
-		GiseiKilo domain.DeciKilo  `json:"giseiKilo"`
-		IsLocal   bool             `json:"isLocal"`
-		Company   domain.CompanyID `json:"company"`
-	}
-
-	var edges []rawEdge
-	if err := json.NewDecoder(file).Decode(&edges); err != nil {
-		return err
-	}
-
-	for _, re := range edges {
-		id0 := g.GetOrAddID(re.Station0)
-		id1 := g.GetOrAddID(re.Station1)
-
-		// 双方向エッジとして追加（鉄道網の場合、通常は双方向）
-		g.AddEdge(domain.Edge{
-			FromID:    id0,
-			ToID:      id1,
-			EigyoKilo: re.EigyoKilo,
-			GiseiKilo: re.GiseiKilo,
-			IsLocal:   re.IsLocal,
-			Company:   re.Company,
-		})
-		g.AddEdge(domain.Edge{
-			FromID:    id1,
-			ToID:      id0,
-			EigyoKilo: re.EigyoKilo,
-			GiseiKilo: re.GiseiKilo,
-			IsLocal:   re.IsLocal,
-			Company:   re.Company,
-		})
-	}
-
-	return nil
 }

--- a/split-pass-api/internal/graph/graph.go
+++ b/split-pass-api/internal/graph/graph.go
@@ -1,8 +1,6 @@
 package graph
 
 import (
-	"encoding/gob"
-	"os"
 	"split-pass-api/internal/domain"
 )
 
@@ -29,34 +27,6 @@ func NewGraph(numStations int) *Graph {
 		FastGraph:           NewFastGraph(numStations),
 		StationNameIDMapper: NewStationNameIDMapper(),
 	}
-}
-
-// SaveBinary はグラフ全体をバイナリ形式で保存します。
-func (g *Graph) SaveBinary(path string) error {
-	file, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	encoder := gob.NewEncoder(file)
-	return encoder.Encode(g)
-}
-
-// LoadGraphBinary はバイナリ形式からグラフを読み込みます。
-func LoadGraphBinary(path string) (*Graph, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	var g Graph
-	decoder := gob.NewDecoder(file)
-	if err := decoder.Decode(&g); err != nil {
-		return nil, err
-	}
-	return &g, nil
 }
 
 // NewFastGraph は指定された駅数の容量を持つ新しい FastGraph インスタンスを作成します。

--- a/split-pass-api/internal/graph/graph_test.go
+++ b/split-pass-api/internal/graph/graph_test.go
@@ -1,7 +1,6 @@
 package graph_test
 
 import (
-	"os"
 	"testing"
 
 	"split-pass-api/internal/domain"
@@ -16,8 +15,8 @@ func TestFindShortestPathGisei(t *testing.T) {
 	endID := g.GetOrAddID("C")
 
 	// テストデータの構築
-	// A --(10km)--> B --(20km)--> C
-	// A --(40km)----------------> C
+	// A --(10.0km)--> B --(20.0km)--> C
+	// A --(40.0km)----------------> C
 	g.AddEdge(domain.Edge{FromID: startID, ToID: midID, GiseiKilo: 100, EigyoKilo: 100})
 	g.AddEdge(domain.Edge{FromID: midID, ToID: endID, GiseiKilo: 200, EigyoKilo: 200})
 	g.AddEdge(domain.Edge{FromID: startID, ToID: endID, GiseiKilo: 400, EigyoKilo: 400})
@@ -42,43 +41,6 @@ func TestFindShortestPathGisei(t *testing.T) {
 	}
 }
 
-func TestSaveAndLoadBinary(t *testing.T) {
-	g := graph.NewGraph(10)
-
-	startID := g.GetOrAddID("A")
-	midID := g.GetOrAddID("B")
-	endID := g.GetOrAddID("C")
-
-	// テストデータの構築
-	// A --(10km)--> B --(20km)--> C
-	// A --(40km)----------------> C
-	g.AddEdge(domain.Edge{FromID: startID, ToID: midID, GiseiKilo: 100, EigyoKilo: 100})
-	g.AddEdge(domain.Edge{FromID: midID, ToID: endID, GiseiKilo: 200, EigyoKilo: 200})
-	g.AddEdge(domain.Edge{FromID: startID, ToID: endID, GiseiKilo: 400, EigyoKilo: 400})
-
-	// シリアライズのテスト
-	tmpFile := "test_graph.gob"
-	defer os.Remove(tmpFile)
-
-	if err := g.SaveBinary(tmpFile); err != nil {
-		t.Fatalf("バイナリ保存に失敗しました: %v", err)
-	}
-
-	g2, err := graph.LoadGraphBinary(tmpFile)
-	if err != nil {
-		t.Fatalf("バイナリ読み込みに失敗しました: %v", err)
-	}
-
-	// 読み込んだグラフで再度テスト
-	res2, err := g2.FindShortestPathGisei(g2.GetOrAddID("A"), g2.GetOrAddID("C"))
-	if err != nil {
-		t.Fatalf("読み込み後の経路探索に失敗しました: %v", err)
-	}
-
-	if res2.GiseiKilo != 300 {
-		t.Errorf("読み込み後の最短距離が不正です: got %v, want 300", res2.GiseiKilo)
-	}
-}
 func TestFindAllCandidatePaths(t *testing.T) {
 	g := graph.NewGraph(10)
 
@@ -87,8 +49,8 @@ func TestFindAllCandidatePaths(t *testing.T) {
 	endID := g.GetOrAddID("C")
 
 	// テストデータの構築
-	// A --(10km)--> B --(20km)--> C
-	// A --(40km)----------------> C
+	// A --(10.0km)--> B --(20.0km)--> C
+	// A --(40.0km)----------------> C
 	g.AddEdge(domain.Edge{FromID: startID, ToID: midID, GiseiKilo: 100, EigyoKilo: 100})
 	g.AddEdge(domain.Edge{FromID: midID, ToID: endID, GiseiKilo: 200, EigyoKilo: 200})
 	g.AddEdge(domain.Edge{FromID: startID, ToID: endID, GiseiKilo: 400, EigyoKilo: 400})

--- a/split-pass-api/internal/graph/validate.go
+++ b/split-pass-api/internal/graph/validate.go
@@ -1,0 +1,20 @@
+package graph
+
+import "errors"
+
+var ErrInvalidGraph = errors.New("グラフの内部状態が不正です（空またはnil）")
+
+// Validate はグラフの内部状態が正常であることを検証します。
+// gobデシリアライズ後などにnilスライス・nilマップが残っていないかを確認します。
+func (g *Graph) Validate() error {
+	if g.FastGraph == nil || g.Edges == nil {
+		return ErrInvalidGraph
+	}
+	if g.StationNameIDMapper == nil || g.NameToID == nil || g.IDToName == nil {
+		return ErrInvalidGraph
+	}
+	if len(g.IDToName) == 0 {
+		return ErrInvalidGraph
+	}
+	return nil
+}

--- a/split-pass-api/internal/infra/graphio/gob.go
+++ b/split-pass-api/internal/infra/graphio/gob.go
@@ -1,0 +1,54 @@
+package graphio
+
+import (
+	"encoding/gob"
+	"errors"
+	"fmt"
+	"os"
+	"split-pass-api/internal/graph"
+)
+
+var ErrEmptyGraph = errors.New("グラフデータが空です")
+
+// GobLoader はバイナリ（gob）形式からグラフをロードします。
+type GobLoader struct{}
+
+// Load はバイナリファイルを読み込み、Graph を返します。
+// デシリアライズ後に内部データが nil の場合はエラーを返します。
+func (l *GobLoader) Load(path string) (*graph.Graph, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("graphio: gobファイルのオープンに失敗しました: %w", err)
+	}
+	defer file.Close()
+
+	var g graph.Graph
+	if err := gob.NewDecoder(file).Decode(&g); err != nil {
+		return nil, fmt.Errorf("graphio: gobのデコードに失敗しました: %w", err)
+	}
+
+	if err := g.Validate(); err != nil {
+		return nil, fmt.Errorf("graphio: %w", err)
+	}
+
+	return &g, nil
+}
+
+// SaveBinary はグラフ全体をバイナリ形式で保存します。
+func SaveBinary(g *graph.Graph, path string) error {
+	if err := g.Validate(); err != nil {
+		return fmt.Errorf("graphio: 保存前の検証に失敗しました: %w", err)
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("graphio: gobファイルの作成に失敗しました: %w", err)
+	}
+	defer file.Close()
+
+	if err := gob.NewEncoder(file).Encode(g); err != nil {
+		return fmt.Errorf("graphio: gobのエンコードに失敗しました: %w", err)
+	}
+
+	return nil
+}

--- a/split-pass-api/internal/infra/graphio/graphio_test.go
+++ b/split-pass-api/internal/infra/graphio/graphio_test.go
@@ -1,0 +1,88 @@
+package graphio_test
+
+import (
+	"errors"
+	"os"
+	"split-pass-api/internal/domain"
+	"split-pass-api/internal/graph"
+	"split-pass-api/internal/infra/graphio"
+	"testing"
+)
+
+// newTestGraph はテスト用の共通グラフを構築します。
+//
+//	A --(100)--> B --(200)--> C
+//	A --(400)--------------> C
+func newTestGraph() (*graph.Graph, int, int, int) {
+	g := graph.NewGraph(10)
+	startID := g.GetOrAddID("A")
+	midID := g.GetOrAddID("B")
+	endID := g.GetOrAddID("C")
+
+	g.AddEdge(domain.Edge{FromID: startID, ToID: midID, GiseiKilo: 100, EigyoKilo: 100})
+	g.AddEdge(domain.Edge{FromID: midID, ToID: endID, GiseiKilo: 200, EigyoKilo: 200})
+	g.AddEdge(domain.Edge{FromID: startID, ToID: endID, GiseiKilo: 400, EigyoKilo: 400})
+
+	return g, startID, midID, endID
+}
+
+func TestSaveAndLoadBinary(t *testing.T) {
+	g, startID, _, endID := newTestGraph()
+
+	tmpFile := "test_graph.gob"
+	defer os.Remove(tmpFile)
+
+	if err := graphio.SaveBinary(g, tmpFile); err != nil {
+		t.Fatalf("バイナリ保存に失敗しました: %v", err)
+	}
+
+	loader := &graphio.GobLoader{}
+	g2, err := loader.Load(tmpFile)
+	if err != nil {
+		t.Fatalf("バイナリ読み込みに失敗しました: %v", err)
+	}
+
+	res, err := g2.FindShortestPathGisei(startID, endID)
+	if err != nil {
+		t.Fatalf("読み込み後の経路探索に失敗しました: %v", err)
+	}
+	if res.GiseiKilo != 300 {
+		t.Errorf("読み込み後の最短距離が不正です: got %v, want 300", res.GiseiKilo)
+	}
+}
+
+func TestGobLoader_Load_FileNotFound(t *testing.T) {
+	loader := &graphio.GobLoader{}
+	_, err := loader.Load("nonexistent.gob")
+	if err == nil {
+		t.Error("存在しないファイルに対してエラーが返されませんでした")
+	}
+}
+
+func TestGobLoader_Load_EmptyFile(t *testing.T) {
+	tmpFile := "test_empty.gob"
+	f, err := os.Create(tmpFile)
+	if err != nil {
+		t.Fatalf("一時ファイルの作成に失敗しました: %v", err)
+	}
+	f.Close()
+	defer os.Remove(tmpFile)
+
+	loader := &graphio.GobLoader{}
+	_, err = loader.Load(tmpFile)
+	if err == nil {
+		t.Error("空ファイルに対してエラーが返されませんでした")
+	}
+}
+
+func TestSaveBinary_InvalidGraph(t *testing.T) {
+	err := graphio.SaveBinary(&graph.Graph{}, "should_not_be_created.gob")
+	defer os.Remove("should_not_be_created.gob")
+
+	if err == nil {
+		t.Error("不正なグラフに対してエラーが返されませんでした")
+	}
+	if !errors.Is(err, graph.ErrInvalidGraph) {
+		t.Errorf("期待するエラーと異なります: got %v, want %v", err, graph.ErrInvalidGraph)
+	}
+}

--- a/split-pass-api/internal/infra/graphio/json.go
+++ b/split-pass-api/internal/infra/graphio/json.go
@@ -1,0 +1,71 @@
+package graphio
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"split-pass-api/internal/domain"
+	"split-pass-api/internal/graph"
+)
+
+var ErrEmptyEdges = errors.New("エッジデータが空です")
+
+// JSONLoader は JSON ファイルからグラフをロードします。
+type JSONLoader struct{}
+
+// Load は JSON ファイルを読み込み、新しい Graph を構築して返します。
+// ファイルが空またはエッジが0件の場合はエラーを返します。
+func (l *JSONLoader) Load(path string) (*graph.Graph, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("graphio: JSONファイルのオープンに失敗しました: %w", err)
+	}
+	defer file.Close()
+
+	type rawEdge struct {
+		Station0  string           `json:"station0"`
+		Station1  string           `json:"station1"`
+		EigyoKilo domain.DeciKilo  `json:"eigyoKilo"`
+		GiseiKilo domain.DeciKilo  `json:"giseiKilo"`
+		IsLocal   bool             `json:"isLocal"`
+		Company   domain.CompanyID `json:"company"`
+	}
+
+	var edges []rawEdge
+	if err := json.NewDecoder(file).Decode(&edges); err != nil {
+		return nil, fmt.Errorf("graphio: JSONのデコードに失敗しました: %w", err)
+	}
+
+	if len(edges) == 0 {
+		return nil, fmt.Errorf("graphio: %w", ErrEmptyEdges)
+	}
+
+	// エッジ数の2倍（双方向）を初期容量として確保
+	g := graph.NewGraph(len(edges) * 2)
+
+	for _, re := range edges {
+		id0 := g.GetOrAddID(re.Station0)
+		id1 := g.GetOrAddID(re.Station1)
+
+		// 双方向エッジとして追加（鉄道網は通常双方向）
+		g.AddEdge(domain.Edge{
+			FromID:    id0,
+			ToID:      id1,
+			EigyoKilo: re.EigyoKilo,
+			GiseiKilo: re.GiseiKilo,
+			IsLocal:   re.IsLocal,
+			Company:   re.Company,
+		})
+		g.AddEdge(domain.Edge{
+			FromID:    id1,
+			ToID:      id0,
+			EigyoKilo: re.EigyoKilo,
+			GiseiKilo: re.GiseiKilo,
+			IsLocal:   re.IsLocal,
+			Company:   re.Company,
+		})
+	}
+
+	return g, nil
+}

--- a/split-pass-api/internal/infra/graphio/loader.go
+++ b/split-pass-api/internal/infra/graphio/loader.go
@@ -1,0 +1,9 @@
+package graphio
+
+import "split-pass-api/internal/graph"
+
+// Loader はグラフをロードするインターフェースです。
+// JSON・Gobなど形式の異なる実装を統一的に扱えます。
+type Loader interface {
+	Load(path string) (*graph.Graph, error)
+}


### PR DESCRIPTION
## 関連Issue
Closes #187 

## 変更の目的
ドメインロジック（グラフ探索）とインフラストラクチャ（データ永続化・読み込み）の責務を分離するため。

## 変更内容
- `internal/graph` に存在していた以下のメソッドを `internal/infra/graphio` パッケージの関数として抽出しました。
  - `LoadFromJSON` -> `json.go`
  - `SaveBinary`, `LoadGraphBinary` -> `gob.go`
- `graphio_test.go` を追加し、分離後のI/O処理の正常動作を担保しました。

## レビュー時の注意点
- ファイルの移動と関数のシグネチャ変更のみを行っており、エンコーディングやグラフ構築の内部ロジック自体には手を加えていません。
- 既存の経路探索（Dijkstra/DFS）のテスト結果に影響がないことを確認済みです。