### PR TITLE
refactor: main.goのエラーハンドリングをrunパターンで改善

### DIFF
--- a/split-pass-api/cmd/convert-graph/main.go
+++ b/split-pass-api/cmd/convert-graph/main.go
@@ -1,38 +1,48 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"split-pass-api/internal/infra/graphio"
 )
 
 func main() {
-	if len(os.Args) < 3 {
-		log.Fatal("Usage: convert-graph <input_json> <output_gob>")
+	// os.Argsを明示的に渡すことで、run関数のテストを容易にする
+	if err := run(os.Args); err != nil {
+		log.Fatalf("エラーが発生しました: %v", err)
+	}
+	log.Println("変換が完了しました。")
+}
+
+func run(args []string) error {
+	if len(args) < 3 {
+		return fmt.Errorf("Usage: convert-graph <input_json> <output_gob>")
 	}
 
-	inputJSON := os.Args[1]
-	outputGOB := os.Args[2]
+	inputJSON := args[1]
+	outputGOB := args[2]
 
 	log.Printf("JSONファイルを読み込んでいます: %s", inputJSON)
 	jsonLoader := &graphio.JSONLoader{}
 	g, err := jsonLoader.Load(inputJSON)
 	if err != nil {
-		log.Fatalf("JSONの読み込みに失敗しました: %v", err)
+		// 根本原因を失わないよう %w でエラーをラップする
+		return fmt.Errorf("JSONの読み込みに失敗しました: %w", err)
 	}
 
 	log.Printf("バイナリファイルを保存しています: %s", outputGOB)
 	if err := graphio.SaveBinary(g, outputGOB); err != nil {
-		log.Fatalf("バイナリの保存に失敗しました: %v", err)
+		return fmt.Errorf("バイナリの保存に失敗しました: %w", err)
 	}
-
-	log.Println("変換が完了しました。")
 
 	log.Printf("検証のためにバイナリを再読み込みします...")
 	gobLoader := &graphio.GobLoader{}
 	g2, err := gobLoader.Load(outputGOB)
 	if err != nil {
-		log.Fatalf("バイナリの再読み込みに失敗しました: %v", err)
+		return fmt.Errorf("バイナリの再読み込みに失敗しました: %w", err)
 	}
 	log.Printf("読み込み完了: 駅数 = %d", len(g2.IDToName))
+
+	return nil
 }


### PR DESCRIPTION
## 関連Issue
Closes #189 

## 変更の目的
CLIツールの安全性（`defer` の実行保証）と、将来のテスト自動化に向けた設計の向上。

## 変更内容
- `cmd/convert-graph/main.go` に `run` パターンを導入しました。
- 各種読み込み・書き込み処理でのエラー時、直ちにプロセスを強制終了（`log.Fatalf`）するのではなく、エラーをラップ（`%w`）して `main` へ伝播させるように修正しました。
- コマンドライン引数を `run` 関数へDIする形に変更しました。

## レビュー時の注意点
- ビジネスロジックやファイルI/Oの仕様自体に変更はありません。
- 存在しないJSONファイルパスを指定するなどの意図的なエラーを発生させた際、ラップされたエラーメッセージが適切に標準出力へ表示されることをローカルで確認済みです。