### PR TITLE
fix: トップへ戻るボタンのモバイル表示位置の修正およびコンポーネントの最適化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "react-dom": "^19.2.6",
         "react-hook-form": "^7.65.0",
         "react-icons": "^5.5.0",
-        "react-scroll": "^1.9.3",
         "react-select": "^5.10.2"
       },
       "devDependencies": {
@@ -7832,12 +7831,6 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
-    "node_modules/lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
-      "license": "MIT"
-    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
@@ -8865,20 +8858,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
-    },
-    "node_modules/react-scroll": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/react-scroll/-/react-scroll-1.9.3.tgz",
-      "integrity": "sha512-xv7FXqF3k63aSLNu4/NjFvRNI0ge7DmmmsbeGarP7LZVAlJMSjUuW3dTtLxp1Afijyv0lS2qwC0GiFHvx1KBHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.throttle": "^4.1.1",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^15.5.4 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^15.5.4 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
     },
     "node_modules/react-select": {
       "version": "5.10.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "react-dom": "^19.2.6",
     "react-hook-form": "^7.65.0",
     "react-icons": "^5.5.0",
-    "react-scroll": "^1.9.3",
     "react-select": "^5.10.2"
   },
   "devDependencies": {
@@ -30,7 +29,6 @@
     "@types/node": "^25.9.1",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
-    "@types/react-scroll": "^1.8.10",
     "@typescript-eslint/eslint-plugin": "^8.60.0",
     "@typescript-eslint/parser": "^8.59.3",
     "eslint": "^9.39.4",

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -35,7 +35,7 @@ export default function ScrollToTopButton() {
             className={`
                 fixed right-4 bottom-8 sm:right-8 sm:bottom-8 z-50
                 flex items-center justify-center w-12 h-12 
-                bg-blue-600 backdrop-blur-sm text-white rounded-full shadow-md 
+                bg-blue-600/80 backdrop-blur-sm text-white rounded-full shadow-md 
                 hover:bg-blue-600 hover:scale-105 active:scale-95
                 transition-all duration-300
                 ${showScrollTop ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10 pointer-events-none'}

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from "react";
 import { HiArrowUp } from "react-icons/hi";
-import { animateScroll as scroll } from "react-scroll";
 
 export default function ScrollToTopButton() {
     const [showScrollTop, setShowScrollTop] = useState(false);
@@ -21,9 +20,9 @@ export default function ScrollToTopButton() {
     }, []);
 
     const scrollToTop = () => {
-        scroll.scrollToTop({
-            duration: 500,
-            smooth: "easeInOutQuad",
+        window.scrollTo({
+            top: 0,
+            behavior: "smooth",
         });
     };
 

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -33,7 +33,7 @@ export default function ScrollToTopButton() {
             onClick={scrollToTop}
             aria-label="ページの上部へ戻る"
             className={`
-                fixed right-4 bottom-20 sm:right-8 sm:bottom-8 z-50
+                fixed right-4 bottom-8 sm:right-8 sm:bottom-8 z-50
                 flex items-center justify-center w-12 h-12 
                 bg-blue-600 backdrop-blur-sm text-white rounded-full shadow-md 
                 hover:bg-blue-600 hover:scale-105 active:scale-95


### PR DESCRIPTION
## 概要
Resolves #198 

トップへ戻るボタンに関して、モバイル端末での表示位置の修正、スタイルの不具合解消、およびパフォーマンス向上のためのリファクタリングを行いました。

## 変更内容
- `className` の `bottom-20` を `bottom-8` に修正し、モバイルでの浮きすぎを解消。
- `bg-blue-600` を `bg-blue-600/80` に修正し、`backdrop-blur-sm` が正しく描画されるように対応。
- `react-scroll` をアンインストール/削除し、標準の `window.scrollTo` APIを使用した実装へ変更。

## テスト手順
1. モバイル（またはブラウザのエミュレーター）で画面を表示し、下へ300px以上スクロールする。
2. ボタンが表示された際、画面下部からの距離が適切（`bottom-8`相当）であることを確認する。
3. ボタンの背景が少し透けており、背後のコンテンツがぼやけて見えることを確認する。
4. ボタンをクリックし、ページ上部へスムーズにスクロールして戻ることを確認する。

## 今後の改善に向けた懸念点・メモ
今回の修正で基本的な位置は改善されましたが、iOS Safariなどのモバイルブラウザでは、画面下部のシステムナビゲーションバーの表示/非表示によってビューポートの高さが動的に変わります。