### PR TITLE
fix: トップへ戻るボタンの描画パフォーマンス向上およびフッター干渉回避の構造改善

### DIFF
--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -1,22 +1,42 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { HiArrowUp } from "react-icons/hi";
 
 export default function ScrollToTopButton() {
     const [showScrollTop, setShowScrollTop] = useState(false);
+    const wrapperRef = useRef<HTMLDivElement>(null);
+    const footerRef = useRef<Element | null>(null);
 
     useEffect(() => {
+        footerRef.current = document.querySelector("footer");
+
+        let animationFrameId: number;
+
         const handleScroll = () => {
-            if (window.scrollY > 300) {
-                setShowScrollTop(true);
-            } else {
-                setShowScrollTop(false);
-            }
+            animationFrameId = requestAnimationFrame(() => {
+                setShowScrollTop(window.scrollY > 300);
+
+                if (wrapperRef.current) {
+                    let overlap = 0;
+
+                    if (footerRef.current) {
+                        const footerRect = footerRef.current.getBoundingClientRect();
+                        overlap = Math.max(0, window.innerHeight - footerRect.top);
+                    }
+
+                    wrapperRef.current.style.transform = `translateY(-${overlap}px)`;
+                }
+            });
         };
 
-        window.addEventListener("scroll", handleScroll);
-        return () => window.removeEventListener("scroll", handleScroll);
+        window.addEventListener("scroll", handleScroll, { passive: true });
+        handleScroll();
+
+        return () => {
+            window.removeEventListener("scroll", handleScroll);
+            cancelAnimationFrame(animationFrameId);
+        };
     }, []);
 
     const scrollToTop = () => {
@@ -28,21 +48,21 @@ export default function ScrollToTopButton() {
             ref={wrapperRef}
             className="fixed right-4 sm:right-8 bottom-8 z-50 pointer-events-none"
         >
-        <button
-            type="button"
-            onClick={scrollToTop}
-            aria-label="ページの上部へ戻る"
-            className={`
-                fixed right-4 bottom-8 sm:right-8 sm:bottom-8 z-50
-                flex items-center justify-center w-12 h-12 
-                bg-blue-600/80 backdrop-blur-sm text-white rounded-full shadow-md 
-                hover:bg-blue-600 hover:scale-105 active:scale-95
-                transition-all duration-300
-                ${showScrollTop ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10 pointer-events-none'}
-            `}
-        >
-            <HiArrowUp className="text-xl" />
-        </button>
+            <button
+                type="button"
+                onClick={scrollToTop}
+                aria-label="ページの上部へ戻る"
+                className={`
+                    pointer-events-auto
+                    flex items-center justify-center w-12 h-12 
+                    bg-blue-600/80 backdrop-blur-sm text-white rounded-full shadow-md 
+                    hover:bg-blue-600 hover:scale-105 active:scale-95
+                    transition-all duration-300
+                    ${showScrollTop ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}
+                `}
+            >
+                <HiArrowUp className="text-xl" />
+            </button>
         </div>
     );
 }

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -20,13 +20,14 @@ export default function ScrollToTopButton() {
     }, []);
 
     const scrollToTop = () => {
-        window.scrollTo({
-            top: 0,
-            behavior: "smooth",
-        });
+        window.scrollTo({ top: 0, behavior: "smooth" });
     };
 
     return (
+        <div
+            ref={wrapperRef}
+            className="fixed right-4 sm:right-8 bottom-8 z-50 pointer-events-none"
+        >
         <button
             type="button"
             onClick={scrollToTop}
@@ -42,5 +43,6 @@ export default function ScrollToTopButton() {
         >
             <HiArrowUp className="text-xl" />
         </button>
+        </div>
     );
 }


### PR DESCRIPTION
## 概要
Resolves #201 

トップへ戻るボタンがフッターと重なるのを防ぐ動的処理において、スクロール時のカクツキを解消し、より堅牢なコンポーネント構造へリファクタリングを行いました。

## 変更内容
- ボタンを `div` 要素（ラッパー）で囲む構造に変更しました。
- CSSトランジションとJSの動的スタイル（`transform`）が同一要素で競合する問題を、責務の分離（ラッパー側でJS制御、ボタン側でCSS制御）によって解決しました。
- ブラウザの再描画負荷（リフロー）を下げるため、動的な位置調整を `bottom` プロパティから GPUアクセラレーションが効く `transform: translateY` に変更しました。
- 外枠のラッパー要素が背後のリンク等のクリックを阻害しないよう、`pointer-events` の適切な切り分けを実装しました。

## テスト手順
1. ページを下方向へスクロールし、300pxを超えた時点でボタンがスムーズにフェードインすることを確認する。
2. ページ最下部のフッター到達時に、ボタンがカクつくことなく滑らかに上へ押し上げられることを確認する。
3. ボタンの背後にある要素（メインコンテンツ等）が正常にクリックできることを確認する。
4. ボタン自体をクリックし、ページ上部へ戻ることを確認する。