### PR TITLE
refactor: エンティティからのJSON依存排除

### DIFF
--- a/split-pass-api/internal/domain/split_pass.go
+++ b/split-pass-api/internal/domain/split_pass.go
@@ -2,12 +2,12 @@ package domain
 
 // SplitPassRequest は分割乗車券計算のリクエストペイロードです
 type SplitPassRequest struct {
-	OriginID      string `json:"origin_id"`
-	DestinationID string `json:"destination_id"`
+	OriginID      string
+	DestinationID string
 }
 
 // SplitPassResponse は分割乗車券計算の結果です
 type SplitPassResponse struct {
-	TotalCost int       `json:"total_cost"`
-	Path      []Station `json:"path"` // 順番に並んだ駅のIDと名前
+	TotalCost int
+	Path      []Station // 順番に並んだ駅のIDと名前
 }

--- a/split-pass-api/internal/domain/station.go
+++ b/split-pass-api/internal/domain/station.go
@@ -2,6 +2,6 @@ package domain
 
 // Station は駅データです
 type Station struct {
-	ID   int    `json:"id"`
-	Name string `json:"name"`
+	ID   int
+	Name string
 }


### PR DESCRIPTION
Closed #208 

## 概要
`internal/domain` パッケージのエンティティから、外部フォーマットへの依存（JSONタグ）を取り除くリファクタリングです。

## 変更内容
- 構造体から `` `json:"id"` `` などのタグを完全に削除。

## 変更の意図（アーキテクチャ上の利点）
ドメインエンティティはビジネスロジックの中核であり、APIのレスポンス形式や外部ファイルのパース形式に引きずられるべきではありません。タグを削除することでドメインが純化され、将来的にgRPC（Protocol Buffers）や別フォーマットを導入する際にも、ドメインを無傷のまま保つことができます。