### PR TITLE
fix: JSONデコード処理の厳密化（未定義キー検知と配列上限オーバーの防止）

### DIFF
--- a/split-pass-api/internal/infra/fareio/registry.go
+++ b/split-pass-api/internal/infra/fareio/registry.go
@@ -1,9 +1,11 @@
 package fareio
 
 import (
+	"bytes"
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"io"
 
 	"split-pass-api/internal/domain"
 	"split-pass-api/internal/fare"
@@ -38,9 +40,24 @@ var trainSpecificSectionFaresJSON []byte
 
 func loadFareTable(data []byte) ([101]domain.PassFare, error) {
 	var table [101]domain.PassFare
-	if err := json.Unmarshal(data, &table); err != nil {
+	var slice []domain.PassFare
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+
+	if err := decoder.Decode(&slice); err != nil {
 		return table, err
 	}
+
+	if _, err := decoder.Token(); err != io.EOF {
+		return table, fmt.Errorf("JSONデータの末尾に予期せぬデータが含まれています")
+	}
+
+	if len(slice) != 101 {
+		return table, fmt.Errorf("運賃テーブルの要素数が不正です（期待値: 101, 実際: %d）", len(slice))
+	}
+
+	copy(table[:], slice)
 	return table, nil
 }
 

--- a/split-pass-api/internal/infra/graphio/graphio_test.go
+++ b/split-pass-api/internal/infra/graphio/graphio_test.go
@@ -3,6 +3,7 @@ package graphio_test
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"split-pass-api/internal/domain"
 	"split-pass-api/internal/graph"
 	"split-pass-api/internal/infra/graphio"
@@ -84,5 +85,87 @@ func TestSaveBinary_InvalidGraph(t *testing.T) {
 	}
 	if !errors.Is(err, graph.ErrInvalidGraph) {
 		t.Errorf("期待するエラーと異なります: got %v, want %v", err, graph.ErrInvalidGraph)
+	}
+}
+
+func TestJSONLoader_Load(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name     string
+		filename string
+		setup    func(path string)
+		wantErr  bool
+	}{
+		{
+			name:     "正常系",
+			filename: "valid.json",
+			setup: func(path string) {
+				jsonData := `[
+					{
+						"station0": "東京",
+						"station1": "神田",
+						"eigyoKilo": 13,
+						"giseiKilo": 13,
+						"isLocal": false,
+						"company": 1,
+						"isTrainSpecificSection": true,
+						"isBarrierFreeSection": true
+					}
+				]`
+				_ = os.WriteFile(path, []byte(jsonData), 0644)
+			},
+			wantErr: false,
+		},
+		{
+			name:     "エッジデータが空",
+			filename: "empty.json",
+			setup: func(path string) {
+				_ = os.WriteFile(path, []byte(`[]`), 0644)
+			},
+			wantErr: true,
+		},
+		{
+			name:     "JSONデータの末尾に予期せぬデータが含まれる",
+			filename: "trailing_data.json",
+			setup: func(path string) {
+				_ = os.WriteFile(path, []byte(`[] { "extra": 1 }`), 0644)
+			},
+			wantErr: true,
+		},
+		{
+			name:     "未知のフィールドが含まれる",
+			filename: "unknown_field.json",
+			setup: func(path string) {
+				jsonData := `[
+					{
+						"station0": "東京",
+						"station1": "神田",
+						"unknown": "field"
+					}
+				]`
+				_ = os.WriteFile(path, []byte(jsonData), 0644)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jsonPath := filepath.Join(tmpDir, tt.filename)
+			tt.setup(jsonPath)
+
+			loader := &graphio.JSONLoader{}
+			got, err := loader.Load(jsonPath)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Load() エラー = %v, 期待されるエラー発生 = %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && got == nil {
+				t.Error("Load() 成功したはずですが、結果が nil です")
+			}
+		})
 	}
 }

--- a/split-pass-api/internal/infra/graphio/json.go
+++ b/split-pass-api/internal/infra/graphio/json.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"split-pass-api/internal/domain"
 	"split-pass-api/internal/graph"
@@ -35,8 +36,14 @@ func (l *JSONLoader) Load(path string) (*graph.Graph, error) {
 	defer file.Close()
 
 	var edges []rawEdge
-	if err := json.NewDecoder(file).Decode(&edges); err != nil {
+	decoder := json.NewDecoder(file)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&edges); err != nil {
 		return nil, fmt.Errorf("graphio: JSONのデコードに失敗しました: %w", err)
+	}
+
+	if _, err := decoder.Token(); err != io.EOF {
+		return nil, fmt.Errorf("graphio: JSONデータの末尾に予期せぬデータが含まれています")
 	}
 
 	if len(edges) == 0 {


### PR DESCRIPTION
Closed #210

## 概要
JSONファイルのロード時における「気づかないデータ欠落（Silent Data Loss）」を完全に排除するため、パース処理の安全性を強化しました。

## 変更内容
1. **未定義キーの早期検知:**
   - `loadFareTable` および `graphio` のデコード処理に `DisallowUnknownFields()` を追加。
   - タイポなどの不正なキーがあった場合、無視せずに即座にパースエラーとします。
2. **配列上限オーバー時のサイレント切り捨て防止:**
   - `loadFareTable` において、`[101]domain.PassFare` への直接デコードを廃止。
   - 一度スライスとして読み込み、`len() != 101` の場合はエラーを返す境界値バリデーションを追加し、超過データがサイレントに消滅するバグを塞ぎました。

## 変更の意図（品質向上）
Goの標準 `json` パッケージは、デフォルトで非常に寛容な動作（未知のキーや入り切らない配列要素を無視する）をします。運賃計算の基盤となるマスターデータの読み込みにおいてこの寛容さは致命的なバグの温床となるため、一切の曖昧さを許容しないフェイルファストな設計へリファクタリングしています。

## 影響範囲・動作確認
- 正常なJSONデータの読み込みロジックに影響はありません。
- 意図的に不正なキーを含めたJSON、および101件以外の要素を持つJSONを読み込ませ、想定通りにエラーが返却されることをローカルで確認済みです。