### PR TITLE
refactor: 適用判定関数の命名を厳密化（IsAll... への変更）

### DIFF
--- a/split-pass-api/internal/fare/barrier_free.go
+++ b/split-pass-api/internal/fare/barrier_free.go
@@ -5,8 +5,8 @@ import (
 	"split-pass-api/internal/domain"
 )
 
-// IsBarrierFreeFeeApplicable は指定された全区間がバリアフリー対象エリアに収まっているかを判定します。
-func IsBarrierFreeFeeApplicable(edges []*domain.Edge) bool {
+// IsAllBarrierFreeFeeApplicable は指定された全区間がバリアフリー対象エリアに収まっているかを判定します。
+func IsAllBarrierFreeFeeApplicable(edges []*domain.Edge) bool {
 	if len(edges) == 0 {
 		return false
 	}

--- a/split-pass-api/internal/fare/barrier_free_test.go
+++ b/split-pass-api/internal/fare/barrier_free_test.go
@@ -33,7 +33,7 @@ func TestCalculateBarrierFreeFee(t *testing.T) {
 	}
 }
 
-func TestIsBarrierFreeFeeApplicable(t *testing.T) {
+func TestIsAllBarrierFreeFeeApplicable(t *testing.T) {
 	tests := []struct {
 		name  string
 		edges []*domain.Edge
@@ -64,8 +64,8 @@ func TestIsBarrierFreeFeeApplicable(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := fare.IsBarrierFreeFeeApplicable(tt.edges); got != tt.want {
-				t.Errorf("IsBarrierFreeFeeApplicable() = %v, want %v", got, tt.want)
+			if got := fare.IsAllBarrierFreeFeeApplicable(tt.edges); got != tt.want {
+				t.Errorf("IsAllBarrierFreeFeeApplicable() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/split-pass-api/internal/fare/train_specific_section.go
+++ b/split-pass-api/internal/fare/train_specific_section.go
@@ -5,8 +5,8 @@ import (
 	"split-pass-api/internal/domain"
 )
 
-// IsTrainSpecificApplicable は指定された全区間が電車特定区間に収まっているかを判定します。
-func IsTrainSpecificApplicable(edges []*domain.Edge) bool {
+// IsAllTrainSpecificApplicable は指定された全区間が電車特定区間に収まっているかを判定します。
+func IsAllTrainSpecificApplicable(edges []*domain.Edge) bool {
 	if len(edges) == 0 {
 		return false
 	}

--- a/split-pass-api/internal/fare/train_specific_sections_test.go
+++ b/split-pass-api/internal/fare/train_specific_sections_test.go
@@ -53,7 +53,7 @@ func TestTrainSpecificSectionsCalculator_Calculate(t *testing.T) {
 	}
 }
 
-func TestIsTrainSpecificApplicable(t *testing.T) {
+func TestIsAllTrainSpecificApplicable(t *testing.T) {
 	tests := []struct {
 		name  string
 		edges []*domain.Edge
@@ -84,8 +84,8 @@ func TestIsTrainSpecificApplicable(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := fare.IsTrainSpecificApplicable(tt.edges); got != tt.want {
-				t.Errorf("IsTrainSpecificApplicable() = %v, want %v", got, tt.want)
+			if got := fare.IsAllTrainSpecificApplicable(tt.edges); got != tt.want {
+				t.Errorf("IsAllTrainSpecificApplicable() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## 概要
Closed #219 
バリアフリー料金および電車特定区間の適用判定関数の名前をリネームし、ドメインルールの曖昧さを排除するリファクタリングです。

## 変更内容
- `IsBarrierFreeFeeApplicable` を `IsAllBarrierFreeFeeApplicable` に変更。
- `IsTrainSpecificApplicable` を `IsAllTrainSpecificApplicable` に変更。
- 上記定義元の変更に伴う、ユースケースおよびテストコードの呼び出し箇所の修正。

## 変更の意図（品質向上）
従来の命名では、対象の区間が「一部でも含まれれば（Any）適用される」のか、「全区間が該当して初めて（All）適用される」のかがシグネチャから判断できず、将来的な機能拡張時に誤用されるリスクがありました。`All` を明示することで、ドメインの前提条件をコード自体に語らせる堅牢な設計にしています。

## 影響範囲・動作確認
- 純粋なリネームのみであり、判定ロジック自体は一切変更していません。
- 既存のすべての単体テストがそのまま PASS することを確認済みです。