### PR TITLE
refactor: 経路マッチング処理の汎用化（RouteMatcherへのリネーム）

### DIFF
--- a/split-pass-api/internal/domain/fare_models.go
+++ b/split-pass-api/internal/domain/fare_models.go
@@ -54,8 +54,8 @@ func (f PassFare) GetByMonths(months int) (int, error) {
 	}
 }
 
-// SpecificRouteFare は経路完全一致で適用される特定区間運賃を保持します。
-type SpecificRouteFare struct {
+// RouteAndFare は経路完全一致で適用される特定区間運賃を保持します。
+type RouteAndFare struct {
 	Route []string
 	Fare  PassFare
 }

--- a/split-pass-api/internal/fare/route_matcher.go
+++ b/split-pass-api/internal/fare/route_matcher.go
@@ -13,23 +13,23 @@ var (
 	ErrDuplicateRoute = errors.New("指定された経路は既に登録されています")
 )
 
-// specificFareEntry は特定の経路とそれに紐づく運賃を保持します。
-type specificFareEntry struct {
+// RouteEntry は特定の経路とそれに紐づく運賃を保持します。
+type RouteEntry struct {
 	Route []int
 	Fare  domain.PassFare
 }
 
-// SpecificRouteMatcher は経路の完全一致による特定運賃を検索・適用します。
+// RouteMatcher は経路の完全一致による特定運賃を検索・適用します。
 // HashMap (FNV-1a) と slices.Equal を用いた Two-Phase Lookup により、
 // 高速かつ安全（衝突耐性あり）な検索を実現します。
-type SpecificRouteMatcher struct {
-	table map[uint64][]specificFareEntry
+type RouteMatcher struct {
+	table map[uint64][]RouteEntry
 }
 
-// NewSpecificRouteMatcher は新しい SpecificRouteMatcher を初期化します。
-func NewSpecificRouteMatcher() *SpecificRouteMatcher {
-	return &SpecificRouteMatcher{
-		table: make(map[uint64][]specificFareEntry),
+// NewRouteMatcher は新しい RouteMatcher を初期化します。
+func NewRouteMatcher() *RouteMatcher {
+	return &RouteMatcher{
+		table: make(map[uint64][]RouteEntry),
 	}
 }
 
@@ -46,9 +46,9 @@ func routeToPseudoFNV(route []int) uint64 {
 }
 
 // LoadFromDomain は JSON からロードしたドメインモデルの配列と Graph (名前解決用) を用いてデータを構築します。
-func (m *SpecificRouteMatcher) LoadFromDomain(fares []domain.SpecificRouteFare, g *graph.Graph) error {
-	m.table = make(map[uint64][]specificFareEntry, len(fares)*2)
-	for _, sf := range fares {
+func (m *RouteMatcher) LoadFromDomain(route_and_fares []domain.RouteAndFare, g *graph.Graph) error {
+	m.table = make(map[uint64][]RouteEntry, len(route_and_fares)*2)
+	for _, sf := range route_and_fares {
 		route := make([]int, len(sf.Route))
 		for i, name := range sf.Route {
 			id, ok := g.GetID(name)
@@ -67,7 +67,7 @@ func (m *SpecificRouteMatcher) LoadFromDomain(fares []domain.SpecificRouteFare, 
 // Insert は経路と運賃をマップに登録します。
 // 既に同じ経路が登録されている場合は ErrDuplicateRoute を返します。
 // 逆方向からの検索にも対応するため、逆順の経路も同時に登録します。
-func (m *SpecificRouteMatcher) Insert(route []int, fare domain.PassFare) error {
+func (m *RouteMatcher) Insert(route []int, fare domain.PassFare) error {
 	// 重複チェック
 	if _, ok := m.Search(route); ok {
 		return ErrDuplicateRoute
@@ -78,7 +78,7 @@ func (m *SpecificRouteMatcher) Insert(route []int, fare domain.PassFare) error {
 	copy(routeCopy, route)
 
 	hash := routeToPseudoFNV(routeCopy)
-	m.table[hash] = append(m.table[hash], specificFareEntry{
+	m.table[hash] = append(m.table[hash], RouteEntry{
 		Route: routeCopy,
 		Fare:  fare,
 	})
@@ -100,7 +100,7 @@ func (m *SpecificRouteMatcher) Insert(route []int, fare domain.PassFare) error {
 		return ErrDuplicateRoute
 	}
 
-	m.table[revHash] = append(m.table[revHash], specificFareEntry{
+	m.table[revHash] = append(m.table[revHash], RouteEntry{
 		Route: rev,
 		Fare:  fare,
 	})
@@ -108,7 +108,7 @@ func (m *SpecificRouteMatcher) Insert(route []int, fare domain.PassFare) error {
 }
 
 // Search は指定された経路に完全に一致する特定区間運賃があるか検索します。
-func (m *SpecificRouteMatcher) Search(route []int) (domain.PassFare, bool) {
+func (m *RouteMatcher) Search(route []int) (domain.PassFare, bool) {
 	if m.table == nil {
 		return domain.PassFare{}, false
 	}

--- a/split-pass-api/internal/fare/route_matcher_internal_test.go
+++ b/split-pass-api/internal/fare/route_matcher_internal_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 )
 
-// TestSpecificRouteMatcher_ActualCollision は人工的にハッシュ衝突を発生させ、
+// TestRouteMatcher_ActualCollision は人工的にハッシュ衝突を発生させ、
 // slices.Equal による完全一致チェックが正しく機能することを検証します。
-func TestSpecificRouteMatcher_ActualCollision(t *testing.T) {
-	matcher := NewSpecificRouteMatcher()
+func TestRouteMatcher_ActualCollision(t *testing.T) {
+	matcher := NewRouteMatcher()
 
 	// 2つの異なる経路を用意
 	route1 := []int{1, 2, 3}
@@ -16,7 +16,7 @@ func TestSpecificRouteMatcher_ActualCollision(t *testing.T) {
 
 	// 人工的に衝突状態をシミュレートするため、同じハッシュ値のバケットに2つ登録する
 	h := uint64(42)
-	matcher.table[h] = []specificFareEntry{
+	matcher.table[h] = []RouteEntry{
 		{Route: route1, Fare: domain.PassFare{OneMonth: 100}},
 		{Route: route2, Fare: domain.PassFare{OneMonth: 200}},
 	}
@@ -28,7 +28,7 @@ func TestSpecificRouteMatcher_ActualCollision(t *testing.T) {
 	// 登録されている route1, route2 自体のハッシュを使う。
 
 	h1 := routeToPseudoFNV(route1)
-	matcher.table[h1] = []specificFareEntry{
+	matcher.table[h1] = []RouteEntry{
 		{Route: route1, Fare: domain.PassFare{OneMonth: 100}},
 		{Route: route2, Fare: domain.PassFare{OneMonth: 200}}, // route1のハッシュにroute2を混ぜる
 	}
@@ -42,7 +42,7 @@ func TestSpecificRouteMatcher_ActualCollision(t *testing.T) {
 	// 通常は matcher.Search(route2) は routeToPseudoFNV(route2) のバケットを見に行く。
 	// そこで、route2のハッシュバケットにも route1 を混ぜて「衝突」を再現する。
 	h2 := routeToPseudoFNV(route2)
-	matcher.table[h2] = []specificFareEntry{
+	matcher.table[h2] = []RouteEntry{
 		{Route: route1, Fare: domain.PassFare{OneMonth: 100}}, // route2のハッシュにroute1が混ざっている
 		{Route: route2, Fare: domain.PassFare{OneMonth: 200}},
 	}
@@ -52,7 +52,7 @@ func TestSpecificRouteMatcher_ActualCollision(t *testing.T) {
 	}
 
 	// 3. 存在しない経路 (route1と同じハッシュだが中身が違う)
-	matcher.table[h1] = append(matcher.table[h1], specificFareEntry{Route: []int{9, 9, 9}, Fare: domain.PassFare{OneMonth: 999}})
+	matcher.table[h1] = append(matcher.table[h1], RouteEntry{Route: []int{9, 9, 9}, Fare: domain.PassFare{OneMonth: 999}})
 	if _, ok := matcher.Search([]int{1, 2, 4}); ok {
 		t.Error("ハッシュが一致しても経路が異なる場合に ok=true が返されました")
 	}

--- a/split-pass-api/internal/fare/route_matcher_test.go
+++ b/split-pass-api/internal/fare/route_matcher_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSpecificRouteMatcher(t *testing.T) {
-	matcher := fare.NewSpecificRouteMatcher()
+	matcher := fare.NewRouteMatcher()
 	g := graph.NewGraph(10)
 
 	// モックデータの準備
@@ -17,7 +17,7 @@ func TestSpecificRouteMatcher(t *testing.T) {
 	idB := g.GetOrAddID("B")
 	idC := g.GetOrAddID("C")
 
-	fares := []domain.SpecificRouteFare{
+	fares := []domain.RouteAndFare{
 		{
 			Route: []string{"A", "B", "C"},
 			Fare:  domain.PassFare{OneMonth: 100, ThreeMonth: 285, SixMonth: 540},
@@ -30,13 +30,13 @@ func TestSpecificRouteMatcher(t *testing.T) {
 
 	// 存在しない駅が含まれる場合のテスト
 	t.Run("存在しない駅が含まれる場合はエラー", func(t *testing.T) {
-		invalidFares := []domain.SpecificRouteFare{
+		invalidFares := []domain.RouteAndFare{
 			{
 				Route: []string{"A", "Unknown"},
 				Fare:  domain.PassFare{OneMonth: 100},
 			},
 		}
-		matcher2 := fare.NewSpecificRouteMatcher()
+		matcher2 := fare.NewRouteMatcher()
 		err := matcher2.LoadFromDomain(invalidFares, g)
 		if err == nil {
 			t.Error("存在しない駅に対してエラーが返されませんでした")
@@ -89,7 +89,7 @@ func TestSpecificRouteMatcher(t *testing.T) {
 }
 
 func TestSpecificRouteMatcher_DuplicateRegistration(t *testing.T) {
-	matcher := fare.NewSpecificRouteMatcher()
+	matcher := fare.NewRouteMatcher()
 	route := []int{1, 2, 3}
 	rev := []int{3, 2, 1}
 	f := domain.PassFare{OneMonth: 100}
@@ -120,7 +120,7 @@ func TestSpecificRouteMatcher_DuplicateRegistration(t *testing.T) {
 }
 
 func TestSpecificRouteMatcher_DefensiveCopy(t *testing.T) {
-	matcher := fare.NewSpecificRouteMatcher()
+	matcher := fare.NewRouteMatcher()
 	route := []int{1, 2, 3}
 	f := domain.PassFare{OneMonth: 100}
 
@@ -144,7 +144,7 @@ func TestSpecificRouteMatcher_DefensiveCopy(t *testing.T) {
 
 // ハッシュ値の衝突が起きた場合でも正しく動作するか検証するテスト
 func TestSpecificRouteMatcher_HashCollision(t *testing.T) {
-	matcher := fare.NewSpecificRouteMatcher()
+	matcher := fare.NewRouteMatcher()
 
 	// A-B-C と B-A-C は同じ要素だが順序が異なるため、FNV-1aではハッシュが異なる可能性が高いが、
 	// 念のため類似配列を登録して干渉しないかテストする

--- a/split-pass-api/internal/infra/fareio/json.go
+++ b/split-pass-api/internal/infra/fareio/json.go
@@ -14,7 +14,7 @@ type rawFareData struct {
 	SixMonth   int `json:"SixMonth"`
 }
 
-type rawSpecificRouteFare struct {
+type rawRouteAndFare struct {
 	Route []string    `json:"route"`
 	Fare  rawFareData `json:"fare"`
 }
@@ -22,15 +22,15 @@ type rawSpecificRouteFare struct {
 // SpecificFareJSONLoader は JSON ファイルから特定区間運賃をロードします。
 type SpecificFareJSONLoader struct{}
 
-// Load は JSON ファイルを読み込み、特定区間運賃の配列を返します。
-func (l *SpecificFareJSONLoader) Load(path string) ([]domain.SpecificRouteFare, error) {
+// Load は JSON ファイルを読み込み、特定運賃区間や調整運賃区間の配列を返します。
+func (l *SpecificFareJSONLoader) Load(path string) ([]domain.RouteAndFare, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("fareio: JSONファイルのオープンに失敗しました: %w", err)
 	}
 	defer file.Close()
 
-	var rawData []rawSpecificRouteFare
+	var rawData []rawRouteAndFare
 	decoder := json.NewDecoder(file)
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&rawData); err != nil {
@@ -41,13 +41,13 @@ func (l *SpecificFareJSONLoader) Load(path string) ([]domain.SpecificRouteFare, 
 		return nil, fmt.Errorf("fareio: JSONデータの末尾に予期せぬデータが含まれています")
 	}
 
-	data := make([]domain.SpecificRouteFare, 0, len(rawData))
+	data := make([]domain.RouteAndFare, 0, len(rawData))
 	for _, raw := range rawData {
 		if len(raw.Route) < 2 {
 			return nil, fmt.Errorf("fareio: 経路には少なくとも2つの駅が必要です（不正なデータ: %v）", raw.Route)
 		}
 
-		data = append(data, domain.SpecificRouteFare{
+		data = append(data, domain.RouteAndFare{
 			Route: raw.Route,
 			Fare: domain.PassFare{
 				OneMonth:   raw.Fare.OneMonth,

--- a/split-pass-api/internal/infra/fareio/json_test.go
+++ b/split-pass-api/internal/infra/fareio/json_test.go
@@ -16,7 +16,7 @@ func TestSpecificFareJSONLoader_Load(t *testing.T) {
 		name      string
 		filename  string
 		setup     func(path string)
-		wantFares []domain.SpecificRouteFare
+		wantFares []domain.RouteAndFare
 		wantErr   bool
 	}{
 		{
@@ -35,7 +35,7 @@ func TestSpecificFareJSONLoader_Load(t *testing.T) {
 				]`
 				_ = os.WriteFile(path, []byte(jsonData), 0644)
 			},
-			wantFares: []domain.SpecificRouteFare{
+			wantFares: []domain.RouteAndFare{
 				{
 					Route: []string{"東京", "神田"},
 					Fare: domain.PassFare{
@@ -71,7 +71,7 @@ func TestSpecificFareJSONLoader_Load(t *testing.T) {
 			setup: func(path string) {
 				_ = os.WriteFile(path, []byte(`[]`), 0644)
 			},
-			wantFares: []domain.SpecificRouteFare{},
+			wantFares: []domain.RouteAndFare{},
 			wantErr:   false,
 		},
 		{


### PR DESCRIPTION
## 関連Issue
Closes #227 

## 変更の目的
今後追加される「調整運賃」の計算において、既存の「特定運賃」と全く同じ経路マッチングロジックが必要になります。
コードの重複を防ぐため、特定運賃専用となっていたマッチャーを汎用的な `RouteMatcher` へとリファクタリングしました。

## 変更内容
- 構造体 `SpecificRouteMatcher` を `RouteMatcher` にリネームしました。
- 関連するコンストラクタ関数（`NewRouteMatcher` 等）の名前を修正しました。
- `usecase` 層におけるインポートと型の参照を新しい名前に更新しました。

## レビュー時の注意点
- 本PRは**構造体と関数のリネーム（型の整理）のみ**を行っています。経路を探索するアルゴリズムの内部ロジック自体には一切手を加えていません。
- すべての単体テスト・統合テストがパスし、既存の特定運賃の計算に影響が出ていないことを確認済みです。