### PR TITLE
refactor: edges.jsonのバイナリ埋め込みとLoaderのio.Reader対応およびカプセル化

### DIFF
--- a/split-pass-api/cmd/convert-graph/main.go
+++ b/split-pass-api/cmd/convert-graph/main.go
@@ -23,8 +23,14 @@ func run(args []string) error {
 	outputGOB := args[2]
 
 	log.Printf("JSONファイルを読み込んでいます: %s", inputJSON)
+	inFile, err := os.Open(inputJSON)
+	if err != nil {
+		return fmt.Errorf("JSONファイルのオープンに失敗しました: %w", err)
+	}
+	defer inFile.Close()
+
 	jsonLoader := &graphio.JSONLoader{}
-	g, err := jsonLoader.Load(inputJSON)
+	g, err := jsonLoader.Load(inFile)
 	if err != nil {
 		return fmt.Errorf("JSONの読み込みに失敗しました: %w", err)
 	}
@@ -35,8 +41,14 @@ func run(args []string) error {
 	}
 
 	log.Printf("検証のためにバイナリを再読み込みします...")
+	outFile, err := os.Open(outputGOB)
+	if err != nil {
+		return fmt.Errorf("バイナリファイルのオープンに失敗しました: %w", err)
+	}
+	defer outFile.Close()
+
 	gobLoader := &graphio.GobLoader{}
-	g2, err := gobLoader.Load(outputGOB)
+	g2, err := gobLoader.Load(outFile)
 	if err != nil {
 		return fmt.Errorf("バイナリの再読み込みに失敗しました: %w", err)
 	}

--- a/split-pass-api/internal/fare/calculator_test.go
+++ b/split-pass-api/internal/fare/calculator_test.go
@@ -6,6 +6,7 @@ import (
 
 	"split-pass-api/internal/domain"
 	"split-pass-api/internal/fare"
+	"split-pass-api/internal/graph/data"
 	"split-pass-api/internal/infra/fareio"
 	"split-pass-api/internal/infra/graphio"
 )
@@ -16,7 +17,10 @@ import (
 
 func TestInitRegistry(t *testing.T) {
 	loader := &graphio.JSONLoader{}
-	g, _ := loader.Load("../graph/data/edges.json")
+	g, err := loader.Load(data.GetEdgesReader())
+	if err != nil {
+		t.Fatalf("グラフデータの読み込みに失敗しました: %v", err)
+	}
 	calcs, err := fareio.InitRegistry(g)
 	if err != nil {
 		t.Fatalf("InitRegistry()の初期化に失敗しました: %v", err)
@@ -47,7 +51,10 @@ func TestInitRegistry(t *testing.T) {
 
 func TestStandardCalculator_Calculate(t *testing.T) {
 	loader := &graphio.JSONLoader{}
-	g, _ := loader.Load("../graph/data/edges.json")
+	g, err := loader.Load(data.GetEdgesReader())
+	if err != nil {
+		t.Fatalf("グラフデータの読み込みに失敗しました: %v", err)
+	}
 	calcs, err := fareio.InitRegistry(g)
 	if err != nil {
 		t.Fatalf("InitRegistryの初期化に失敗しました: %v", err)
@@ -182,7 +189,10 @@ func TestStandardCalculator_Calculate(t *testing.T) {
 
 func TestHokkaidoCalculator_Calculate(t *testing.T) {
 	loader := &graphio.JSONLoader{}
-	g, _ := loader.Load("../graph/data/edges.json")
+	g, err := loader.Load(data.GetEdgesReader())
+	if err != nil {
+		t.Fatalf("グラフデータの読み込みに失敗しました: %v", err)
+	}
 	calcs, err := fareio.InitRegistry(g)
 	if err != nil {
 		t.Fatalf("InitRegistryの初期化に失敗しました: %v", err)
@@ -225,7 +235,10 @@ func TestHokkaidoCalculator_Calculate(t *testing.T) {
 
 func TestEastCalculator_Calculate(t *testing.T) {
 	loader := &graphio.JSONLoader{}
-	g, _ := loader.Load("../graph/data/edges.json")
+	g, err := loader.Load(data.GetEdgesReader())
+	if err != nil {
+		t.Fatalf("グラフデータの読み込みに失敗しました: %v", err)
+	}
 	calcs, err := fareio.InitRegistry(g)
 	if err != nil {
 		t.Fatalf("InitRegistryの初期化に失敗しました: %v", err)
@@ -268,7 +281,10 @@ func TestEastCalculator_Calculate(t *testing.T) {
 
 func TestShikokuCalculator_Calculate(t *testing.T) {
 	loader := &graphio.JSONLoader{}
-	g, _ := loader.Load("../graph/data/edges.json")
+	g, err := loader.Load(data.GetEdgesReader())
+	if err != nil {
+		t.Fatalf("グラフデータの読み込みに失敗しました: %v", err)
+	}
 	calcs, err := fareio.InitRegistry(g)
 	if err != nil {
 		t.Fatalf("InitRegistryの初期化に失敗しました: %v", err)
@@ -345,11 +361,10 @@ func TestShikokuCalculator_Calculate(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		}
+	}
 
-		runCalculatorTests(t, calc, tests)
-		}
-
+	runCalculatorTests(t, calc, tests)
+}
 
 // ────────────────────────────────────────────────────────────
 // KyushuCalculator
@@ -357,7 +372,10 @@ func TestShikokuCalculator_Calculate(t *testing.T) {
 
 func TestKyushuCalculator_Calculate(t *testing.T) {
 	loader := &graphio.JSONLoader{}
-	g, _ := loader.Load("../graph/data/edges.json")
+	g, err := loader.Load(data.GetEdgesReader())
+	if err != nil {
+		t.Fatalf("グラフデータの読み込みに失敗しました: %v", err)
+	}
 	calcs, err := fareio.InitRegistry(g)
 	if err != nil {
 		t.Fatalf("InitRegistryの初期化に失敗しました: %v", err)
@@ -499,11 +517,10 @@ func TestKyushuCalculator_Calculate(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		}
+	}
 
-		runCalculatorTests(t, calc, tests)
-		}
-
+	runCalculatorTests(t, calc, tests)
+}
 
 // ────────────────────────────────────────────────────────────
 // ヘルパー

--- a/split-pass-api/internal/fare/joint_test.go
+++ b/split-pass-api/internal/fare/joint_test.go
@@ -3,17 +3,17 @@ package fare_test
 import (
 	"split-pass-api/internal/domain"
 	"split-pass-api/internal/fare"
+	"split-pass-api/internal/graph/data"
 	"split-pass-api/internal/infra/fareio"
 	"split-pass-api/internal/infra/graphio"
 	"testing"
 )
 
 func TestCalculateJointFare(t *testing.T) {
-	// 実データのレジストリを使用
 	loader := &graphio.JSONLoader{}
-	g, err := loader.Load("../graph/data/edges.json")
+	g, err := loader.Load(data.GetEdgesReader())
 	if err != nil {
-		t.Fatalf("グラフのロードに失敗しました: %v", err)
+		t.Fatalf("グラフデータのロードに失敗: %v", err)
 	}
 	calcs, err := fareio.InitRegistry(g)
 	if err != nil {

--- a/split-pass-api/internal/fare/train_specific_sections_test.go
+++ b/split-pass-api/internal/fare/train_specific_sections_test.go
@@ -3,6 +3,7 @@ package fare_test
 import (
 	"split-pass-api/internal/domain"
 	"split-pass-api/internal/fare"
+	"split-pass-api/internal/graph/data"
 	"split-pass-api/internal/infra/fareio"
 	"split-pass-api/internal/infra/graphio"
 	"testing"
@@ -10,9 +11,9 @@ import (
 
 func TestTrainSpecificSectionsCalculator_Calculate(t *testing.T) {
 	loader := &graphio.JSONLoader{}
-	g, err := loader.Load("../graph/data/edges.json")
+	g, err := loader.Load(data.GetEdgesReader())
 	if err != nil {
-		t.Fatalf("グラフのロードに失敗しました: %v", err)
+		t.Fatalf("グラフデータのロードに失敗: %v", err)
 	}
 	calcs, err := fareio.InitRegistry(g)
 	if err != nil {

--- a/split-pass-api/internal/graph/data/data.go
+++ b/split-pass-api/internal/graph/data/data.go
@@ -1,0 +1,14 @@
+package data
+
+import (
+	"bytes"
+	_ "embed"
+)
+
+//go:embed edges.json
+var edgesJSON []byte
+
+// GetEdgesReader はグラフデータ(edges.json)のReaderを返すゲッターメソッドです。
+func GetEdgesReader() *bytes.Reader {
+	return bytes.NewReader(edgesJSON)
+}

--- a/split-pass-api/internal/infra/graphio/gob.go
+++ b/split-pass-api/internal/infra/graphio/gob.go
@@ -4,6 +4,7 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"split-pass-api/internal/graph"
 )
@@ -13,17 +14,11 @@ var ErrEmptyGraph = errors.New("グラフデータが空です")
 // GobLoader はバイナリ（gob）形式からグラフをロードします。
 type GobLoader struct{}
 
-// Load はバイナリファイルを読み込み、Graph を返します。
+// Load はバイナリ形式のデータを読み込み、Graph を返します。
 // デシリアライズ後に内部データが nil の場合はエラーを返します。
-func (l *GobLoader) Load(path string) (*graph.Graph, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("graphio: gobファイルのオープンに失敗しました: %w", err)
-	}
-	defer file.Close()
-
+func (l *GobLoader) Load(r io.Reader) (*graph.Graph, error) {
 	var g graph.Graph
-	if err := gob.NewDecoder(file).Decode(&g); err != nil {
+	if err := gob.NewDecoder(r).Decode(&g); err != nil {
 		return nil, fmt.Errorf("graphio: gobのデコードに失敗しました: %w", err)
 	}
 

--- a/split-pass-api/internal/infra/graphio/graphio_test.go
+++ b/split-pass-api/internal/infra/graphio/graphio_test.go
@@ -37,8 +37,14 @@ func TestSaveAndLoadBinary(t *testing.T) {
 		t.Fatalf("バイナリ保存に失敗しました: %v", err)
 	}
 
+	f, err := os.Open(tmpFile)
+	if err != nil {
+		t.Fatalf("ファイルのオープンに失敗しました: %v", err)
+	}
+	defer f.Close()
+
 	loader := &graphio.GobLoader{}
-	g2, err := loader.Load(tmpFile)
+	g2, err := loader.Load(f)
 	if err != nil {
 		t.Fatalf("バイナリ読み込みに失敗しました: %v", err)
 	}
@@ -54,7 +60,8 @@ func TestSaveAndLoadBinary(t *testing.T) {
 
 func TestGobLoader_Load_FileNotFound(t *testing.T) {
 	loader := &graphio.GobLoader{}
-	_, err := loader.Load("nonexistent.gob")
+	f, _ := os.Open("nonexistent.gob")
+	_, err := loader.Load(f)
 	if err == nil {
 		t.Error("存在しないファイルに対してエラーが返されませんでした")
 	}
@@ -69,8 +76,11 @@ func TestGobLoader_Load_EmptyFile(t *testing.T) {
 	f.Close()
 	defer os.Remove(tmpFile)
 
+	f2, _ := os.Open(tmpFile)
+	defer f2.Close()
+
 	loader := &graphio.GobLoader{}
-	_, err = loader.Load(tmpFile)
+	_, err = loader.Load(f2)
 	if err == nil {
 		t.Error("空ファイルに対してエラーが返されませんでした")
 	}
@@ -155,8 +165,13 @@ func TestJSONLoader_Load(t *testing.T) {
 			jsonPath := filepath.Join(tmpDir, tt.filename)
 			tt.setup(jsonPath)
 
+			f, _ := os.Open(jsonPath)
+			if f != nil {
+				defer f.Close()
+			}
+
 			loader := &graphio.JSONLoader{}
-			got, err := loader.Load(jsonPath)
+			got, err := loader.Load(f)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Load() エラー = %v, 期待されるエラー発生 = %v", err, tt.wantErr)

--- a/split-pass-api/internal/infra/graphio/json.go
+++ b/split-pass-api/internal/infra/graphio/json.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"split-pass-api/internal/domain"
 	"split-pass-api/internal/graph"
 )
@@ -26,17 +25,11 @@ type rawEdge struct {
 	IsBarrierFreeSection   bool             `json:"isBarrierFreeSection"`
 }
 
-// Load は JSON ファイルを読み込み、新しい Graph を構築して返します。
-// ファイルが空またはエッジが0件の場合はエラーを返します。
-func (l *JSONLoader) Load(path string) (*graph.Graph, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("graphio: JSONファイルのオープンに失敗しました: %w", err)
-	}
-	defer file.Close()
-
+// Load は JSON データを読み込み、新しい Graph を構築して返します。
+// データが空またはエッジが0件の場合はエラーを返します。
+func (l *JSONLoader) Load(r io.Reader) (*graph.Graph, error) {
 	var edges []rawEdge
-	decoder := json.NewDecoder(file)
+	decoder := json.NewDecoder(r)
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&edges); err != nil {
 		return nil, fmt.Errorf("graphio: JSONのデコードに失敗しました: %w", err)

--- a/split-pass-api/internal/infra/graphio/loader.go
+++ b/split-pass-api/internal/infra/graphio/loader.go
@@ -1,9 +1,12 @@
 package graphio
 
-import "split-pass-api/internal/graph"
+import (
+	"io"
+	"split-pass-api/internal/graph"
+)
 
 // Loader はグラフをロードするインターフェースです。
 // JSON・Gobなど形式の異なる実装を統一的に扱えます。
 type Loader interface {
-	Load(path string) (*graph.Graph, error)
+	Load(r io.Reader) (*graph.Graph, error)
 }


### PR DESCRIPTION
## 関連Issue
Closes #236 

## 変更の目的
テスト環境および本番環境において、ファイルシステムや実行ディレクトリ（パス）への依存を完全に排除し、堅牢でクリーンなアーキテクチャを実現するためのリファクタリングです。

## 変更内容
1. `internal/graph/data` に `edges.json` を `//go:embed` でバイナリ埋め込みしました。
2. データの意図しない書き換え（ミュータビリティ）を防ぐため、埋め込んだスライスは非公開とし、`GetEdgesReader() *bytes.Reader` を経由して安全にアクセスするようカプセル化しました。
3. `JSONLoader` の `Load` メソッドの引数を `string` から `io.Reader` に変更し、入力元を完全に抽象化しました。
4. `main.go` やテストコードのグラフ読み込み処理を、`loader.Load(data.GetEdgesReader())` に刷新しました。
5. 外部からファイルを読み込む処理（`convert-graph` 等）は、`os.Open` によるストリーム入力に修正し、確実なリソース解放（`defer f.Close()`）を適用しています。

## レビュー時の注意点
- Loaderのインターフェース変更、カプセル化の導入、および呼び出し元の修正は、ビルドを一時的にも壊さないよう（Atomic Commitの原則に基づき）1つのコミットにまとめています。
- 既存のすべてのテスト（`go test ./...`）がパスすることを確認済みです。