### PR TITLE
refactor: SaveBinaryの出力先をio.Writerに抽象化

### DIFF
--- a/split-pass-api/cmd/convert-graph/main.go
+++ b/split-pass-api/cmd/convert-graph/main.go
@@ -36,7 +36,13 @@ func run(args []string) error {
 	}
 
 	log.Printf("バイナリファイルを保存しています: %s", outputGOB)
-	if err := graphio.SaveBinary(g, outputGOB); err != nil {
+	outGobFile, err := os.Create(outputGOB)
+	if err != nil {
+		return fmt.Errorf("バイナリファイルの作成に失敗しました: %w", err)
+	}
+	defer outGobFile.Close()
+
+	if err := graphio.SaveBinary(g, outGobFile); err != nil {
 		return fmt.Errorf("バイナリの保存に失敗しました: %w", err)
 	}
 

--- a/split-pass-api/internal/infra/graphio/gob.go
+++ b/split-pass-api/internal/infra/graphio/gob.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"split-pass-api/internal/graph"
 )
 
@@ -29,19 +28,13 @@ func (l *GobLoader) Load(r io.Reader) (*graph.Graph, error) {
 	return &g, nil
 }
 
-// SaveBinary はグラフ全体をバイナリ形式で保存します。
-func SaveBinary(g *graph.Graph, path string) error {
+// SaveBinary はグラフ全体をバイナリ形式で書き込みます。
+func SaveBinary(g *graph.Graph, w io.Writer) error {
 	if err := g.Validate(); err != nil {
 		return fmt.Errorf("graphio: 保存前の検証に失敗しました: %w", err)
 	}
 
-	file, err := os.Create(path)
-	if err != nil {
-		return fmt.Errorf("graphio: gobファイルの作成に失敗しました: %w", err)
-	}
-	defer file.Close()
-
-	if err := gob.NewEncoder(file).Encode(g); err != nil {
+	if err := gob.NewEncoder(w).Encode(g); err != nil {
 		return fmt.Errorf("graphio: gobのエンコードに失敗しました: %w", err)
 	}
 

--- a/split-pass-api/internal/infra/graphio/graphio_test.go
+++ b/split-pass-api/internal/infra/graphio/graphio_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/gob"
 	"errors"
-	"os"
 	"split-pass-api/internal/domain"
 	"split-pass-api/internal/graph"
 	"split-pass-api/internal/infra/graphio"
@@ -71,8 +70,8 @@ func TestGobLoader_Load_EmptyReader(t *testing.T) {
 }
 
 func TestSaveBinary_InvalidGraph(t *testing.T) {
-	err := graphio.SaveBinary(&graph.Graph{}, "should_not_be_created.gob")
-	defer os.Remove("should_not_be_created.gob")
+	var buf bytes.Buffer
+	err := graphio.SaveBinary(&graph.Graph{}, &buf)
 
 	if err == nil {
 		t.Error("不正なグラフに対してエラーが返されませんでした")


### PR DESCRIPTION
## 関連Issue
Closes #240 

## 変更の目的
`graphio` パッケージからファイルシステム（OSレイヤー）への依存を完全に引き剥がし、入出力の対象を問わないクリーンなドメインロジックへと昇華させるためのリファクタリングです。

## 変更内容
1. `SaveBinary` メソッドが内部で行っていたファイル生成（`os.Create`）のロジックを削除し、引数で渡された `io.Writer` に対して直接エンコードを行うよう修正しました。
2. これに伴い、テストコードで発生していた一時ファイルの作成・削除（`defer os.Remove`）を廃止し、`bytes.Buffer` を介した高速なオンメモリ検証へ移行しました。