### PR TITLE
refactor: 料金マトリクスの汎用化(PassPrice)

### DIFF
--- a/split-pass-api/internal/domain/addon.go
+++ b/split-pass-api/internal/domain/addon.go
@@ -13,7 +13,7 @@ var (
 type addonDefinition struct {
 	StationA string
 	StationB string
-	Fare     PassFare
+	Fare     PassPrice
 }
 
 type stationPairKey struct {
@@ -30,7 +30,7 @@ func makePairKey(id1, id2 int) stationPairKey {
 // AddonRegistry は特定区間の加算運賃を管理します。
 type AddonRegistry struct {
 	definitions []addonDefinition
-	resolved    map[stationPairKey]PassFare
+	resolved    map[stationPairKey]PassPrice
 	// 関西空港線の重複判定用（旅客営業規則に基づく特殊対応）
 	hinenoID int
 	rinkuuID int
@@ -41,7 +41,7 @@ type AddonRegistry struct {
 func NewAddonRegistry() *AddonRegistry {
 	return &AddonRegistry{
 		definitions: make([]addonDefinition, 0),
-		resolved:    make(map[stationPairKey]PassFare),
+		resolved:    make(map[stationPairKey]PassPrice),
 		hinenoID:    -1,
 		rinkuuID:    -1,
 		kansaiID:    -1,
@@ -49,7 +49,7 @@ func NewAddonRegistry() *AddonRegistry {
 }
 
 // Register は特定の駅名ペアに対する加算運賃を登録します。
-func (r *AddonRegistry) Register(stationA, stationB string, fare PassFare) {
+func (r *AddonRegistry) Register(stationA, stationB string, fare PassPrice) {
 	r.definitions = append(r.definitions, addonDefinition{
 		StationA: stationA,
 		StationB: stationB,
@@ -59,7 +59,7 @@ func (r *AddonRegistry) Register(stationA, stationB string, fare PassFare) {
 
 // ResolveIDs は現在のグラフの駅IDを用いて、高速検索用のマップを構築します。
 func (r *AddonRegistry) ResolveIDs(resolver func(string) (int, bool)) error {
-	r.resolved = make(map[stationPairKey]PassFare, len(r.definitions))
+	r.resolved = make(map[stationPairKey]PassPrice, len(r.definitions))
 
 	// 特殊判定用の駅IDを解決
 	r.hinenoID, _ = resolver("日根野")
@@ -85,7 +85,7 @@ func (r *AddonRegistry) ResolveIDs(resolver func(string) (int, bool)) error {
 }
 
 // Lookup は指定された駅ID間に加算運賃が設定されているか確認し、あればその運賃を返します。
-func (r *AddonRegistry) Lookup(id1, id2 int) (PassFare, bool) {
+func (r *AddonRegistry) Lookup(id1, id2 int) (PassPrice, bool) {
 	key := makePairKey(id1, id2)
 	fare, ok := r.resolved[key]
 	return fare, ok
@@ -93,7 +93,7 @@ func (r *AddonRegistry) Lookup(id1, id2 int) (PassFare, bool) {
 
 // GetApplicableAddons は経路全体から適用すべき加算運賃を抽出します。
 // 関西空港線などの特殊な重複ルールは、旅客営業規則に基づき明示的に判定します。
-func (r *AddonRegistry) GetApplicableAddons(path []int) []PassFare {
+func (r *AddonRegistry) GetApplicableAddons(path []int) []PassPrice {
 	if len(path) < 2 {
 		return nil
 	}
@@ -104,7 +104,7 @@ func (r *AddonRegistry) GetApplicableAddons(path []int) []PassFare {
 		stationSet[id] = struct{}{}
 	}
 
-	var result []PassFare
+	var result []PassPrice
 
 	// 1. 関西空港線の判定 (旅客営業規則に基づく重複適用防止)
 	_, hasHineno := stationSet[r.hinenoID]

--- a/split-pass-api/internal/domain/addon_test.go
+++ b/split-pass-api/internal/domain/addon_test.go
@@ -25,7 +25,7 @@ func TestAddonRegistry_ResolveIDs(t *testing.T) {
 		name      string
 		registers []struct {
 			s1, s2 string
-			fare   domain.PassFare
+			fare   domain.PassPrice
 		}
 		wantLookup []struct {
 			id1, id2 int
@@ -38,9 +38,9 @@ func TestAddonRegistry_ResolveIDs(t *testing.T) {
 			name: "正常系: 全ての駅名が解決可能（逆引き含む）",
 			registers: []struct {
 				s1, s2 string
-				fare   domain.PassFare
+				fare   domain.PassPrice
 			}{
-				{"StationA", "StationB", domain.PassFare{OneMonth: 100}},
+				{"StationA", "StationB", domain.PassPrice{OneMonth: 100}},
 			},
 			wantLookup: []struct {
 				id1, id2 int
@@ -56,9 +56,9 @@ func TestAddonRegistry_ResolveIDs(t *testing.T) {
 			name: "異常系: 同一駅の登録",
 			registers: []struct {
 				s1, s2 string
-				fare   domain.PassFare
+				fare   domain.PassPrice
 			}{
-				{"StationA", "StationA", domain.PassFare{OneMonth: 100}},
+				{"StationA", "StationA", domain.PassPrice{OneMonth: 100}},
 			},
 			wantErr: domain.ErrSameStation,
 		},
@@ -66,9 +66,9 @@ func TestAddonRegistry_ResolveIDs(t *testing.T) {
 			name: "異常系: 存在しない駅名が含まれる",
 			registers: []struct {
 				s1, s2 string
-				fare   domain.PassFare
+				fare   domain.PassPrice
 			}{
-				{"StationA", "UnknownStation", domain.PassFare{OneMonth: 200}},
+				{"StationA", "UnknownStation", domain.PassPrice{OneMonth: 200}},
 			},
 			wantErr: domain.ErrStationNotFound,
 		},
@@ -76,10 +76,10 @@ func TestAddonRegistry_ResolveIDs(t *testing.T) {
 			name: "正常系: 複数の区間を登録",
 			registers: []struct {
 				s1, s2 string
-				fare   domain.PassFare
+				fare   domain.PassPrice
 			}{
-				{"StationA", "StationB", domain.PassFare{OneMonth: 100}},
-				{"StationB", "StationC", domain.PassFare{OneMonth: 200}},
+				{"StationA", "StationB", domain.PassPrice{OneMonth: 100}},
+				{"StationB", "StationC", domain.PassPrice{OneMonth: 200}},
 			},
 			wantLookup: []struct {
 				id1, id2 int
@@ -122,7 +122,7 @@ func TestAddonRegistry_ResolveIDs(t *testing.T) {
 
 func TestAddonRegistry_ResolveIDs_Recalculation(t *testing.T) {
 	r := domain.NewAddonRegistry()
-	r.Register("A", "B", domain.PassFare{OneMonth: 100})
+	r.Register("A", "B", domain.PassPrice{OneMonth: 100})
 
 	// 1回目の解決 (A=1, B=2)
 	_ = r.ResolveIDs(func(name string) (int, bool) {

--- a/split-pass-api/internal/domain/models.go
+++ b/split-pass-api/internal/domain/models.go
@@ -33,15 +33,15 @@ func DetermineRouteType(hasTrunk, hasLocal bool) (RouteType, error) {
 	return RouteTypeTrunkOnly, nil
 }
 
-// PassFare は各月数（1, 3, 6ヶ月）の定期運賃を保持します。
-type PassFare struct {
+// PassPrice は各月数（1, 3, 6ヶ月）の定期運賃を保持します。
+type PassPrice struct {
 	OneMonth   int
 	ThreeMonth int
 	SixMonth   int
 }
 
 // GetByMonths は指定された月数の運賃を返します。
-func (f PassFare) GetByMonths(months int) (int, error) {
+func (f PassPrice) GetByMonths(months int) (int, error) {
 	switch months {
 	case 1:
 		return f.OneMonth, nil
@@ -54,10 +54,10 @@ func (f PassFare) GetByMonths(months int) (int, error) {
 	}
 }
 
-// RouteAndFare は経路完全一致で適用される特定区間運賃を保持します。
+// RouteAndFare は経路完全一致で適用される特定区間運賃や調整区間運賃を保持します。
 type RouteAndFare struct {
 	Route []string
-	Fare  PassFare
+	Fare  PassPrice
 }
 
 // PassFareParams は定期運賃計算の入力パラメータです。

--- a/split-pass-api/internal/fare/common.go
+++ b/split-pass-api/internal/fare/common.go
@@ -13,7 +13,7 @@ var (
 )
 
 // calculateBaseFare は、幹線と地方交通線の運賃表を使い分ける本州・北海道向けの運賃計算ロジックです。
-func calculateBaseFare(params domain.PassFareParams, trunkTable, localTable *[101]domain.PassFare) (int, error) {
+func calculateBaseFare(params domain.PassFareParams, trunkTable, localTable *[101]domain.PassPrice) (int, error) {
 	var targetKm int
 	var useTrunkTable bool
 	var err error
@@ -70,7 +70,7 @@ func calculateBaseFare(params domain.PassFareParams, trunkTable, localTable *[10
 }
 
 // calculateSingleTableFare は、常に擬制キロを使用し単一の運賃表を用いる九州・四国向けの運賃計算ロジックです。
-func calculateSingleTableFare(params domain.PassFareParams, table *[101]domain.PassFare) (int, error) {
+func calculateSingleTableFare(params domain.PassFareParams, table *[101]domain.PassPrice) (int, error) {
 	targetKm, err := params.GiseiKilo.ToCeiledKm()
 	if err != nil {
 		return 0, fmt.Errorf("calculateSingleTableFare: %w", err)
@@ -79,7 +79,7 @@ func calculateSingleTableFare(params domain.PassFareParams, table *[101]domain.P
 }
 
 // calculateFromTable は運賃表（100kmごとに折り返し）から月数に応じた運賃を抽出する純粋な計算処理です。
-func calculateFromTable(targetKm int, months int, table *[101]domain.PassFare) (int, error) {
+func calculateFromTable(targetKm int, months int, table *[101]domain.PassPrice) (int, error) {
 	if table == nil {
 		return 0, fmt.Errorf("calculateFromTable: %w", ErrInvalidTable)
 	}

--- a/split-pass-api/internal/fare/east.go
+++ b/split-pass-api/internal/fare/east.go
@@ -4,13 +4,13 @@ import (
 	"split-pass-api/internal/domain"
 )
 
-func NewEastCalculator(trunkFares, localFares [101]domain.PassFare) *EastCalculator {
+func NewEastCalculator(trunkFares, localFares [101]domain.PassPrice) *EastCalculator {
 	return &EastCalculator{trunkFares: trunkFares, localFares: localFares}
 }
 
 type EastCalculator struct {
-	trunkFares [101]domain.PassFare
-	localFares [101]domain.PassFare
+	trunkFares [101]domain.PassPrice
+	localFares [101]domain.PassPrice
 }
 
 func (c *EastCalculator) Calculate(params domain.PassFareParams) (int, error) {

--- a/split-pass-api/internal/fare/hokkaido.go
+++ b/split-pass-api/internal/fare/hokkaido.go
@@ -4,13 +4,13 @@ import (
 	"split-pass-api/internal/domain"
 )
 
-func NewHokkaidoCalculator(trunkFares, localFares [101]domain.PassFare) *HokkaidoCalculator {
+func NewHokkaidoCalculator(trunkFares, localFares [101]domain.PassPrice) *HokkaidoCalculator {
 	return &HokkaidoCalculator{trunkFares: trunkFares, localFares: localFares}
 }
 
 type HokkaidoCalculator struct {
-	trunkFares [101]domain.PassFare
-	localFares [101]domain.PassFare
+	trunkFares [101]domain.PassPrice
+	localFares [101]domain.PassPrice
 }
 
 func (c *HokkaidoCalculator) Calculate(params domain.PassFareParams) (int, error) {

--- a/split-pass-api/internal/fare/kyushu.go
+++ b/split-pass-api/internal/fare/kyushu.go
@@ -10,7 +10,7 @@ import (
 // 外部には公開せず、getKyushuSpecificFare と Calculate の間でのみ使います。
 var errNoSpecialFare = errors.New("九州の特定定期運賃の適用対象外")
 
-func NewKyushuCalculator(fares [101]domain.PassFare) *KyushuCalculator {
+func NewKyushuCalculator(fares [101]domain.PassPrice) *KyushuCalculator {
 	return &KyushuCalculator{fares: fares}
 }
 
@@ -30,23 +30,23 @@ func getKyushuSpecificFare(params domain.PassFareParams) (int, error) {
 	if params.RouteType == domain.RouteTypeLocalOnly {
 		switch {
 		case g == 4 && e == 3:
-			return extractMonthFare(domain.PassFare{OneMonth: 7130, ThreeMonth: 20440, SixMonth: 36200}, m)
+			return extractMonthFare(domain.PassPrice{OneMonth: 7130, ThreeMonth: 20440, SixMonth: 36200}, m)
 		case g == 11:
-			return extractMonthFare(domain.PassFare{OneMonth: 10230, ThreeMonth: 29430, SixMonth: 50290}, m)
+			return extractMonthFare(domain.PassPrice{OneMonth: 10230, ThreeMonth: 29430, SixMonth: 50290}, m)
 		case g == 16:
-			return extractMonthFare(domain.PassFare{OneMonth: 11470, ThreeMonth: 33010, SixMonth: 57030}, m)
+			return extractMonthFare(domain.PassPrice{OneMonth: 11470, ThreeMonth: 33010, SixMonth: 57030}, m)
 		case g == 17 && e == 15:
-			return extractMonthFare(domain.PassFare{OneMonth: 11530, ThreeMonth: 33200, SixMonth: 58090}, m)
+			return extractMonthFare(domain.PassPrice{OneMonth: 11530, ThreeMonth: 33200, SixMonth: 58090}, m)
 		case g == 21:
-			return extractMonthFare(domain.PassFare{OneMonth: 15300, ThreeMonth: 44030, SixMonth: 78260}, m)
+			return extractMonthFare(domain.PassPrice{OneMonth: 15300, ThreeMonth: 44030, SixMonth: 78260}, m)
 		case g == 22:
-			return extractMonthFare(domain.PassFare{OneMonth: 15360, ThreeMonth: 44210, SixMonth: 78380}, m)
+			return extractMonthFare(domain.PassPrice{OneMonth: 15360, ThreeMonth: 44210, SixMonth: 78380}, m)
 		case g == 26 && e == 23:
-			return extractMonthFare(domain.PassFare{OneMonth: 19210, ThreeMonth: 55250, SixMonth: 97870}, m)
+			return extractMonthFare(domain.PassPrice{OneMonth: 19210, ThreeMonth: 55250, SixMonth: 97870}, m)
 		case g == 31 && e == 28:
-			return extractMonthFare(domain.PassFare{OneMonth: 23010, ThreeMonth: 66230, SixMonth: 117290}, m)
+			return extractMonthFare(domain.PassPrice{OneMonth: 23010, ThreeMonth: 66230, SixMonth: 117290}, m)
 		case g == 36 && e == 32:
-			return extractMonthFare(domain.PassFare{OneMonth: 27120, ThreeMonth: 78090, SixMonth: 138280}, m)
+			return extractMonthFare(domain.PassPrice{OneMonth: 27120, ThreeMonth: 78090, SixMonth: 138280}, m)
 		case g == 41 && e == 37:
 			// 仕様：6ヶ月のみ特殊運賃。1・3ヶ月は通常テーブルを適用する。
 			if m == 6 {
@@ -63,21 +63,21 @@ func getKyushuSpecificFare(params domain.PassFareParams) (int, error) {
 	if params.RouteType == domain.RouteTypeMixed {
 		switch {
 		case g == 4 && e == 3:
-			return extractMonthFare(domain.PassFare{OneMonth: 7130, ThreeMonth: 20440, SixMonth: 36200}, m)
+			return extractMonthFare(domain.PassPrice{OneMonth: 7130, ThreeMonth: 20440, SixMonth: 36200}, m)
 		case g == 11 && e == 10:
-			return extractMonthFare(domain.PassFare{OneMonth: 10230, ThreeMonth: 29430, SixMonth: 50290}, m)
+			return extractMonthFare(domain.PassPrice{OneMonth: 10230, ThreeMonth: 29430, SixMonth: 50290}, m)
 		}
 	}
 
 	return 0, errNoSpecialFare
 }
 
-func extractMonthFare(fare domain.PassFare, months int) (int, error) {
+func extractMonthFare(fare domain.PassPrice, months int) (int, error) {
 	return fare.GetByMonths(months)
 }
 
 type KyushuCalculator struct {
-	fares [101]domain.PassFare
+	fares [101]domain.PassPrice
 }
 
 func (c *KyushuCalculator) Calculate(params domain.PassFareParams) (int, error) {

--- a/split-pass-api/internal/fare/route_matcher.go
+++ b/split-pass-api/internal/fare/route_matcher.go
@@ -16,7 +16,7 @@ var (
 // RouteEntry は特定の経路とそれに紐づく運賃を保持します。
 type RouteEntry struct {
 	Route []int
-	Fare  domain.PassFare
+	Fare  domain.PassPrice
 }
 
 // RouteMatcher は経路の完全一致による特定運賃を検索・適用します。
@@ -71,7 +71,7 @@ func (m *RouteMatcher) LoadFromDomain(route_and_fares []domain.RouteAndFare, g *
 // Insert は経路と運賃をマップに登録します。
 // 既に同じ経路が登録されている場合は ErrDuplicateRoute を返します。
 // 逆方向からの検索にも対応するため、逆順の経路も同時に登録します。
-func (m *RouteMatcher) Insert(route []int, fare domain.PassFare) error {
+func (m *RouteMatcher) Insert(route []int, fare domain.PassPrice) error {
 	// 重複チェック
 	if _, ok := m.Search(route); ok {
 		return ErrDuplicateRoute
@@ -112,14 +112,14 @@ func (m *RouteMatcher) Insert(route []int, fare domain.PassFare) error {
 }
 
 // Search は指定された経路に完全に一致する特定区間運賃があるか検索します。
-func (m *RouteMatcher) Search(route []int) (domain.PassFare, bool) {
+func (m *RouteMatcher) Search(route []int) (domain.PassPrice, bool) {
 	if m.table == nil {
-		return domain.PassFare{}, false
+		return domain.PassPrice{}, false
 	}
 	hash := routeToPseudoFNV(route)
 	entries, ok := m.table[hash]
 	if !ok {
-		return domain.PassFare{}, false
+		return domain.PassPrice{}, false
 	}
 
 	// ハッシュが一致したエントリの中から、スライスが完全に一致するものを探す（衝突対策）
@@ -129,5 +129,5 @@ func (m *RouteMatcher) Search(route []int) (domain.PassFare, bool) {
 		}
 	}
 
-	return domain.PassFare{}, false
+	return domain.PassPrice{}, false
 }

--- a/split-pass-api/internal/fare/route_matcher_internal_test.go
+++ b/split-pass-api/internal/fare/route_matcher_internal_test.go
@@ -17,8 +17,8 @@ func TestRouteMatcher_ActualCollision(t *testing.T) {
 	// 人工的に衝突状態をシミュレートするため、同じハッシュ値のバケットに2つ登録する
 	h := uint64(42)
 	matcher.table[h] = []RouteEntry{
-		{Route: route1, Fare: domain.PassFare{OneMonth: 100}},
-		{Route: route2, Fare: domain.PassFare{OneMonth: 200}},
+		{Route: route1, Fare: domain.PassPrice{OneMonth: 100}},
+		{Route: route2, Fare: domain.PassPrice{OneMonth: 200}},
 	}
 
 	// Search メソッドのテスト（ハッシュ値を強制的に指定できないため、
@@ -29,8 +29,8 @@ func TestRouteMatcher_ActualCollision(t *testing.T) {
 
 	h1 := routeToPseudoFNV(route1)
 	matcher.table[h1] = []RouteEntry{
-		{Route: route1, Fare: domain.PassFare{OneMonth: 100}},
-		{Route: route2, Fare: domain.PassFare{OneMonth: 200}}, // route1のハッシュにroute2を混ぜる
+		{Route: route1, Fare: domain.PassPrice{OneMonth: 100}},
+		{Route: route2, Fare: domain.PassPrice{OneMonth: 200}}, // route1のハッシュにroute2を混ぜる
 	}
 
 	// 1. route1 を探す -> 見つかるはず
@@ -43,8 +43,8 @@ func TestRouteMatcher_ActualCollision(t *testing.T) {
 	// そこで、route2のハッシュバケットにも route1 を混ぜて「衝突」を再現する。
 	h2 := routeToPseudoFNV(route2)
 	matcher.table[h2] = []RouteEntry{
-		{Route: route1, Fare: domain.PassFare{OneMonth: 100}}, // route2のハッシュにroute1が混ざっている
-		{Route: route2, Fare: domain.PassFare{OneMonth: 200}},
+		{Route: route1, Fare: domain.PassPrice{OneMonth: 100}}, // route2のハッシュにroute1が混ざっている
+		{Route: route2, Fare: domain.PassPrice{OneMonth: 200}},
 	}
 
 	if f, ok := matcher.Search(route2); !ok || f.OneMonth != 200 {
@@ -52,7 +52,7 @@ func TestRouteMatcher_ActualCollision(t *testing.T) {
 	}
 
 	// 3. 存在しない経路 (route1と同じハッシュだが中身が違う)
-	matcher.table[h1] = append(matcher.table[h1], RouteEntry{Route: []int{9, 9, 9}, Fare: domain.PassFare{OneMonth: 999}})
+	matcher.table[h1] = append(matcher.table[h1], RouteEntry{Route: []int{9, 9, 9}, Fare: domain.PassPrice{OneMonth: 999}})
 	if _, ok := matcher.Search([]int{1, 2, 4}); ok {
 		t.Error("ハッシュが一致しても経路が異なる場合に ok=true が返されました")
 	}

--- a/split-pass-api/internal/fare/route_matcher_test.go
+++ b/split-pass-api/internal/fare/route_matcher_test.go
@@ -20,7 +20,7 @@ func TestRouteMatcher(t *testing.T) {
 	fares := []domain.RouteAndFare{
 		{
 			Route: []string{"A", "B", "C"},
-			Fare:  domain.PassFare{OneMonth: 100, ThreeMonth: 285, SixMonth: 540},
+			Fare:  domain.PassPrice{OneMonth: 100, ThreeMonth: 285, SixMonth: 540},
 		},
 	}
 
@@ -33,7 +33,7 @@ func TestRouteMatcher(t *testing.T) {
 		invalidFares := []domain.RouteAndFare{
 			{
 				Route: []string{"A", "Unknown"},
-				Fare:  domain.PassFare{OneMonth: 100},
+				Fare:  domain.PassPrice{OneMonth: 100},
 			},
 		}
 		matcher2 := fare.NewRouteMatcher()
@@ -92,7 +92,7 @@ func TestRouteMatcher_DuplicateRegistration(t *testing.T) {
 	matcher := fare.NewRouteMatcher()
 	route := []int{1, 2, 3}
 	rev := []int{3, 2, 1}
-	f := domain.PassFare{OneMonth: 100}
+	f := domain.PassPrice{OneMonth: 100}
 
 	// 1. 初回登録（成功）
 	if err := matcher.Insert(route, f); err != nil {
@@ -122,7 +122,7 @@ func TestRouteMatcher_DuplicateRegistration(t *testing.T) {
 func TestRouteMatcher_DefensiveCopy(t *testing.T) {
 	matcher := fare.NewRouteMatcher()
 	route := []int{1, 2, 3}
-	f := domain.PassFare{OneMonth: 100}
+	f := domain.PassPrice{OneMonth: 100}
 
 	if err := matcher.Insert(route, f); err != nil {
 		t.Fatalf("Insert 失敗: %v", err)
@@ -151,8 +151,8 @@ func TestRouteMatcher_HashCollision(t *testing.T) {
 	route1 := []int{1, 2, 3}
 	route2 := []int{1, 3, 2}
 
-	fare1 := domain.PassFare{OneMonth: 100}
-	fare2 := domain.PassFare{OneMonth: 200}
+	fare1 := domain.PassPrice{OneMonth: 100}
+	fare2 := domain.PassPrice{OneMonth: 200}
 
 	_ = matcher.Insert(route1, fare1) // route1 と その逆順 が 100 で登録される
 	_ = matcher.Insert(route2, fare2) // route2 と その逆順 が 200 で登録される

--- a/split-pass-api/internal/fare/shikoku.go
+++ b/split-pass-api/internal/fare/shikoku.go
@@ -4,12 +4,12 @@ import (
 	"split-pass-api/internal/domain"
 )
 
-func NewShikokuCalculator(fares [101]domain.PassFare) *ShikokuCalculator {
+func NewShikokuCalculator(fares [101]domain.PassPrice) *ShikokuCalculator {
 	return &ShikokuCalculator{fares: fares}
 }
 
 type ShikokuCalculator struct {
-	fares [101]domain.PassFare
+	fares [101]domain.PassPrice
 }
 
 func (c *ShikokuCalculator) Calculate(params domain.PassFareParams) (int, error) {

--- a/split-pass-api/internal/fare/standard.go
+++ b/split-pass-api/internal/fare/standard.go
@@ -4,13 +4,13 @@ import (
 	"split-pass-api/internal/domain"
 )
 
-func NewStandardCalculator(trunkFares, localFares [101]domain.PassFare) *StandardCalculator {
+func NewStandardCalculator(trunkFares, localFares [101]domain.PassPrice) *StandardCalculator {
 	return &StandardCalculator{trunkFares: trunkFares, localFares: localFares}
 }
 
 type StandardCalculator struct {
-	trunkFares [101]domain.PassFare
-	localFares [101]domain.PassFare
+	trunkFares [101]domain.PassPrice
+	localFares [101]domain.PassPrice
 }
 
 func (c *StandardCalculator) Calculate(params domain.PassFareParams) (int, error) {

--- a/split-pass-api/internal/fare/train_specific_section.go
+++ b/split-pass-api/internal/fare/train_specific_section.go
@@ -20,11 +20,11 @@ func IsAllTrainSpecificApplicable(edges []*domain.Edge) bool {
 
 // TrainSpecificSectionCalculator は電車特定区間の運賃計算を行います。
 type TrainSpecificSectionCalculator struct {
-	fares [101]domain.PassFare
+	fares [101]domain.PassPrice
 }
 
 // NewTrainSpecificSectionCalculator は運賃データを受け取り、計算機を初期化します。
-func NewTrainSpecificSectionCalculator(fares [101]domain.PassFare) *TrainSpecificSectionCalculator {
+func NewTrainSpecificSectionCalculator(fares [101]domain.PassPrice) *TrainSpecificSectionCalculator {
 	return &TrainSpecificSectionCalculator{fares: fares}
 }
 

--- a/split-pass-api/internal/infra/fareio/json.go
+++ b/split-pass-api/internal/infra/fareio/json.go
@@ -49,7 +49,7 @@ func (l *RouteAndFareJSONLoader) Load(path string) ([]domain.RouteAndFare, error
 
 		data = append(data, domain.RouteAndFare{
 			Route: raw.Route,
-			Fare: domain.PassFare{
+			Fare: domain.PassPrice{
 				OneMonth:   raw.Fare.OneMonth,
 				ThreeMonth: raw.Fare.ThreeMonth,
 				SixMonth:   raw.Fare.SixMonth,

--- a/split-pass-api/internal/infra/fareio/json_test.go
+++ b/split-pass-api/internal/infra/fareio/json_test.go
@@ -38,7 +38,7 @@ func TestRouteAndFareJSONLoader_Load(t *testing.T) {
 			wantFares: []domain.RouteAndFare{
 				{
 					Route: []string{"東京", "神田"},
-					Fare: domain.PassFare{
+					Fare: domain.PassPrice{
 						OneMonth:   1000,
 						ThreeMonth: 2850,
 						SixMonth:   5400,

--- a/split-pass-api/internal/infra/fareio/registry.go
+++ b/split-pass-api/internal/infra/fareio/registry.go
@@ -45,9 +45,9 @@ var specificFaresJSON []byte
 //go:embed data/adjustedFares.json
 var adjustedFaresJSON []byte
 
-func loadFareTable(data []byte) ([101]domain.PassFare, error) {
-	var table [101]domain.PassFare
-	var slice []domain.PassFare
+func loadFareTable(data []byte) ([101]domain.PassPrice, error) {
+	var table [101]domain.PassPrice
+	var slice []domain.PassPrice
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()
@@ -87,7 +87,7 @@ func loadRouteAndFares(data []byte, name string) ([]domain.RouteAndFare, error) 
 		}
 		dataResult = append(dataResult, domain.RouteAndFare{
 			Route: raw.Route,
-			Fare: domain.PassFare{
+			Fare: domain.PassPrice{
 				OneMonth:   raw.Fare.OneMonth,
 				ThreeMonth: raw.Fare.ThreeMonth,
 				SixMonth:   raw.Fare.SixMonth,


### PR DESCRIPTION
## 関連Issue
Closes #242 

## 変更の目的
ドメインモデルから「言葉の矛盾」排除し、将来の拡張に耐えうるクリーンなアーキテクチャを実現します。

## 変更内容
`PassFare` を `PassPrice` にリネームし、「運賃（Fare）」と「料金（Charge）」のどちらにも使える汎用的な価格マトリクスとして再定義しました。

## 注意点
- 運賃計算パラメータである `PassFareParams` は、計算対象が「運賃」に限定されるため意図的にリネームしていません。