### PR TITLE
feat: FindOptimalSplitUseCase の実装とDPによる探索最適化

### DIFF
--- a/split-pass-api/internal/usecase/find_optimal_split_usecase.go
+++ b/split-pass-api/internal/usecase/find_optimal_split_usecase.go
@@ -1,0 +1,141 @@
+package usecase
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"split-pass-api/internal/domain"
+)
+
+// SplitSegment は分割された個々の区間とその運賃計算結果を保持します。
+type SplitSegment struct {
+	Path   []int
+	Result *CalculationResult
+}
+
+// SplitResult は最適な分割結果とその内訳を保持します。
+type SplitResult struct {
+	TotalAmount int
+	Segments    []SplitSegment
+}
+
+type FindOptimalSplitUseCase struct {
+	calcUseCase *CalculateAmountUseCase
+}
+
+func NewFindOptimalSplitUseCase(calcUseCase *CalculateAmountUseCase) *FindOptimalSplitUseCase {
+	return &FindOptimalSplitUseCase{
+		calcUseCase: calcUseCase,
+	}
+}
+
+var (
+	ErrNoValidSplitPattern = errors.New("有効な分割パターンが見つかりませんでした")
+)
+
+// Execute は指定された経路の全分割パターンを評価し、最安となる分割結果をすべて返します。
+// 1次元動的計画法 (DP) を使用し、内部計算を含めて O(N^3) の時間計算量で処理します。
+//
+// [安全上の制約]
+// 内部でサブスライスを共有するため、呼び出し元は Execute 呼び出し後も
+// path の要素を変更してはなりません（Read-Only）。
+func (u *FindOptimalSplitUseCase) Execute(path []int, months int) ([]SplitResult, error) {
+
+	if months != 1 && months != 3 && months != 6 {
+		return nil, fmt.Errorf("findOptimalSplit: %w", domain.ErrInvalidMonths)
+	}
+
+	n := len(path)
+	if n < 2 {
+		return nil, errors.New("経路には少なくとも2つの駅が必要です")
+	}
+
+	cache := make([]*CalculationResult, n*n)
+
+	const INF = math.MaxInt
+	dp := make([]int, n)
+	for i := range dp {
+		dp[i] = INF
+	}
+	dp[0] = 0
+
+	// Goでは nil スライスに対して直接 append() することが安全であり、メモリ効率が最大化されます。
+	prev := make([][]int, n)
+	var lastErr error
+
+	for j := 1; j < n; j++ {
+		for i := 0; i < j; i++ {
+			if dp[i] == INF {
+				continue
+			}
+
+			subPath := path[i : j+1]
+			res, err := u.calcUseCase.Execute(subPath, months)
+			if err != nil {
+				lastErr = err
+				continue
+			}
+
+			cache[i*n+j] = res
+			cost := dp[i] + res.TotalAmount()
+
+			if cost < dp[j] {
+				dp[j] = cost
+				prev[j] = []int{i}
+			} else if cost == dp[j] {
+				prev[j] = append(prev[j], i)
+			}
+		}
+	}
+
+	if dp[n-1] == INF {
+		if lastErr != nil {
+			return nil, fmt.Errorf("findOptimalSplit: %w", lastErr)
+		}
+		return nil, fmt.Errorf("findOptimalSplit: %w", ErrNoValidSplitPattern)
+	}
+
+	var results []SplitResult
+
+	// 改善: 探索中は「どの駅で分割したか（インデックス）」だけを記録する
+	cutPoints := make([]int, 0, n)
+	cutPoints = append(cutPoints, n-1)
+
+	var dfs func(current int)
+	dfs = func(current int) {
+		if current == 0 {
+			// 終端に到達して初めて、出力用の構造体とスライスを一気に生成する（関心の分離）
+			segs := make([]SplitSegment, len(cutPoints)-1)
+
+			// cutPointsには [終点, ..., 始点(0)] と逆順に入っているため、逆から読んで正順のSegmentsを作る
+			for k := 0; k < len(cutPoints)-1; k++ {
+				endIdx := cutPoints[len(cutPoints)-2-k]
+				startIdx := cutPoints[len(cutPoints)-1-k]
+
+				segPath := make([]int, endIdx-startIdx+1)
+				copy(segPath, path[startIdx:endIdx+1])
+
+				segs[k] = SplitSegment{
+					Path:   segPath,
+					Result: cache[startIdx*n+endIdx],
+				}
+			}
+
+			results = append(results, SplitResult{
+				TotalAmount: dp[n-1],
+				Segments:    segs,
+			})
+			return
+		}
+
+		for _, p := range prev[current] {
+			cutPoints = append(cutPoints, p)
+			dfs(p)
+			cutPoints = cutPoints[:len(cutPoints)-1]
+		}
+	}
+
+	dfs(n - 1)
+
+	return results, nil
+}

--- a/split-pass-api/internal/usecase/find_optimal_split_usecase_test.go
+++ b/split-pass-api/internal/usecase/find_optimal_split_usecase_test.go
@@ -1,0 +1,239 @@
+package usecase_test
+
+import (
+	"reflect"
+	"split-pass-api/internal/domain"
+	"split-pass-api/internal/fare"
+	"split-pass-api/internal/graph"
+	"split-pass-api/internal/usecase"
+	"testing"
+)
+
+func TestFindOptimalSplitUseCase_Execute(t *testing.T) {
+	g := graph.NewGraph(20)
+	id := func(name string) int { return g.GetOrAddID(name) }
+
+	// A - B - C のグラフを作成
+	g.AddEdge(domain.Edge{
+		FromID: id("A"), ToID: id("B"),
+		EigyoKilo: 100, GiseiKilo: 100, IsLocal: false, Company: domain.JREast,
+	})
+	g.AddEdge(domain.Edge{
+		FromID: id("B"), ToID: id("C"),
+		EigyoKilo: 100, GiseiKilo: 100, IsLocal: false, Company: domain.JREast,
+	})
+	// もう1つ追加
+	g.AddEdge(domain.Edge{
+		FromID: id("C"), ToID: id("D"),
+		EigyoKilo: 100, GiseiKilo: 100, IsLocal: false, Company: domain.JREast,
+	})
+
+	reg := fare.NewRegistry()
+
+	// ダミーの運賃テーブル
+	// A-B (10km): 1000円
+	// B-C (10km): 1000円
+	// C-D (10km): 1000円
+	// A-C (20km): 2500円（分割した方が安い設定：1000+1000 = 2000円）
+	// B-D (20km): 2500円（同上）
+	// A-D (30km): 4000円
+	var dummyTable [101]domain.PassPrice
+	for i := range dummyTable {
+		if i <= 10 {
+			dummyTable[i] = domain.PassPrice{OneMonth: 1000} // 10kmまで
+		} else if i <= 20 {
+			dummyTable[i] = domain.PassPrice{OneMonth: 2500} // 20kmまで
+		} else {
+			dummyTable[i] = domain.PassPrice{OneMonth: 4000} // それ以上
+		}
+	}
+
+	eastCalc := fare.NewEastCalculator(dummyTable, dummyTable)
+	stdCalc := fare.NewStandardCalculator(dummyTable, dummyTable)
+	reg.Register(domain.JREast, eastCalc)
+	reg.Register(domain.JRCentral, stdCalc)
+
+	addonFareReg := domain.NewAddonRegistry()
+	addonChargeReg := domain.NewAddonRegistry()
+
+	calcUseCase := usecase.NewCalculateAmountUseCase(
+		g,
+		reg,
+		addonFareReg,
+		addonChargeReg,
+		fare.NewTrainSpecificSectionCalculator(dummyTable),
+		fare.NewRouteMatcher(),
+		fare.NewRouteMatcher(),
+	)
+
+	findOptimalUseCase := usecase.NewFindOptimalSplitUseCase(calcUseCase)
+
+	tests := []struct {
+		name    string
+		path    []int
+		months  int
+		want    []usecase.SplitResult
+		wantErr bool
+	}{
+		{
+			name:   "分割した方が安いパターン (A-B-C)",
+			path:   []int{id("A"), id("B"), id("C")},
+			months: 1,
+			want: []usecase.SplitResult{
+				{
+					TotalAmount: 2000,
+					Segments: []usecase.SplitSegment{
+						{
+							Path:   []int{id("A"), id("B")},
+							Result: &usecase.CalculationResult{Fare: 1000},
+						},
+						{
+							Path:   []int{id("B"), id("C")},
+							Result: &usecase.CalculationResult{Fare: 1000},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "3駅区間で全通し・1分割・2分割を比較 (A-B-C-D) 最安はA-B, B-C, C-D の3分割",
+			path:   []int{id("A"), id("B"), id("C"), id("D")},
+			months: 1,
+			want: []usecase.SplitResult{
+				{
+					TotalAmount: 3000, // A-B, B-C, C-D のそれぞれで1000円
+					Segments: []usecase.SplitSegment{
+						{
+							Path:   []int{id("A"), id("B")},
+							Result: &usecase.CalculationResult{Fare: 1000},
+						},
+						{
+							Path:   []int{id("B"), id("C")},
+							Result: &usecase.CalculationResult{Fare: 1000},
+						},
+						{
+							Path:   []int{id("C"), id("D")},
+							Result: &usecase.CalculationResult{Fare: 1000},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "異常系：経路が1駅",
+			path:    []int{id("A")},
+			months:  1,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "異常系：存在しない経路",
+			path:    []int{id("A"), id("D")},
+			months:  1,
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := findOptimalUseCase.Execute(tt.path, tt.months)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if len(got) != len(tt.want) {
+					t.Fatalf("Execute() returned %v results, want %v", len(got), len(tt.want))
+				}
+				for i := range got {
+					if got[i].TotalAmount != tt.want[i].TotalAmount {
+						t.Errorf("Execute()[%d] TotalAmount = %v, want %v", i, got[i].TotalAmount, tt.want[i].TotalAmount)
+					}
+					if len(got[i].Segments) != len(tt.want[i].Segments) {
+						t.Fatalf("Execute()[%d] Segments count = %v, want %v", i, len(got[i].Segments), len(tt.want[i].Segments))
+					}
+					for j := range got[i].Segments {
+						if !reflect.DeepEqual(got[i].Segments[j].Path, tt.want[i].Segments[j].Path) {
+							t.Errorf("Segments[%d][%d].Path = %v, want %v", i, j, got[i].Segments[j].Path, tt.want[i].Segments[j].Path)
+						}
+						if got[i].Segments[j].Result.Fare != tt.want[i].Segments[j].Result.Fare {
+							t.Errorf("Segments[%d][%d].Result.Fare = %v, want %v", i, j, got[i].Segments[j].Result.Fare, tt.want[i].Segments[j].Result.Fare)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+// 複数パターンの最安値が返ることを確認するテスト
+func TestFindOptimalSplitUseCase_Execute_MultipleOptimalPaths(t *testing.T) {
+	g := graph.NewGraph(20)
+	id := func(name string) int { return g.GetOrAddID(name) }
+
+	g.AddEdge(domain.Edge{
+		FromID: id("A"), ToID: id("B"), EigyoKilo: 100, GiseiKilo: 100, IsLocal: false, Company: domain.JREast,
+	})
+	g.AddEdge(domain.Edge{
+		FromID: id("B"), ToID: id("C"), EigyoKilo: 100, GiseiKilo: 100, IsLocal: false, Company: domain.JREast,
+	})
+	g.AddEdge(domain.Edge{
+		FromID: id("C"), ToID: id("D"), EigyoKilo: 100, GiseiKilo: 100, IsLocal: false, Company: domain.JREast,
+	})
+
+	reg := fare.NewRegistry()
+
+	// ダミー運賃:
+	// 10km (1区間) = 1000円
+	// 20km (2区間) = 2000円
+	// 30km (3区間) = 3000円
+	// -> この設定だと、「A-B-C-D」は
+	// 1. 全通し: A-D (3000円)
+	// 2. 1分割: A-B(1000), B-D(2000) -> 3000円
+	// 3. 1分割: A-C(2000), C-D(1000) -> 3000円
+	// 4. 2分割: A-B(1000), B-C(1000), C-D(1000) -> 3000円
+	// すべてのパターンが3000円になり、4つの結果が返るはず
+	var dummyTable [101]domain.PassPrice
+	for i := range dummyTable {
+		if i <= 10 {
+			dummyTable[i] = domain.PassPrice{OneMonth: 1000}
+		} else if i <= 20 {
+			dummyTable[i] = domain.PassPrice{OneMonth: 2000}
+		} else {
+			dummyTable[i] = domain.PassPrice{OneMonth: 3000}
+		}
+	}
+
+	eastCalc := fare.NewEastCalculator(dummyTable, dummyTable)
+	stdCalc := fare.NewStandardCalculator(dummyTable, dummyTable)
+	reg.Register(domain.JREast, eastCalc)
+	reg.Register(domain.JRCentral, stdCalc)
+
+	addonFareReg := domain.NewAddonRegistry()
+	addonChargeReg := domain.NewAddonRegistry()
+
+	calcUseCase := usecase.NewCalculateAmountUseCase(
+		g, reg, addonFareReg, addonChargeReg,
+		fare.NewTrainSpecificSectionCalculator(dummyTable),
+		fare.NewRouteMatcher(), fare.NewRouteMatcher(),
+	)
+
+	findOptimalUseCase := usecase.NewFindOptimalSplitUseCase(calcUseCase)
+
+	got, err := findOptimalUseCase.Execute([]int{id("A"), id("B"), id("C"), id("D")}, 1)
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	if len(got) != 4 {
+		t.Errorf("Expected 4 optimal paths, got %d", len(got))
+	}
+	for i, res := range got {
+		if res.TotalAmount != 3000 {
+			t.Errorf("Result %d total amount = %d, want 3000", i, res.TotalAmount)
+		}
+	}
+}


### PR DESCRIPTION
## 関連Issue
Closes #255 

## 変更の目的
ユーザーに「最安の分割定期券」を提案するコア機能を実現するため、経路配列から最適な分割パターンを探索するユースケースを実装します。

## 変更内容
1. 探索結果の内訳を表現する `SplitResult` および `SplitSegment` を新設しました（※I/Oの関心事であるJSONタグは排除しています）。
2. `FindOptimalSplitUseCase` を実装し、動的計画法（DP）を用いて探索を行います。各区間の運賃計算が $O(N)$ であるため、アルゴリズム全体の時間計算量は $O(N^3)$ となります。

## アーキテクチャ・パフォーマンスの工夫
本PRでは、将来的なリクエスト増大を見据え、極限までパフォーマンスチューニングを行っています。
- **1次防衛線（早期リターン）:** 不正な `months` が入力された場合、DPの二重ループに入る前に $O(1)$ で弾くことでCPUリソースの浪費を完全に防いでいます。
- **1Dスライスマッピング:** `map` によるハッシュ計算とアロケーションを避け、`make([]*CalculationResult, n*n)` によるフラットな1次元スライスでキャッシュを管理しています。
- **DFSの関心の分離:** バックトラック（経路復元）の際、再帰処理中は「どの駅で分割したか（`cutPoints`）」のインデックス記録のみを行い、終端に到達した瞬間に1回だけスライスと構造体を生成する設計とし、GC（ガベージコレクション）の負荷を最小化しています。
- **契約の明示:** 処理速度のためにスライスのメモリを共有していますが、関数コメントにて「引数 `path` は Read-Only である」というドメイン制約を明示しています。