### PR TITLE
refactor: インラインエラーのSentinel Error化およびエラーハンドリングの改善

### DIFF
--- a/split-pass-api/internal/domain/addon.go
+++ b/split-pass-api/internal/domain/addon.go
@@ -1,13 +1,7 @@
 package domain
 
 import (
-	"errors"
 	"fmt"
-)
-
-var (
-	ErrStationNotFound = errors.New("駅が見つかりません")
-	ErrSameStation     = errors.New("同一駅間の加算運賃は設定できません")
 )
 
 type addonDefinition struct {

--- a/split-pass-api/internal/domain/distance.go
+++ b/split-pass-api/internal/domain/distance.go
@@ -1,12 +1,7 @@
 package domain
 
 import (
-	"errors"
 	"fmt"
-)
-
-var (
-	ErrNegativeDistance = errors.New("距離は0以上でなければなりません")
 )
 
 // DeciKilo は距離を10倍した整数（0.1km単位での誤差を防ぐため）

--- a/split-pass-api/internal/domain/errors.go
+++ b/split-pass-api/internal/domain/errors.go
@@ -1,0 +1,26 @@
+package domain
+
+import "errors"
+
+var (
+	// ErrInvalidMonths は不正な月数が指定された場合のエラーです。
+	ErrInvalidMonths = errors.New("不正な月数です（1, 3, 6のいずれかを指定してください）")
+
+	// ErrStationNotFound は、指定された駅が見つからない場合のエラーです。
+	ErrStationNotFound = errors.New("駅が見つかりません")
+
+	// ErrSameStation は、開始駅と終了駅が同じ場合に発生するエラーです。
+	ErrSameStation = errors.New("同一駅間の加算運賃は設定できません")
+
+	// ErrNegativeDistance は、距離に負の値が指定された場合のエラーです。
+	ErrNegativeDistance = errors.New("距離は0以上でなければなりません")
+
+	// ErrNoRouteType は、幹線も地方交通線も含まれていない場合のエラーです。
+	ErrNoRouteType = errors.New("幹線も地方交通線も含まれていません")
+
+	// ErrInvalidPath は、経路が無効な場合（駅数が足りないなど）のエラーです。
+	ErrInvalidPath = errors.New("経路には少なくとも2つの駅が必要です")
+
+	// ErrUnknownCompany は、指定された会社IDが未知の場合のエラーです。
+	ErrUnknownCompany = errors.New("未知の会社ID")
+)

--- a/split-pass-api/internal/domain/models.go
+++ b/split-pass-api/internal/domain/models.go
@@ -1,13 +1,7 @@
 package domain
 
 import (
-	"errors"
 	"fmt"
-)
-
-var (
-	// ErrInvalidMonths は不正な月数が指定された場合のエラーです。
-	ErrInvalidMonths = errors.New("不正な月数です（1, 3, 6のいずれかを指定してください）")
 )
 
 // RouteType は路線の種別（幹線、地方交通線など）を表します。
@@ -22,7 +16,7 @@ const (
 // DetermineRouteType は幹線・地方交通線の有無から RouteType を判定します。
 func DetermineRouteType(hasTrunk, hasLocal bool) (RouteType, error) {
 	if !hasTrunk && !hasLocal {
-		return 0, errors.New("DetermineRouteType: 幹線も地方交通線も含まれていません")
+		return 0, fmt.Errorf("DetermineRouteType: %w", ErrNoRouteType)
 	}
 	if hasTrunk && hasLocal {
 		return RouteTypeMixed, nil

--- a/split-pass-api/internal/fare/route_matcher.go
+++ b/split-pass-api/internal/fare/route_matcher.go
@@ -48,7 +48,7 @@ func routeToPseudoFNV(route []int) uint64 {
 // LoadFromDomain は JSON からロードしたドメインモデルの配列と Graph (名前解決用) を用いてデータを構築します。
 func (m *RouteMatcher) LoadFromDomain(route_and_fares []domain.RouteAndFare, g *graph.Graph) error {
 	if g == nil {
-		return errors.New("LoadFromDomain: グラフの読み込みに失敗しました")
+		return fmt.Errorf("LoadFromDomain: %w", graph.ErrInvalidGraph)
 	}
 
 	m.table = make(map[uint64][]RouteEntry, len(route_and_fares)*2)
@@ -57,7 +57,7 @@ func (m *RouteMatcher) LoadFromDomain(route_and_fares []domain.RouteAndFare, g *
 		for i, name := range sf.Route {
 			id, ok := g.GetID(name)
 			if !ok {
-				return fmt.Errorf("LoadFromDomain: 指定された経路に含まれる駅 '%s' がグラフに見つかりません", name)
+				return fmt.Errorf("LoadFromDomain: %w: %s", domain.ErrStationNotFound, name)
 			}
 			route[i] = id
 		}

--- a/split-pass-api/internal/graph/dijkstra.go
+++ b/split-pass-api/internal/graph/dijkstra.go
@@ -2,7 +2,6 @@ package graph
 
 import (
 	"container/heap"
-	"errors"
 	"fmt"
 	"split-pass-api/internal/domain"
 )
@@ -50,10 +49,10 @@ func (pq *priorityQueue) Pop() interface{} {
 // FindShortestPathGisei はダイクストラ法を用いて最短擬制キロ経路を検索します。
 func (g *Graph) FindShortestPathGisei(startID, endID int) (*PathResult, error) {
 	if startID < 0 || startID >= len(g.IDToName) {
-		return nil, fmt.Errorf("開始駅が見つかりません: ID %d", startID)
+		return nil, fmt.Errorf("FindShortestPathGisei: %w: ID %d", domain.ErrStationNotFound, startID)
 	}
 	if endID < 0 || endID >= len(g.IDToName) {
-		return nil, fmt.Errorf("目的駅が見つかりません: ID %d", endID)
+		return nil, fmt.Errorf("FindShortestPathGisei: %w: ID %d", domain.ErrStationNotFound, endID)
 	}
 
 	numStations := len(g.IDToName)
@@ -92,7 +91,7 @@ func (g *Graph) FindShortestPathGisei(startID, endID int) (*PathResult, error) {
 	}
 
 	if prev[endID] == -1 && startID != endID {
-		return nil, errors.New("経路が見つかりませんでした")
+		return nil, ErrPathNotFound
 	}
 
 	// 経路の復元
@@ -112,10 +111,10 @@ func (g *Graph) FindShortestPathGisei(startID, endID int) (*PathResult, error) {
 // これにより、分割購入で安くなる可能性がある経路を網羅します。
 func (g *Graph) FindAllCandidatePaths(startID, endID int, maxGisei domain.DeciKilo) ([]*PathResult, error) {
 	if startID < 0 || startID >= len(g.IDToName) {
-		return nil, fmt.Errorf("開始駅が見つかりません: ID %d", startID)
+		return nil, fmt.Errorf("FindAllCandidatePaths: %w: ID %d", domain.ErrStationNotFound, startID)
 	}
 	if endID < 0 || endID >= len(g.IDToName) {
-		return nil, fmt.Errorf("目的駅が見つかりません: ID %d", endID)
+		return nil, fmt.Errorf("FindAllCandidatePaths: %w: ID %d", domain.ErrStationNotFound, endID)
 	}
 
 	var results []*PathResult
@@ -164,7 +163,7 @@ func (g *Graph) FindAllCandidatePaths(startID, endID int, maxGisei domain.DeciKi
 	dfs(startID, 0, 0)
 
 	if len(results) == 0 {
-		return nil, errors.New("候補経路が見つかりませんでした")
+		return nil, ErrNoCandidatePaths
 	}
 
 	return results, nil

--- a/split-pass-api/internal/graph/errors.go
+++ b/split-pass-api/internal/graph/errors.go
@@ -1,0 +1,17 @@
+package graph
+
+import "errors"
+
+var (
+	// ErrPathNotFound は、目的地までの経路が見つからない場合のエラーです。
+	ErrPathNotFound = errors.New("経路が見つかりませんでした")
+
+	// ErrNoCandidatePaths は、候補となる経路が一つも見つからない場合のエラーです。
+	ErrNoCandidatePaths = errors.New("候補経路が見つかりませんでした")
+
+	// ErrEdgeNotFound は、指定された駅間に直接の接続がない場合のエラーです。
+	ErrEdgeNotFound = errors.New("駅間に直接のエッジがありません")
+
+	// ErrInvalidGraph は、グラフの内部状態が不正な場合のエラーです。
+	ErrInvalidGraph = errors.New("グラフの内部状態が不正です（空またはnil）")
+)

--- a/split-pass-api/internal/graph/validate.go
+++ b/split-pass-api/internal/graph/validate.go
@@ -1,9 +1,5 @@
 package graph
 
-import "errors"
-
-var ErrInvalidGraph = errors.New("グラフの内部状態が不正です（空またはnil）")
-
 // Validate はグラフの内部状態が正常であることを検証します。
 // gobデシリアライズ後などにnilスライス・nilマップが残っていないかを確認します。
 func (g *Graph) Validate() error {

--- a/split-pass-api/internal/infra/fareio/json.go
+++ b/split-pass-api/internal/infra/fareio/json.go
@@ -44,7 +44,7 @@ func (l *RouteAndFareJSONLoader) Load(path string) ([]domain.RouteAndFare, error
 	data := make([]domain.RouteAndFare, 0, len(rawData))
 	for _, raw := range rawData {
 		if len(raw.Route) < 2 {
-			return nil, fmt.Errorf("fareio: 経路には少なくとも2つの駅が必要です（不正なデータ: %v）", raw.Route)
+			return nil, fmt.Errorf("fareio: %w (不正なデータ: %v)", domain.ErrInvalidPath, raw.Route)
 		}
 
 		data = append(data, domain.RouteAndFare{

--- a/split-pass-api/internal/optimizer/dp.go
+++ b/split-pass-api/internal/optimizer/dp.go
@@ -1,17 +1,10 @@
 package optimizer
 
 import (
-	"errors"
 	"fmt"
 	"math"
+	"split-pass-api/internal/domain"
 	"split-pass-api/internal/usecase"
-)
-
-var (
-	// ErrInvalidPathLength は、経路として指定された駅数が足りない場合のエラーです。
-	ErrInvalidPathLength = errors.New("経路には少なくとも2つの駅が必要です")
-	// ErrNoValidPattern は、有効な分割パターンが見つからなかった場合のエラーです。
-	ErrNoValidPattern = errors.New("有効な分割パターンが見つかりませんでした")
 )
 
 // DPOptimizer は、1次元動的計画法 (DP) を使用して最適な経路分割を探索するアルゴリズムクラスです。
@@ -30,7 +23,7 @@ func NewDPOptimizer[T usecase.EvaluationResult](evaluator usecase.RouteEvaluator
 func (o *DPOptimizer[T]) Optimize(path []int, months int) ([]usecase.OptimizedPath[T], error) {
 	n := len(path)
 	if n < 2 {
-		return nil, ErrInvalidPathLength
+		return nil, fmt.Errorf("DPOptimizer.Optimize: %w", domain.ErrInvalidPath)
 	}
 
 	cache := make([]T, n*n)

--- a/split-pass-api/internal/optimizer/errors.go
+++ b/split-pass-api/internal/optimizer/errors.go
@@ -1,0 +1,8 @@
+package optimizer
+
+import "errors"
+
+var (
+	// ErrNoValidPattern は、有効な分割パターンが見つからなかった場合のエラーです。
+	ErrNoValidPattern = errors.New("有効な分割パターンが見つかりませんでした")
+)

--- a/split-pass-api/internal/usecase/calculate_amount_usecase.go
+++ b/split-pass-api/internal/usecase/calculate_amount_usecase.go
@@ -1,11 +1,13 @@
 package usecase
 
 import (
-	"errors"
 	"fmt"
 	"split-pass-api/internal/domain"
 	"split-pass-api/internal/fare"
 	"split-pass-api/internal/graph"
+)
+
+var (
 )
 
 // CalculateAmountUseCase は経路から定期運賃を計算するユースケースです。
@@ -88,7 +90,7 @@ func (u *CalculateAmountUseCase) analyzeRoute(path []int) (*routeSummary, error)
 			}
 		}
 		if edge == nil {
-			return nil, fmt.Errorf("駅間に直接のエッジがありません: ID %d -> ID %d", fromID, toID)
+			return nil, fmt.Errorf("analyzeRoute: %w: ID %d -> ID %d", graph.ErrEdgeNotFound, fromID, toID)
 		}
 		summary.edges = append(summary.edges, edge)
 
@@ -104,7 +106,7 @@ func (u *CalculateAmountUseCase) analyzeRoute(path []int) (*routeSummary, error)
 		// 会社別集計
 		cID := edge.Company
 		if int(cID) < 0 || int(cID) >= len(summary.statsByCompany) {
-			return nil, fmt.Errorf("未知の会社ID: %d", cID)
+			return nil, fmt.Errorf("analyzeRoute: %w: %d", domain.ErrUnknownCompany, cID)
 		}
 		summary.statsByCompany[cID].used = true
 		summary.statsByCompany[cID].eigyo += edge.EigyoKilo
@@ -122,7 +124,7 @@ func (u *CalculateAmountUseCase) analyzeRoute(path []int) (*routeSummary, error)
 // Execute は経路（駅IDの配列）を入力として受け取り、正しい定期運賃を返します。
 func (u *CalculateAmountUseCase) Execute(path []int, months int) (*CalculationResult, error) {
 	if len(path) < 2 {
-		return nil, errors.New("経路には少なくとも2つの駅が必要です")
+		return nil, fmt.Errorf("CalculateAmountUseCase.Execute: %w", domain.ErrInvalidPath)
 	}
 
 	// 経路情報の集計


### PR DESCRIPTION
## 概要
Closed #260 

呼び出し元でエラーを安全に判定し、APIのレスポンスコード（404 Not Found等）へ適切にマッピングできるようにするため、ハードコードされていた文字列エラーを Sentinel Error（パッケージ定義変数）にリファクタリングしました。

## 変更内容
- `ErrNoCandidatePaths`（候補経路が見つかりませんでした）などの判定必須なエラーを `var` として定義。
- 対象箇所における `errors.New` の直接生成を削除し、定義したエラー変数の返却に統一。

## 品質向上のための設計判断
本PRでは「むやみに全てのエラーを変数化する」ことは避け、**「呼び出し元が処理を分岐させる必要があるか」** を基準に抽出を行っています。
また、複数の機能から参照される可能性のある汎用的なドメインエラーについては、特定のユースケースパッケージ内ではなく、共通参照可能な場所へ配置するよう配慮しています。

## 注意事項
- **過剰設計のチェック:** 変数化されたエラーは、本当に呼び出し元で区別する必要があるものか（単なるログ出力用エラーまで変数化されていないか）。
- **レイヤーの妥当性:** エラー変数の定義場所（パッケージ）は、依存関係の観点から適切か。
- **エラーの握りつぶし:** もし背後に根本原因がある箇所で、`%w` によるラップを忘れて元のエラー情報を消失させている箇所はないか。

## 影響範囲
- エラーの返却方法および判定方法の修正のみであり、正常系のビジネスロジックには影響しません。既存のテストがすべてパスすることを確認済みです。