### PR TITLE
test: 実際の駅マスターデータを用いた運賃計算および分割最適化の結合テスト追加

### DIFF
--- a/split-pass-api/tests/integration/amount_test.go
+++ b/split-pass-api/tests/integration/amount_test.go
@@ -1,0 +1,183 @@
+package integration_test
+
+import (
+	"split-pass-api/internal/domain"
+	"split-pass-api/internal/graph"
+	"split-pass-api/internal/graph/data"
+	"split-pass-api/internal/infra/fareio"
+	"split-pass-api/internal/infra/graphio"
+	"split-pass-api/internal/usecase"
+	"testing"
+)
+
+// setupUseCase はテスト用に本番データを含むユースケースを初期化します。
+func setupUseCase(t *testing.T) (*usecase.CalculateAmountUseCase, *graph.Graph) {
+	t.Helper()
+
+	// 1. グラフのロード
+	loader := &graphio.JSONLoader{}
+	g, err := loader.Load(data.GetEdgesReader())
+	if err != nil {
+		t.Fatalf("データのロードに失敗しました: %v", err)
+	}
+
+	// 2. 運賃計算レジストリの初期化
+	calcs, err := fareio.InitRegistry(g)
+	if err != nil {
+		t.Fatalf("運賃計算レジストリの初期化に失敗しました: %v", err)
+	}
+
+	// 3. 加算運賃の登録（本番の main.go と同様の設定）
+	addonFareReg := domain.NewAddonRegistry()
+	addonFareReg.Register("南千歳", "新千歳空港", domain.PassPrice{OneMonth: 660, ThreeMonth: 1880, SixMonth: 3180})
+	addonFareReg.Register("日根野", "りんくうタウン", domain.PassPrice{OneMonth: 4690, ThreeMonth: 13320, SixMonth: 22440})
+	addonFareReg.Register("日根野", "関西空港", domain.PassPrice{OneMonth: 6640, ThreeMonth: 18900, SixMonth: 31820})
+	addonFareReg.Register("りんくうタウン", "関西空港", domain.PassPrice{OneMonth: 5010, ThreeMonth: 14250, SixMonth: 24000})
+	addonFareReg.Register("児島", "宇多津", domain.PassPrice{OneMonth: 1610, ThreeMonth: 4600, SixMonth: 8170})
+	addonFareReg.Register("田吉", "宮崎空港", domain.PassPrice{OneMonth: 3840, ThreeMonth: 10960, SixMonth: 18680})
+
+	// 4. 加算料金の登録
+	addonChargeReg := domain.NewAddonRegistry()
+	addonChargeReg.Register("博多", "博多南", domain.PassPrice{OneMonth: 4680, ThreeMonth: 13340, SixMonth: 25270})
+
+	// 5. ID解決
+	if err := addonFareReg.ResolveIDs(func(name string) (int, bool) {
+		id, ok := g.NameToID[name]
+		return id, ok
+	}); err != nil {
+		t.Fatalf("加算運賃のID解決に失敗しました: %v", err)
+	}
+
+	if err := addonChargeReg.ResolveIDs(func(name string) (int, bool) {
+		id, ok := g.NameToID[name]
+		return id, ok
+	}); err != nil {
+		t.Fatalf("加算料金のID解決に失敗しました: %v", err)
+	}
+
+	u := usecase.NewCalculateAmountUseCase(
+		g,
+		calcs.Registry,
+		addonFareReg,
+		addonChargeReg,
+		calcs.TrainSpecific,
+		calcs.SpecificRoute,
+		calcs.AdjustedRoute,
+	)
+	return u, g
+}
+
+func TestAmountCalculation_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("統合テストをスキップします")
+	}
+
+	u, g := setupUseCase(t)
+
+	// 駅名からIDを取得するヘルパー
+	getIDs := func(names ...string) []int {
+		ids := make([]int, len(names))
+		for i, name := range names {
+			id, ok := g.NameToID[name]
+			if !ok {
+				t.Fatalf("駅名が見つかりません: %s", name)
+			}
+			ids[i] = id
+		}
+		return ids
+	}
+
+	tests := []struct {
+		name    string
+		path    []int
+		months  int
+		want    usecase.CalculationResult
+		wantErr bool
+	}{
+		{
+			name:   "東京〜新宿（中央線経由）",
+			path:   getIDs("東京", "神田", "御茶ノ水", "水道橋", "飯田橋", "市ケ谷", "四ツ谷", "信濃町", "千駄ケ谷", "代々木", "新宿"),
+			months: 1,
+			want: usecase.CalculationResult{
+				// 営業キロ 10.3km -> 11km (電車特定区間運賃)
+				Fare:           7840, // 運賃
+				BarrierFreeFee: 0,
+				Charge:         0,
+			},
+		},
+		{
+			name:   "大阪〜新大阪（営業キロ基準）",
+			path:   getIDs("大阪", "新大阪"),
+			months: 1,
+			want: usecase.CalculationResult{
+				// 営業キロ 3.8km -> 4km
+				Fare:           5020,
+				BarrierFreeFee: 300, // 電車特定区間はバリアフリー料金対象
+				Charge:         0,
+			},
+		},
+		{
+			name:   "南千歳〜新千歳空港（加算運賃の適用）",
+			path:   getIDs("南千歳", "新千歳空港"),
+			months: 1,
+			want: usecase.CalculationResult{
+				// 加算運賃 660 + JR北海道幹線 3km(7690)
+				Fare:           8350,
+				BarrierFreeFee: 0,
+				Charge:         0,
+			},
+		},
+		{
+			name:   "東京〜品川（東海道線）",
+			path:   getIDs("東京", "有楽町", "新橋", "浜松町", "田町", "高輪ゲートウェイ", "品川"),
+			months: 1,
+			want: usecase.CalculationResult{
+				// 営業キロ 6.8km -> 7km
+				Fare:           6240,
+				BarrierFreeFee: 0,
+				Charge:         0,
+			},
+		},
+		{
+			name:   "日根野〜関西空港（加算運賃の重複適用防止の検証）",
+			path:   getIDs("日根野", "りんくうタウン", "関西空港"),
+			months: 1,
+			want: usecase.CalculationResult{
+				// 電車特定区間 12km (6990) + 日根野-関空加算 (6640)
+				Fare:           13330,
+				BarrierFreeFee: 300,
+				Charge:         0,
+			},
+		},
+		{
+			name:   "博多南～南福岡（特急料金の適用検証）",
+			path:   getIDs("博多南", "博多", "竹下", "笹原", "南福岡"),
+			months: 6,
+			want: usecase.CalculationResult{
+				// 15.2 -> 16km 運賃 6か月(47520 + (45650 - 28520)) + 特急料金 6か月 (25270)
+				Fare:           64650,
+				BarrierFreeFee: 0,
+				Charge:         25270,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := u.Execute(tt.path, tt.months)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Execute() エラー = %v, 期待されるエラー発生 = %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if got == nil {
+					t.Errorf("Execute() = nil, 期待値 %v", tt.want)
+					return
+				}
+				if *got != tt.want {
+					t.Errorf("Execute() = %v, 期待値 %v", *got, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/split-pass-api/tests/integration/cheapest_split_amount_test.go
+++ b/split-pass-api/tests/integration/cheapest_split_amount_test.go
@@ -1,0 +1,141 @@
+package integration_test
+
+import (
+	"split-pass-api/internal/domain"
+	"split-pass-api/internal/graph/data"
+	"split-pass-api/internal/infra/fareio"
+	"split-pass-api/internal/infra/graphio"
+	"split-pass-api/internal/optimizer"
+	"split-pass-api/internal/usecase"
+	"testing"
+)
+
+func TestSearchOptimalSplitUseCase_Integration(t *testing.T) {
+	// 1. 環境構築 (main.go と同様のセットアップ)
+	loader := &graphio.JSONLoader{}
+	g, err := loader.Load(data.GetEdgesReader())
+	if err != nil {
+		t.Fatalf("グラフの読み込みに失敗: %v", err)
+	}
+
+	calcs, err := fareio.InitRegistry(g)
+	if err != nil {
+		t.Fatalf("運賃計算機の初期化に失敗: %v", err)
+	}
+
+	// 特例ルールの設定 (main.go と同様)
+	bypassReg := domain.NewBypassRegistry()
+	bypassReg.Register(
+		[]string{"大沼", "大沼公園", "赤井川", "駒ケ岳", "森"},
+		[]string{"大沼", "鹿部", "渡島沼尻", "渡島砂原", "掛澗", "尾白内", "東森", "森"},
+	)
+	bypassReg.Register(
+		[]string{"日暮里", "西日暮里", "田端", "上中里", "王子", "東十条", "赤羽"},
+		[]string{"日暮里", "尾久", "赤羽"},
+	)
+	bypassReg.Register(
+		[]string{"赤羽", "川口", "西川口", "蕨", "南浦和", "浦和", "北浦和", "与野", "さいたま新都心", "大宮"},
+		[]string{"赤羽", "北赤羽", "浮間舟渡", "戸田公園", "（北）戸田", "北戸田", "武蔵浦和", "中浦和", "南与野", "与野本町", "北与野", "大宮"},
+	)
+	bypassReg.Register(
+		[]string{"品川", "大井町", "大森", "蒲田", "川崎", "鶴見"},
+		[]string{"品川", "西大井", "武蔵小杉", "新川崎", "鶴見"},
+	)
+
+	bypassRules, err := bypassReg.ResolveIDs(func(name string) (int, bool) {
+		id, ok := g.GetID(name)
+		return id, ok
+	})
+	if err != nil {
+		t.Fatalf("特例ルールの解決に失敗: %v", err)
+	}
+
+	// ユースケースの初期化
+	amountUseCase := usecase.NewCalculateAmountUseCase(
+		g, calcs.Registry, domain.NewAddonRegistry(), domain.NewAddonRegistry(),
+		calcs.TrainSpecific, calcs.SpecificRoute, calcs.AdjustedRoute,
+	)
+	opt := optimizer.NewDPOptimizer(amountUseCase)
+	splitUseCase := usecase.NewFindOptimalSplitUseCase(opt, amountUseCase)
+	searchUseCase := usecase.NewSearchOptimalSplitUseCase(g, splitUseCase, bypassRules)
+
+	// 2. テストケースの実行
+	tests := []struct {
+		name    string
+		from    string
+		to      string
+		months  int
+		want    int
+		wantErr bool
+	}{
+		{
+			name:   "大宮〜東京 (通常の分割検討)",
+			from:   "大宮",
+			to:     "東京",
+			months: 1,
+			want:   17970,
+		},
+		{
+			name:   "日暮里〜赤羽 (通しが最安)",
+			from:   "日暮里",
+			to:     "赤羽",
+			months: 1,
+			want:   6240,
+		},
+		{
+			name:   "横浜〜新宿 (長距離の分割検討)",
+			from:   "横浜",
+			to:     "新宿",
+			months: 3,
+			want:   52200,
+		},
+		{
+			name:   "函館〜東森 (第69条の考慮　片側のみ)",
+			from:   "函館",
+			to:     "東森",
+			months: 6,
+			want:   226080,
+		},
+		{
+			name:   "新川崎〜大井町 (第69条の考慮　特例区間内完結)",
+			from:   "新川崎",
+			to:     "大井町",
+			months: 3,
+			want:   22340,
+		},
+		{
+			name:    "東京〜東京 (同一駅、エラーケース)",
+			from:    "東京",
+			to:      "東京",
+			months:  6,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fromID, ok1 := g.GetID(tt.from)
+			toID, ok2 := g.GetID(tt.to)
+			if !ok1 || !ok2 {
+				t.Fatalf("駅が見つかりません: %s, %s", tt.from, tt.to)
+			}
+
+			results, err := searchUseCase.Execute(fromID, toID, tt.months)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err == nil {
+				if len(results) == 0 {
+					t.Error("結果が空です")
+					return
+				}
+
+				if results[0].TotalAmount != tt.want {
+					t.Errorf("Execute() TotalAmount = %d, want %d", results[0].TotalAmount, tt.want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closed #265 

純粋なロジック層（アルゴリズム）の実装が完了したため、実際の駅マスターや運賃データベースを注入した結合テスト（Integration Test）およびテストを追加しました。

本PRでは、モックを使用せず、本番同等のマスターデータを読み込んだ上で以下のケースを検証しています。
- 単純な営業キロに基づく通し運賃の計算
- 特例区間（第69条）における実キロと計算キロの差異検証
- 経路分割オーケストレータを通した、特定区間の最安値分割パターンの算出（オーバーシュートを含む）