### PR TITLE
refactor: usecaseパッケージ内の冗長なサフィックスを削除し命名規則を統一

### DIFF
--- a/split-pass-api/internal/usecase/calculate_amount.go
+++ b/split-pass-api/internal/usecase/calculate_amount.go
@@ -7,12 +7,11 @@ import (
 	"split-pass-api/internal/graph"
 )
 
-var (
-)
+var ()
 
-// CalculateAmountUseCase は経路から定期運賃を計算するユースケースです。
+// CalculateAmount は経路から定期運賃を計算するユースケースです。
 // グラフ、運賃レジストリ、特定区間加算運賃レジストリを協調させます。
-type CalculateAmountUseCase struct {
+type CalculateAmount struct {
 	graph                    *graph.Graph
 	reg                      *fare.Registry
 	addonFareReg             *domain.AddonRegistry
@@ -22,8 +21,8 @@ type CalculateAmountUseCase struct {
 	adjustedFareRouteMatcher *fare.RouteMatcher
 }
 
-// NewCalculateAmountUseCase は新しい CalculateAmountUseCase を作成します。
-func NewCalculateAmountUseCase(
+// NewCalculateAmount は新しい CalculateAmount を作成します。
+func NewCalculateAmount(
 	g *graph.Graph,
 	reg *fare.Registry,
 	addonFareReg *domain.AddonRegistry,
@@ -31,8 +30,8 @@ func NewCalculateAmountUseCase(
 	trainSpecificCalc *fare.TrainSpecificSectionCalculator,
 	specificFareRouteMatcher *fare.RouteMatcher,
 	adjustedFareRouteMatcher *fare.RouteMatcher,
-) *CalculateAmountUseCase {
-	return &CalculateAmountUseCase{
+) *CalculateAmount {
+	return &CalculateAmount{
 		graph:                    g,
 		reg:                      reg,
 		addonFareReg:             addonFareReg,
@@ -72,7 +71,7 @@ func (r *CalculationResult) TotalAmount() int {
 	return r.Fare + r.BarrierFreeFee + r.Charge
 }
 
-func (u *CalculateAmountUseCase) analyzeRoute(path []int) (*routeSummary, error) {
+func (u *CalculateAmount) analyzeRoute(path []int) (*routeSummary, error) {
 	summary := &routeSummary{
 		edges: make([]*domain.Edge, 0, len(path)-1),
 	}
@@ -122,9 +121,9 @@ func (u *CalculateAmountUseCase) analyzeRoute(path []int) (*routeSummary, error)
 }
 
 // Execute は経路（駅IDの配列）を入力として受け取り、正しい定期運賃を返します。
-func (u *CalculateAmountUseCase) Execute(path []int, months int) (*CalculationResult, error) {
+func (u *CalculateAmount) Execute(path []int, months int) (*CalculationResult, error) {
 	if len(path) < 2 {
-		return nil, fmt.Errorf("CalculateAmountUseCase.Execute: %w", domain.ErrInvalidPath)
+		return nil, fmt.Errorf("CalculateAmount.Execute: %w", domain.ErrInvalidPath)
 	}
 
 	// 経路情報の集計
@@ -217,7 +216,7 @@ func (u *CalculateAmountUseCase) Execute(path []int, months int) (*CalculationRe
 	// 運賃計算パッケージ用のデータに変換
 	totalRouteType, err := domain.DetermineRouteType(summary.hasTrunk, summary.hasLocal)
 	if err != nil {
-		return nil, fmt.Errorf("CalculateAmountUseCase: 全区間のルート種別判定に失敗しました: %w", err)
+		return nil, fmt.Errorf("CalculateAmount: 全区間のルート種別判定に失敗しました: %w", err)
 	}
 
 	components := make([]fare.JointFareComponent, 0, domain.CompanyCount)
@@ -227,7 +226,7 @@ func (u *CalculateAmountUseCase) Execute(path []int, months int) (*CalculationRe
 		}
 		compRouteType, err := domain.DetermineRouteType(summary.statsByCompany[i].hasTrunk, summary.statsByCompany[i].hasLocal)
 		if err != nil {
-			return nil, fmt.Errorf("CalculateAmountUseCase: 会社 %d のルート種別判定に失敗しました: %w", i, err)
+			return nil, fmt.Errorf("CalculateAmount: 会社 %d のルート種別判定に失敗しました: %w", i, err)
 		}
 		components = append(components, fare.JointFareComponent{
 			CompanyID: domain.CompanyID(i),

--- a/split-pass-api/internal/usecase/calculate_amount_test.go
+++ b/split-pass-api/internal/usecase/calculate_amount_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestCalculateAmountUseCase_Execute(t *testing.T) {
+func TestCalculateAmount_Execute(t *testing.T) {
 	g := graph.NewGraph(20)
 
 	// 駅IDの取得を容易にするためのヘルパー
@@ -69,7 +69,7 @@ func TestCalculateAmountUseCase_Execute(t *testing.T) {
 		return id, ok
 	})
 
-	u := usecase.NewCalculateAmountUseCase(
+	u := usecase.NewCalculateAmount(
 		g,
 		reg,
 		addonFareReg,

--- a/split-pass-api/internal/usecase/find_optimal_split.go
+++ b/split-pass-api/internal/usecase/find_optimal_split.go
@@ -50,24 +50,24 @@ type SplitOptimizer[T EvaluationResult] interface {
 	Optimize(path []int, months int, locked []bool) ([]OptimizedPath[T], error)
 }
 
-// FindOptimalSplitUseCase は経路から分割定期券の最安パターンを見つけるユースケースです。
+// FindOptimalSplit は経路から分割定期券の最安パターンを見つけるユースケースです。
 // DPなどの具体的なアルゴリズムは SplitOptimizer に委譲されます。
-type FindOptimalSplitUseCase struct {
-	optimizer   SplitOptimizer[*CalculationResult]
-	calcUseCase *CalculateAmountUseCase
+type FindOptimalSplit struct {
+	optimizer SplitOptimizer[*CalculationResult]
+	calc      *CalculateAmount
 }
 
-// NewFindOptimalSplitUseCase は新しい FindOptimalSplitUseCase を作成します。
-func NewFindOptimalSplitUseCase(opt SplitOptimizer[*CalculationResult], calc *CalculateAmountUseCase) *FindOptimalSplitUseCase {
-	return &FindOptimalSplitUseCase{
-		optimizer:   opt,
-		calcUseCase: calc,
+// NewFindOptimalSplit は新しい FindOptimalSplit を作成します。
+func NewFindOptimalSplit(opt SplitOptimizer[*CalculationResult], calc *CalculateAmount) *FindOptimalSplit {
+	return &FindOptimalSplit{
+		optimizer: opt,
+		calc:      calc,
 	}
 }
 
 // Execute は指定された経路の全分割パターンを評価し、最安となる分割結果をすべて返します。
 // locked[i] が true の駅インデックスでは分割が禁止されます。
-func (u *FindOptimalSplitUseCase) Execute(path []int, months int, locked []bool) ([]SplitResult, error) {
+func (u *FindOptimalSplit) Execute(path []int, months int, locked []bool) ([]SplitResult, error) {
 	if len(path) < 2 {
 		return nil, fmt.Errorf("findOptimalSplit: 経路には少なくとも2つの駅が必要です")
 	}

--- a/split-pass-api/internal/usecase/find_optimal_split_test.go
+++ b/split-pass-api/internal/usecase/find_optimal_split_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestFindOptimalSplitUseCase_Execute(t *testing.T) {
+func TestFindOptimalSplit_Execute(t *testing.T) {
 	g := graph.NewGraph(20)
 	id := func(name string) int { return g.GetOrAddID(name) }
 
@@ -69,7 +69,7 @@ func TestFindOptimalSplitUseCase_Execute(t *testing.T) {
 	addonFareReg := domain.NewAddonRegistry()
 	addonChargeReg := domain.NewAddonRegistry()
 
-	calcUseCase := usecase.NewCalculateAmountUseCase(
+	calc := usecase.NewCalculateAmount(
 		g,
 		reg,
 		addonFareReg,
@@ -79,8 +79,8 @@ func TestFindOptimalSplitUseCase_Execute(t *testing.T) {
 		fare.NewRouteMatcher(),
 	)
 
-	opt := optimizer.NewDPOptimizer(calcUseCase)
-	findOptimalUseCase := usecase.NewFindOptimalSplitUseCase(opt, calcUseCase)
+	opt := optimizer.NewDPOptimizer(calc)
+	findOptimal := usecase.NewFindOptimalSplit(opt, calc)
 
 	tests := []struct {
 		name    string
@@ -171,7 +171,7 @@ func TestFindOptimalSplitUseCase_Execute(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			locked := make([]bool, len(tt.path))
-			got, err := findOptimalUseCase.Execute(tt.path, tt.months, locked)
+			got, err := findOptimal.Execute(tt.path, tt.months, locked)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -202,7 +202,7 @@ func TestFindOptimalSplitUseCase_Execute(t *testing.T) {
 }
 
 // 複数パターンの最安値が返ることを確認するテスト
-func TestFindOptimalSplitUseCase_Execute_MultipleOptimalPaths(t *testing.T) {
+func TestFindOptimalSplit_Execute_MultipleOptimalPaths(t *testing.T) {
 	g := graph.NewGraph(20)
 	id := func(name string) int { return g.GetOrAddID(name) }
 
@@ -247,18 +247,18 @@ func TestFindOptimalSplitUseCase_Execute_MultipleOptimalPaths(t *testing.T) {
 	addonFareReg := domain.NewAddonRegistry()
 	addonChargeReg := domain.NewAddonRegistry()
 
-	calcUseCase := usecase.NewCalculateAmountUseCase(
+	calc := usecase.NewCalculateAmount(
 		g, reg, addonFareReg, addonChargeReg,
 		fare.NewTrainSpecificSectionCalculator(dummyTable),
 		fare.NewRouteMatcher(), fare.NewRouteMatcher(),
 	)
 
-	opt := optimizer.NewDPOptimizer(calcUseCase)
-	findOptimalUseCase := usecase.NewFindOptimalSplitUseCase(opt, calcUseCase)
+	opt := optimizer.NewDPOptimizer(calc)
+	findOptimal := usecase.NewFindOptimalSplit(opt, calc)
 
 	path := []int{id("A"), id("B"), id("C"), id("D")}
 	locked := make([]bool, len(path))
-	got, err := findOptimalUseCase.Execute(path, 1, locked)
+	got, err := findOptimal.Execute(path, 1, locked)
 	if err != nil {
 		t.Fatalf("Execute() unexpected error: %v", err)
 	}

--- a/split-pass-api/internal/usecase/search_optimal_split.go
+++ b/split-pass-api/internal/usecase/search_optimal_split.go
@@ -21,24 +21,24 @@ type EvaluationTask struct {
 	Segments []RouteSegment
 }
 
-// SearchOptimalSplitUseCase は候補経路の探索・補正・分割最適化を統括するユースケースです。
-type SearchOptimalSplitUseCase struct {
-	graph        *graph.Graph
-	splitUseCase *FindOptimalSplitUseCase
-	rules        []domain.ResolvedBypassRule
+// SearchOptimalSplit は候補経路の探索・補正・分割最適化を統括するユースケースです。
+type SearchOptimalSplit struct {
+	graph *graph.Graph
+	split *FindOptimalSplit
+	rules []domain.ResolvedBypassRule
 }
 
-// NewSearchOptimalSplitUseCase は新しい SearchOptimalSplitUseCase を作成します。
-func NewSearchOptimalSplitUseCase(g *graph.Graph, u *FindOptimalSplitUseCase, rules []domain.ResolvedBypassRule) *SearchOptimalSplitUseCase {
+// NewSearchOptimalSplit は新しい SearchOptimalSplit を作成します。
+func NewSearchOptimalSplit(g *graph.Graph, u *FindOptimalSplit, rules []domain.ResolvedBypassRule) *SearchOptimalSplit {
 	// サーバー起動時に1回だけ、衝突のない安全な双方向ルールを生成・保持する
-	return &SearchOptimalSplitUseCase{
-		graph:        g,
-		splitUseCase: u,
-		rules:        makeUniqueBidirectionalRules(rules),
+	return &SearchOptimalSplit{
+		graph: g,
+		split: u,
+		rules: makeUniqueBidirectionalRules(rules),
 	}
 }
 
-func (u *SearchOptimalSplitUseCase) Execute(startID, endID, months int) ([]SplitResult, error) {
+func (u *SearchOptimalSplit) Execute(startID, endID, months int) ([]SplitResult, error) {
 	candidatePathResults, err := u.getCandidatePaths(startID, endID)
 	if err != nil {
 		return nil, err
@@ -59,7 +59,7 @@ func (u *SearchOptimalSplitUseCase) Execute(startID, endID, months int) ([]Split
 	return u.filterGlobalOptimal(allPatterns), nil
 }
 
-func (u *SearchOptimalSplitUseCase) getCandidatePaths(startID, endID int) ([]*graph.PathResult, error) {
+func (u *SearchOptimalSplit) getCandidatePaths(startID, endID int) ([]*graph.PathResult, error) {
 	shortest, err := u.graph.FindShortestPathGisei(startID, endID)
 	if err != nil {
 		return nil, fmt.Errorf("searchOptimalSplit: 最短経路の検索に失敗: %w", err)
@@ -73,7 +73,7 @@ func (u *SearchOptimalSplitUseCase) getCandidatePaths(startID, endID int) ([]*gr
 	return candidates, nil
 }
 
-func (u *SearchOptimalSplitUseCase) generateTasks(paths [][]int, rules []domain.ResolvedBypassRule) []EvaluationTask {
+func (u *SearchOptimalSplit) generateTasks(paths [][]int, rules []domain.ResolvedBypassRule) []EvaluationTask {
 	var tasks []EvaluationTask
 
 	for _, path := range paths {
@@ -141,7 +141,7 @@ func (u *SearchOptimalSplitUseCase) generateTasks(paths [][]int, rules []domain.
 }
 
 // buildOvershootPath は発着駅が遠回り上にある場合、分岐駅まで延長した経路と locked を生成します（分岐2用）。
-func (u *SearchOptimalSplitUseCase) buildOvershootPath(path []int, locked []bool, rule domain.ResolvedBypassRule) ([]int, []bool) {
+func (u *SearchOptimalSplit) buildOvershootPath(path []int, locked []bool, rule domain.ResolvedBypassRule) ([]int, []bool) {
 	// 始点のオーバーシュート判定
 	for i := 1; i < len(rule.DetourPath)-1; i++ {
 		suffix := rule.DetourPath[i:]
@@ -183,7 +183,7 @@ func (u *SearchOptimalSplitUseCase) buildOvershootPath(path []int, locked []bool
 }
 
 // expandPath は経路内の遠回り区間を再帰的に展開し、強制分割の全組み合わせを返します（分岐2用）。
-func (u *SearchOptimalSplitUseCase) expandPath(path []int, locked []bool, rules []domain.ResolvedBypassRule) [][]RouteSegment {
+func (u *SearchOptimalSplit) expandPath(path []int, locked []bool, rules []domain.ResolvedBypassRule) [][]RouteSegment {
 	for _, rule := range rules {
 		startIdx, _ := u.findSubPath(path, rule.DetourPath)
 		if startIdx == -1 {
@@ -233,7 +233,7 @@ func (u *SearchOptimalSplitUseCase) expandPath(path []int, locked []bool, rules 
 	return [][]RouteSegment{{{Path: path, Locked: locked}}}
 }
 
-func (u *SearchOptimalSplitUseCase) evaluateTasks(tasks []EvaluationTask, months int) ([]SplitResult, error) {
+func (u *SearchOptimalSplit) evaluateTasks(tasks []EvaluationTask, months int) ([]SplitResult, error) {
 	var allPatterns []SplitResult
 
 	for _, task := range tasks {
@@ -242,7 +242,7 @@ func (u *SearchOptimalSplitUseCase) evaluateTasks(tasks []EvaluationTask, months
 		isValidTask := true
 
 		for _, seg := range task.Segments {
-			results, err := u.splitUseCase.Execute(seg.Path, months, seg.Locked)
+			results, err := u.split.Execute(seg.Path, months, seg.Locked)
 			if err != nil || len(results) == 0 {
 				isValidTask = false
 				break
@@ -266,7 +266,7 @@ func (u *SearchOptimalSplitUseCase) evaluateTasks(tasks []EvaluationTask, months
 	return allPatterns, nil
 }
 
-func (u *SearchOptimalSplitUseCase) filterGlobalOptimal(patterns []SplitResult) []SplitResult {
+func (u *SearchOptimalSplit) filterGlobalOptimal(patterns []SplitResult) []SplitResult {
 	if len(patterns) == 0 {
 		return nil
 	}
@@ -286,7 +286,7 @@ func (u *SearchOptimalSplitUseCase) filterGlobalOptimal(patterns []SplitResult) 
 }
 
 // isEntirelyOnRule は経路の全駅が特例の近道・遠回りのいずれかに含まれているかを判定します（分岐1用）。
-func (u *SearchOptimalSplitUseCase) isEntirelyOnRule(path []int, rule domain.ResolvedBypassRule) bool {
+func (u *SearchOptimalSplit) isEntirelyOnRule(path []int, rule domain.ResolvedBypassRule) bool {
 	for _, stationID := range path {
 		if !u.containsStation(rule.ShortcutPath, stationID) && !u.containsStation(rule.DetourPath, stationID) {
 			return false
@@ -296,7 +296,7 @@ func (u *SearchOptimalSplitUseCase) isEntirelyOnRule(path []int, rule domain.Res
 }
 
 // isOnDetourMiddle は駅IDが遠回りルールの中間駅（分岐駅を除く）に含まれるかを返します。
-func (u *SearchOptimalSplitUseCase) isOnDetourMiddle(stationID int, rule domain.ResolvedBypassRule) bool {
+func (u *SearchOptimalSplit) isOnDetourMiddle(stationID int, rule domain.ResolvedBypassRule) bool {
 	for i := 1; i < len(rule.DetourPath)-1; i++ {
 		if rule.DetourPath[i] == stationID {
 			return true
@@ -306,7 +306,7 @@ func (u *SearchOptimalSplitUseCase) isOnDetourMiddle(stationID int, rule domain.
 }
 
 // containsStation は経路内に指定の駅IDが含まれるかを返します。
-func (u *SearchOptimalSplitUseCase) containsStation(path []int, stationID int) bool {
+func (u *SearchOptimalSplit) containsStation(path []int, stationID int) bool {
 	for _, id := range path {
 		if id == stationID {
 			return true
@@ -316,7 +316,7 @@ func (u *SearchOptimalSplitUseCase) containsStation(path []int, stationID int) b
 }
 
 // indexOf はスライス内の要素のインデックスを返します。見つからない場合は -1 を返します。
-func (u *SearchOptimalSplitUseCase) indexOf(path []int, stationID int) int {
+func (u *SearchOptimalSplit) indexOf(path []int, stationID int) int {
 	for i, id := range path {
 		if id == stationID {
 			return i
@@ -335,7 +335,7 @@ func makeShortcutLocked(shortcutPath []int) []bool {
 }
 
 // findSubPath は2つのスライス間の部分一致を検索し、開始インデックスと終了インデックスを返します。見つからない場合は (-1, -1) を返します。
-func (u *SearchOptimalSplitUseCase) findSubPath(a, b []int) (int, int) {
+func (u *SearchOptimalSplit) findSubPath(a, b []int) (int, int) {
 	if len(b) == 0 || len(a) < len(b) {
 		return -1, -1
 	}
@@ -347,7 +347,7 @@ func (u *SearchOptimalSplitUseCase) findSubPath(a, b []int) (int, int) {
 	return -1, -1
 }
 
-func (u *SearchOptimalSplitUseCase) isMatch(a, b []int) bool {
+func (u *SearchOptimalSplit) isMatch(a, b []int) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/split-pass-api/internal/usecase/search_optimal_split_test.go
+++ b/split-pass-api/internal/usecase/search_optimal_split_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func TestSearchOptimalSplitUseCase_Execute(t *testing.T) {
+func TestSearchOptimalSplit_Execute(t *testing.T) {
 	g := graph.NewGraph(20)
 	id := func(name string) int { return g.GetOrAddID(name) }
 
@@ -36,20 +36,20 @@ func TestSearchOptimalSplitUseCase_Execute(t *testing.T) {
 	reg.Register(domain.JREast, fare.NewEastCalculator(dummyTable, dummyTable))
 	reg.Register(domain.JRCentral, fare.NewStandardCalculator(dummyTable, dummyTable))
 
-	calcAmountUseCase := usecase.NewCalculateAmountUseCase(
+	calcAmount := usecase.NewCalculateAmount(
 		g, reg, domain.NewAddonRegistry(), domain.NewAddonRegistry(),
 		fare.NewTrainSpecificSectionCalculator(dummyTable),
 		fare.NewRouteMatcher(), fare.NewRouteMatcher(),
 	)
 
-	splitUseCase := usecase.NewFindOptimalSplitUseCase(optimizer.NewDPOptimizer(calcAmountUseCase), calcAmountUseCase)
+	split := usecase.NewFindOptimalSplit(optimizer.NewDPOptimizer(calcAmount), calcAmount)
 
 	t.Run("特例ルールなし: 最短経路(A-B-C)内の分割が最安になるケース", func(t *testing.T) {
-		searchUseCase := usecase.NewSearchOptimalSplitUseCase(g, splitUseCase, nil)
+		search := usecase.NewSearchOptimalSplit(g, split, nil)
 		// A-B-C (20km): 通し=2500, 分割(A-B, B-C)=1000+1000=2000
 		// A-C (21km): 通し=3000
 		// 特例なしの場合、最安は 2000
-		got, err := searchUseCase.Execute(id("A"), id("C"), 1)
+		got, err := search.Execute(id("A"), id("C"), 1)
 		if err != nil {
 			t.Fatalf("Execute が失敗しました: %v", err)
 		}
@@ -74,14 +74,14 @@ func TestSearchOptimalSplitUseCase_Execute(t *testing.T) {
 				DetourPath:   []int{id("A"), id("C")},
 			},
 		}
-		searchUseCase := usecase.NewSearchOptimalSplitUseCase(g, splitUseCase, rules)
+		search := usecase.NewSearchOptimalSplit(g, split, rules)
 
 		// DからC(遠回り端点)を検索する。
 		// DFSは [D, A, C] を出力するはず。
 		// オーケストレーターは C が遠回りの端点だと検知し、近道の分岐駅(Cの本来の到着点)まで
 		// ルートを [D, A, B, C] に置換・補正（オーバーシュート）する。
 		// さらに、近道中間駅 B には locked が掛かり分割禁止となる。
-		got, err := searchUseCase.Execute(id("D"), id("C"), 1)
+		got, err := search.Execute(id("D"), id("C"), 1)
 		if err != nil {
 			t.Fatalf("Execute が失敗しました: %v", err)
 		}
@@ -98,8 +98,8 @@ func TestSearchOptimalSplitUseCase_Execute(t *testing.T) {
 	})
 
 	t.Run("異常系：存在しない駅", func(t *testing.T) {
-		searchUseCase := usecase.NewSearchOptimalSplitUseCase(g, splitUseCase, nil)
-		_, err := searchUseCase.Execute(-1, 99, 1)
+		search := usecase.NewSearchOptimalSplit(g, split, nil)
+		_, err := search.Execute(-1, 99, 1)
 		if err == nil {
 			t.Error("無効な駅IDに対するエラーが期待されますが、nilを取得しました")
 		}

--- a/split-pass-api/tests/integration/amount_test.go
+++ b/split-pass-api/tests/integration/amount_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 )
 
-// setupUseCase はテスト用に本番データを含むユースケースを初期化します。
-func setupUseCase(t *testing.T) (*usecase.CalculateAmountUseCase, *graph.Graph) {
+// setup はテスト用に本番データを含むユースケースを初期化します。
+func setup(t *testing.T) (*usecase.CalculateAmount, *graph.Graph) {
 	t.Helper()
 
 	// 1. グラフのロード
@@ -55,7 +55,7 @@ func setupUseCase(t *testing.T) (*usecase.CalculateAmountUseCase, *graph.Graph) 
 		t.Fatalf("加算料金のID解決に失敗しました: %v", err)
 	}
 
-	u := usecase.NewCalculateAmountUseCase(
+	u := usecase.NewCalculateAmount(
 		g,
 		calcs.Registry,
 		addonFareReg,
@@ -72,7 +72,7 @@ func TestAmountCalculation_Integration(t *testing.T) {
 		t.Skip("統合テストをスキップします")
 	}
 
-	u, g := setupUseCase(t)
+	u, g := setup(t)
 
 	// 駅名からIDを取得するヘルパー
 	getIDs := func(names ...string) []int {

--- a/split-pass-api/tests/integration/cheapest_split_amount_test.go
+++ b/split-pass-api/tests/integration/cheapest_split_amount_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestSearchOptimalSplitUseCase_Integration(t *testing.T) {
+func TestSearchOptimalSplit_Integration(t *testing.T) {
 	// 1. 環境構築 (main.go と同様のセットアップ)
 	loader := &graphio.JSONLoader{}
 	g, err := loader.Load(data.GetEdgesReader())
@@ -51,13 +51,13 @@ func TestSearchOptimalSplitUseCase_Integration(t *testing.T) {
 	}
 
 	// ユースケースの初期化
-	amountUseCase := usecase.NewCalculateAmountUseCase(
+	amount := usecase.NewCalculateAmount(
 		g, calcs.Registry, domain.NewAddonRegistry(), domain.NewAddonRegistry(),
 		calcs.TrainSpecific, calcs.SpecificRoute, calcs.AdjustedRoute,
 	)
-	opt := optimizer.NewDPOptimizer(amountUseCase)
-	splitUseCase := usecase.NewFindOptimalSplitUseCase(opt, amountUseCase)
-	searchUseCase := usecase.NewSearchOptimalSplitUseCase(g, splitUseCase, bypassRules)
+	opt := optimizer.NewDPOptimizer(amount)
+	split := usecase.NewFindOptimalSplit(opt, amount)
+	search := usecase.NewSearchOptimalSplit(g, split, bypassRules)
 
 	// 2. テストケースの実行
 	tests := []struct {
@@ -120,7 +120,7 @@ func TestSearchOptimalSplitUseCase_Integration(t *testing.T) {
 				t.Fatalf("駅が見つかりません: %s, %s", tt.from, tt.to)
 			}
 
-			results, err := searchUseCase.Execute(fromID, toID, tt.months)
+			results, err := search.Execute(fromID, toID, tt.months)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Execute() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Closed #267 

## 概要
Go言語の標準的な命名規則（Effective GoにおけるStutteringの回避）に準拠するため、`usecase` パッケージの全体的なリネームを実施しました。本PRにはロジックの変更（機能追加やバグ修正）は一切含まれていません。

## 変更内容
- `usecase` パッケージ内の構造体およびコンストラクタから `UseCase` サフィックスを削除（例: `FindOptimalSplitUseCase` -> `FindOptimalSplit`）。
- 依存する外部パッケージ（`main.go` や `handler` 階層）での呼び出し箇所を新しい命名に合わせて更新。

## レビュー時の注意点
- 純粋なリネームと参照元の更新のみを行っているため、テストコードの挙動やビジネスロジックへの影響はありません。