### PR TITLE
feat: 定期券印字用アルゴリズムの追加と宣言的ルールエンジンの導入

### DIFF
--- a/split-pass-api/internal/usecase/via.go
+++ b/split-pass-api/internal/usecase/via.go
@@ -1,0 +1,272 @@
+package usecase
+
+import (
+	"split-pass-api/internal/graph"
+)
+
+// viaBypassRule は経由印字のための特例区間ルールを定義します。
+type viaBypassRule struct {
+	Pattern     []string // 特例としてマッチさせる駅の並び
+	Vias        []string // 追加する経由名
+	EvaluateEnd bool     // 💡 true: 終端駅を次のループで評価(第69条), false: 終端駅もスキップ(東京近郊)
+
+	// 前の駅の条件
+	AnyPrev     bool     // trueなら前の駅を問わない
+	PrevAllowed []string // AnyPrevがfalseの場合、ここに列挙された駅のみ許可
+
+	// 次の駅の条件
+	AnyNext     bool     // trueなら次の駅を問わない
+	NextAllowed []string // AnyNextがfalseの場合、ここに列挙された駅のみ許可
+}
+
+// ドメイン知識（ルール）を宣言的に定義
+var viaRules = []viaBypassRule{
+	// ==========================================
+	// 第69条 経路特定区間 (EvaluateEnd = true)
+	// ==========================================
+	// (1) 大沼〜森
+	{
+		Pattern: []string{"大沼", "大沼公園", "赤井川", "駒ケ岳", "森"}, Vias: []string{"函館線"}, EvaluateEnd: true,
+		PrevAllowed: []string{"新函館北斗"}, NextAllowed: []string{"石倉"},
+	},
+	{
+		Pattern: []string{"森", "駒ケ岳", "赤井川", "大沼公園", "大沼"}, Vias: []string{"函館線"}, EvaluateEnd: true,
+		PrevAllowed: []string{"石倉"}, NextAllowed: []string{"新函館北斗"},
+	},
+	// (2) 日暮里〜赤羽
+	{
+		Pattern: []string{"日暮里", "西日暮里", "田端", "上中里", "王子", "東十条", "赤羽"}, Vias: []string{"王子", "尾久"}, EvaluateEnd: true,
+		PrevAllowed: []string{"鶯谷", "三河島"}, NextAllowed: []string{"川口", "北赤羽", "十条"},
+	},
+	{
+		Pattern: []string{"赤羽", "東十条", "王子", "上中里", "田端", "西日暮里", "日暮里"}, Vias: []string{"王子", "尾久"}, EvaluateEnd: true,
+		PrevAllowed: []string{"川口", "北赤羽", "十条"}, NextAllowed: []string{"鶯谷", "三河島"},
+	},
+	// (3) 赤羽〜大宮
+	{
+		Pattern: []string{"赤羽", "川口", "西川口", "蕨", "南浦和", "浦和", "北浦和", "与野", "さいたま新都心", "大宮"}, Vias: []string{"川口", "北赤羽"}, EvaluateEnd: true,
+		PrevAllowed: []string{"尾久", "東十条", "十条"}, NextAllowed: []string{"土呂", "宮原", "（川）日進"},
+	},
+	{
+		Pattern: []string{"大宮", "さいたま新都心", "与野", "北浦和", "浦和", "南浦和", "蕨", "西川口", "川口", "赤羽"}, Vias: []string{"川口", "北赤羽"}, EvaluateEnd: true,
+		PrevAllowed: []string{"土呂", "宮原", "（川）日進"}, NextAllowed: []string{"尾久", "東十条", "十条"},
+	},
+	// (4) 品川〜鶴見
+	{
+		Pattern: []string{"品川", "大井町", "大森", "蒲田", "川崎", "鶴見"}, Vias: []string{"東海道線"}, EvaluateEnd: true,
+		PrevAllowed: []string{"高輪ゲートウェイ", "大崎"}, NextAllowed: []string{"新子安", "国道", "羽沢横浜国大"},
+	},
+	{
+		Pattern: []string{"鶴見", "川崎", "蒲田", "大森", "大井町", "品川"}, Vias: []string{"東海道線"}, EvaluateEnd: true,
+		PrevAllowed: []string{"新子安", "国道", "羽沢横浜国大"}, NextAllowed: []string{"高輪ゲートウェイ", "大崎"},
+	},
+
+	// ==========================================
+	// 東京ー秋葉原ー錦糸町　 (EvaluateEnd = true)
+	// ==========================================
+	// (5)東京～秋葉原
+	{
+		Pattern: []string{"東京", "神田", "秋葉原"}, Vias: []string{"[近]東北"}, EvaluateEnd: true,
+		PrevAllowed: []string{"有楽町", "八丁堀", "新日本橋"}, NextAllowed: []string{"神田", "御茶ノ水"},
+	},
+	{
+		Pattern: []string{"秋葉原", "神田", "東京"}, Vias: []string{"[近]東北"}, EvaluateEnd: true,
+		PrevAllowed: []string{"有楽町", "八丁堀", "新日本橋"}, NextAllowed: []string{"馬喰町", "亀戸"},
+	},
+	// (6)秋葉原～錦糸町
+	{
+		Pattern: []string{"秋葉原", "浅草橋", "両国", "錦糸町"}, Vias: []string{"両国"}, EvaluateEnd: true,
+		PrevAllowed: []string{"神田", "御茶ノ水", "御徒町"}, NextAllowed: []string{"馬喰町", "亀戸"},
+	},
+	{
+		Pattern: []string{"錦糸町", "両国", "浅草橋", "秋葉原"}, Vias: []string{"両国"}, EvaluateEnd: true,
+		PrevAllowed: []string{"馬喰町", "亀戸"}, NextAllowed: []string{"神田", "御茶ノ水", "御徒町"},
+	},
+	// (7)錦糸町～東京
+	{
+		Pattern: []string{"錦糸町", "馬喰町", "新日本橋", "東京"}, Vias: []string{"馬喰町"}, EvaluateEnd: true,
+		PrevAllowed: []string{"両国", "亀戸"}, NextAllowed: []string{"神田", "有楽町", "八丁堀"},
+	},
+	{
+		Pattern: []string{"東京", "新日本橋", "馬喰町", "錦糸町"}, Vias: []string{"馬喰町"}, EvaluateEnd: true,
+		PrevAllowed: []string{"神田", "有楽町", "八丁堀"}, NextAllowed: []string{"両国", "亀戸"},
+	},
+	// (8)神田->東京
+	{
+		Pattern: []string{"神田", "東京"}, Vias: []string{}, EvaluateEnd: true,
+		PrevAllowed: []string{"御茶ノ水", "秋葉原"}, NextAllowed: []string{"有楽町", "八丁堀", "新日本橋"},
+	},
+
+	// ==========================================
+	// 神田ー秋葉原ー御茶ノ水 (EvaluateEnd = false)
+	// ==========================================
+	// (9) 東北 (東京〜秋葉原)
+	{
+		Pattern: []string{"東京", "神田", "秋葉原"}, Vias: []string{"[近]東北"}, EvaluateEnd: false,
+		AnyPrev: true, NextAllowed: []string{"御徒町", "浅草橋"},
+	},
+	{
+		Pattern: []string{"神田", "秋葉原"}, Vias: []string{"[近]東北"}, EvaluateEnd: false,
+		NextAllowed: []string{"御徒町", "浅草橋"}, // i=0 から開始する場合用
+	},
+	{
+		Pattern: []string{"秋葉原", "神田", "東京"}, Vias: []string{"[近]東北"}, EvaluateEnd: false,
+		PrevAllowed: []string{"御徒町", "浅草橋"}, AnyNext: true,
+	},
+	{
+		Pattern: []string{"秋葉原", "神田"}, Vias: []string{"[近]東北"}, EvaluateEnd: false,
+		PrevAllowed: []string{"御徒町", "浅草橋"}, // 終端で終わる場合用
+	},
+	// (10) [近]中央 (東京〜御茶ノ水)
+	{
+		Pattern: []string{"東京", "神田", "御茶ノ水"}, Vias: []string{"[近]中央"}, EvaluateEnd: false,
+		AnyPrev: true, NextAllowed: []string{"水道橋"},
+	},
+	{
+		Pattern: []string{"神田", "御茶ノ水"}, Vias: []string{"[近]中央"}, EvaluateEnd: false,
+		NextAllowed: []string{"水道橋"},
+	},
+	{
+		Pattern: []string{"御茶ノ水", "神田", "東京"}, Vias: []string{"[近]中央"}, EvaluateEnd: false,
+		PrevAllowed: []string{"水道橋"}, AnyNext: true,
+	},
+	{
+		Pattern: []string{"御茶ノ水", "神田"}, Vias: []string{"[近]中央"}, EvaluateEnd: false,
+		PrevAllowed: []string{"水道橋"},
+	},
+	// (11) [近]総武 (浅草橋〜水道橋)
+	{
+		Pattern: []string{"浅草橋", "秋葉原", "御茶ノ水", "水道橋"}, Vias: []string{"[近]総武"}, EvaluateEnd: false,
+		AnyPrev: true, AnyNext: true,
+	},
+	{
+		Pattern: []string{"秋葉原", "御茶ノ水", "水道橋"}, Vias: []string{"[近]総武"}, EvaluateEnd: false,
+		AnyNext: true,
+	},
+	{
+		Pattern: []string{"浅草橋", "秋葉原", "御茶ノ水"}, Vias: []string{"[近]総武"}, EvaluateEnd: false,
+		AnyPrev: true,
+	},
+	{
+		Pattern: []string{"秋葉原", "御茶ノ水"}, Vias: []string{"[近]総武"}, EvaluateEnd: false,
+	},
+	{
+		Pattern: []string{"水道橋", "御茶ノ水", "秋葉原", "浅草橋"}, Vias: []string{"[近]総武"}, EvaluateEnd: false,
+		AnyPrev: true, AnyNext: true,
+	},
+	{
+		Pattern: []string{"御茶ノ水", "秋葉原", "浅草橋"}, Vias: []string{"[近]総武"}, EvaluateEnd: false,
+		AnyNext: true,
+	},
+	{
+		Pattern: []string{"水道橋", "御茶ノ水", "秋葉原"}, Vias: []string{"[近]総武"}, EvaluateEnd: false,
+		AnyPrev: true,
+	},
+	{
+		Pattern: []string{"御茶ノ水", "秋葉原"}, Vias: []string{"[近]総武"}, EvaluateEnd: false,
+	},
+}
+
+// GetVia は経路中の分岐駅の名前リストを返します。
+func GetVia(g *graph.Graph, path []int) []string {
+	if len(path) < 2 {
+		return []string{}
+	}
+
+	stationNameList := make([]string, len(path))
+	for i, stationID := range path {
+		stationNameList[i] = g.IDToName[stationID]
+	}
+
+	var via []string
+
+	for i := 0; i < len(path)-1; i++ {
+		// 1. 特例区間の判定（2駅の場合も i=0 の1回だけここを通過する）
+		if addedVia, skipCount, matched := evaluateBypassViaRules(stationNameList, i); matched {
+			via = append(via, addedVia...)
+			i += skipCount
+			continue
+		}
+
+		if len(path) == 2 {
+			continue
+		}
+
+		// 2. 通常の分岐駅判定（3駅以上の経路でのみ実行される）
+		if len(g.Edges[path[i]]) > 2 {
+			if i < len(path)-2 {
+				via = append(via, stationNameList[i+1])
+			} else {
+				if i > 0 && !(len(g.Edges[path[i-1]]) > 2) {
+					via = append(via, stationNameList[i])
+				} else if i == 0 {
+					via = append(via, stationNameList[i])
+				}
+			}
+		}
+	}
+
+	if len(path) == 2 && len(via) == 0 {
+		return []string{}
+	}
+
+	if len(via) == 0 {
+		via = append(via, stationNameList[1])
+	}
+
+	return via
+}
+
+func evaluateBypassViaRules(path []string, i int) ([]string, int, bool) {
+	for _, rule := range viaRules {
+		if isViaRuleMatch(path, i, rule) {
+			skipCount := 0
+			if rule.EvaluateEnd {
+				skipCount = len(rule.Pattern) - 2
+			} else {
+				skipCount = len(rule.Pattern) - 1
+			}
+			if skipCount < 0 {
+				skipCount = 0
+			}
+			return rule.Vias, skipCount, true
+		}
+	}
+	return nil, 0, false
+}
+
+// isViaRuleMatch は特定のルールが現在のインデックスに合致するかを判定します。
+func isViaRuleMatch(path []string, i int, rule viaBypassRule) bool {
+	if i+len(rule.Pattern) > len(path) {
+		return false
+	}
+	for j, station := range rule.Pattern {
+		if path[i+j] != station {
+			return false
+		}
+	}
+
+	if i > 0 && !rule.AnyPrev {
+		if len(rule.PrevAllowed) == 0 || !containsStationName(rule.PrevAllowed, path[i-1]) {
+			return false
+		}
+	}
+
+	endIdx := i + len(rule.Pattern)
+	if endIdx < len(path) && !rule.AnyNext {
+		if len(rule.NextAllowed) == 0 || !containsStationName(rule.NextAllowed, path[endIdx]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func containsStationName(list []string, item string) bool {
+	for _, s := range list {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}

--- a/split-pass-api/internal/usecase/via_test.go
+++ b/split-pass-api/internal/usecase/via_test.go
@@ -1,0 +1,106 @@
+package usecase_test
+
+import (
+	"reflect"
+	"split-pass-api/internal/domain"
+	"split-pass-api/internal/graph"
+	"split-pass-api/internal/usecase"
+	"testing"
+)
+
+func TestGetVia_Unit(t *testing.T) {
+	g := graph.NewGraph(20)
+	id := func(name string) int { return g.GetOrAddID(name) }
+
+	// シンプルなグラフを作成
+	g.AddEdge(domain.Edge{FromID: id("A"), ToID: id("B")})
+	g.AddEdge(domain.Edge{FromID: id("B"), ToID: id("A")})
+	g.AddEdge(domain.Edge{FromID: id("B"), ToID: id("C")})
+	g.AddEdge(domain.Edge{FromID: id("C"), ToID: id("B")})
+	g.AddEdge(domain.Edge{FromID: id("C"), ToID: id("D")})
+	g.AddEdge(domain.Edge{FromID: id("D"), ToID: id("C")})
+	g.AddEdge(domain.Edge{FromID: id("B"), ToID: id("E")})
+	g.AddEdge(domain.Edge{FromID: id("E"), ToID: id("B")})
+
+	tests := []struct {
+		name string
+		path []string
+		want []string
+	}{
+		{
+			name: "長さ2の経路",
+			path: []string{"A", "B"},
+			want: []string{}, // 長さ2以下の場合は空
+		},
+		{
+			name: "分岐がない経路（デフォルトの経由）",
+			path: []string{"C", "D", "X"},
+			want: []string{"D"}, // 経由がない場合は stationNameList[1] が追加される
+		},
+		{
+			name: "分岐駅を経由する一般的な経路",
+			path: []string{"A", "B", "C", "D"},
+			want: []string{"C"}, // Bの次数が3なので、stationNameList[i+1] である "C" が追加される
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pathIDs := make([]int, len(tt.path))
+			for i, p := range tt.path {
+				pathIDs[i] = id(p)
+			}
+
+			got := usecase.GetVia(g, pathIDs)
+
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetVia() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetVia_SpecialRules_Unit(t *testing.T) {
+	g := graph.NewGraph(20)
+	id := func(name string) int { return g.GetOrAddID(name) }
+
+	tests := []struct {
+		name string
+		path []string
+		want []string
+	}{
+		{
+			name: "東京〜神田〜秋葉原〜御徒町（東北特例）",
+			path: []string{"東京", "神田", "秋葉原", "御徒町"},
+			want: []string{"[近]東北"},
+		},
+		{
+			name: "東京〜神田〜御茶ノ水〜水道橋（中央特例）",
+			path: []string{"有楽町", "東京", "神田", "御茶ノ水", "水道橋"},
+			want: []string{"[近]中央"},
+		},
+		{
+			name: "浅草橋〜秋葉原〜御茶ノ水〜水道橋（総武特例）",
+			path: []string{"浅草橋", "秋葉原", "御茶ノ水", "水道橋"},
+			want: []string{"[近]総武"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pathIDs := make([]int, len(tt.path))
+			for i, p := range tt.path {
+				pathIDs[i] = id(p)
+			}
+
+			got := usecase.GetVia(g, pathIDs)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetVia() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/split-pass-api/tests/integration/via_test.go
+++ b/split-pass-api/tests/integration/via_test.go
@@ -1,0 +1,74 @@
+package integration
+
+import (
+	"split-pass-api/internal/graph/data"
+	"split-pass-api/internal/infra/graphio"
+	"split-pass-api/internal/usecase"
+	"testing"
+)
+
+func TestGetViaStations_Integration(t *testing.T) {
+	loader := &graphio.JSONLoader{}
+	g, err := loader.Load(data.GetEdgesReader())
+	if err != nil {
+		t.Fatalf("グラフの読み込みに失敗: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		path []string
+		want []string
+	}{
+		{
+			name: "東京から黒磯（東北線経由）",
+			path: []string{"東京", "神田", "秋葉原", "御徒町", "上野", "鶯谷", "日暮里", "西日暮里", "田端", "上中里", "王子", "東十条", "赤羽", "川口", "西川口", "蕨", "南浦和", "浦和", "北浦和", "与野", "さいたま新都心", "大宮", "土呂", "東大宮", "蓮田", "白岡", "新白岡", "久喜", "東鷲宮", "栗橋", "古河", "野木", "間々田", "小山", "小金井", "自治医大", "石橋", "雀宮", "宇都宮", "岡本", "宝積寺", "氏家", "蒲須坂", "片岡", "矢板", "（北）野崎", "西那須野", "那須塩原", "黒磯"},
+			want: []string{"[近]東北", "王子", "尾久", "川口", "北赤羽", "土呂", "小金井", "岡本", "氏家"},
+		},
+		{
+			name: "品川から横浜",
+			path: []string{"品川", "大井町", "大森", "蒲田", "川崎", "鶴見", "新子安", "東神奈川", "横浜"},
+			want: []string{"東海道線", "新子安", "東神奈川"},
+		},
+		{
+			name: "越中島から神田",
+			path: []string{"越中島", "八丁堀", "東京", "神田"},
+			want: []string{"東京"},
+		},
+		{
+			name: "神田から越中島",
+			path: []string{"神田", "東京", "八丁堀", "越中島"},
+			want: []string{"八丁堀"},
+		},
+		{
+			name: "東京から神田",
+			path: []string{"東京", "神田"},
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pathIDs := make([]int, len(tt.path))
+			for i, p := range tt.path {
+				id, ok := g.GetID(p)
+				if !ok {
+					t.Fatalf("駅が見つかりません: %s", p)
+				}
+				pathIDs[i] = id
+			}
+
+			vias := usecase.GetVia(g, pathIDs)
+			t.Logf("[%s] 経由印字: %v", tt.name, vias)
+
+			if len(vias) != len(tt.want) {
+				t.Errorf("GetVia() returned %d elements, want %d. got: %v, want: %v", len(vias), len(tt.want), vias, tt.want)
+			} else {
+				for i, v := range vias {
+					if v != tt.want[i] {
+						t.Errorf("GetVia()[%d] = %s, want %s", i, v, tt.want[i])
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closed #270 

## 概要
経路配列（`[]int`）から、定期券券面に印字すべき経由駅文字列を算出する `GetVia` 関数と、その網羅的なテストケースを実装しました。

## アーキテクチャ上の工夫（リファクタリング）
初期の設計構想では `for` ループ内でのインデックス操作（`i += N`）によるハードコードを検討していましたが、以下の技術的負債を防ぐために**宣言的ルールエンジン（`viaBypassRule`）へのリファクタリング**を実施しています。

- **ドメイン知識の分離:** 経路パターンの完全一致、前後駅の許可条件、終端駅の評価フラグ（`EvaluateEnd`）を構造体に切り出すことで、コードの可読性と拡張性を向上。
- **バグの物理的排除:** 第69条（終端評価あり）と近郊特例（終端評価なし）という相反するドメイン要件を、フラグ一つで安全に制御し、ループ変数の手計算によるスキップ漏れや配列外参照パニックを完全に防ぐセーフティガードを組み込みました。

## 変更内容
- `GetVia` 関数およびコアロジックの実装
- 特例区間ルール（第69条、近郊特例等）を定義した `viaRules` の追加
- **[Test]** ダミーグラフを用いたルールエンジンの純粋な論理検証（単体テスト）
- **[Test]** 実際の駅ネットワーク（JSONグラフデータ）と特例マスターデータを用いた実経路の検証（結合テスト）