### PR TITLE
feat: REST APIハンドラ層の追加およびCloud Run向けサーバーエントリポイントの実装

### DIFF
--- a/split-pass-api/cmd/api/main.go
+++ b/split-pass-api/cmd/api/main.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"split-pass-api/internal/domain"
+	"split-pass-api/internal/graph/data"
+	"split-pass-api/internal/handler"
+	"split-pass-api/internal/infra/fareio"
+	"split-pass-api/internal/infra/graphio"
+	"split-pass-api/internal/optimizer"
+	"split-pass-api/internal/usecase"
+)
+
+const (
+	// shutdownTimeout はgraceful shutdownの最大待機時間です
+	shutdownTimeout = 10 * time.Second
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Printf("致命的なエラー: %v", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080" // デフォルト値
+	}
+	listenAddr := ":" + port
+
+	// グラフの初期化
+	log.Printf("JSONからグラフを構築しています")
+	loader := &graphio.JSONLoader{}
+	g, loadErr := loader.Load(data.GetEdgesReader())
+	if loadErr != nil {
+		return fmt.Errorf("JSONの読み込みに失敗しました: %w", loadErr)
+	}
+
+	// 運賃計算レジストリの初期化
+	calcs, err := fareio.InitRegistry(g)
+	if err != nil {
+		return fmt.Errorf("運賃計算機の初期化に失敗しました: %w", err)
+	}
+
+	// 特定区間加算運賃の設定
+	addonFareReg := domain.NewAddonRegistry()
+	addonFareReg.Register("南千歳", "新千歳空港", domain.PassPrice{OneMonth: 660, ThreeMonth: 1880, SixMonth: 3180})
+	addonFareReg.Register("日根野", "りんくうタウン", domain.PassPrice{OneMonth: 4690, ThreeMonth: 13320, SixMonth: 22440})
+	addonFareReg.Register("日根野", "関西空港", domain.PassPrice{OneMonth: 6640, ThreeMonth: 18900, SixMonth: 31820})
+	addonFareReg.Register("りんくうタウン", "関西空港", domain.PassPrice{OneMonth: 5010, ThreeMonth: 14250, SixMonth: 24000})
+	addonFareReg.Register("児島", "宇多津", domain.PassPrice{OneMonth: 1610, ThreeMonth: 4600, SixMonth: 8170})
+	addonFareReg.Register("田吉", "宮崎空港", domain.PassPrice{OneMonth: 3840, ThreeMonth: 10960, SixMonth: 18680})
+
+	// IDを解決
+	if err := addonFareReg.ResolveIDs(func(name string) (int, bool) {
+		id, ok := g.NameToID[name]
+		return id, ok
+	}); err != nil {
+		return fmt.Errorf("加算運賃のID解決に失敗しました: %w", err)
+	}
+
+	// 特急料金の設定
+	addonChargeReg := domain.NewAddonRegistry()
+	addonChargeReg.Register("博多", "博多南", domain.PassPrice{OneMonth: 4680, ThreeMonth: 13340, SixMonth: 25270})
+
+	// 旅客営業規則 第69条 特例区間の設定
+	bypassReg := domain.NewBypassRegistry()
+	// (1) 大沼以遠の各駅と、森以遠の各駅との相互間
+	bypassReg.Register(
+		[]string{"大沼", "大沼公園", "赤井川", "駒ケ岳", "森"},
+		[]string{"大沼", "鹿部", "渡島沼尻", "渡島砂原", "掛澗", "尾白内", "東森", "森"},
+	)
+	// (2) 日暮里以遠の各駅と、赤羽以遠の各駅との相互間
+	bypassReg.Register(
+		[]string{"日暮里", "西日暮里", "田端", "上中里", "王子", "東十条", "赤羽"},
+		[]string{"日暮里", "尾久", "赤羽"},
+	)
+	// (3) 赤羽以遠の各駅と、大宮以遠の各駅との相互間
+	bypassReg.Register(
+		[]string{"赤羽", "川口", "西川口", "蕨", "南浦和", "浦和", "北浦和", "与野", "さいたま新都心", "大宮"},
+		[]string{"赤羽", "北赤羽", "浮間舟渡", "戸田公園", "（北）戸田", "北戸田", "武蔵浦和", "中浦和", "南与野", "与野本町", "北与野", "大宮"},
+	)
+	// (4) 品川以遠の各駅と、鶴見以遠の各駅との相互間
+	bypassReg.Register(
+		[]string{"品川", "大井町", "大森", "蒲田", "川崎", "鶴見"},
+		[]string{"品川", "西大井", "武蔵小杉", "新川崎", "鶴見"},
+	)
+	// (5) 東京以遠（品川、有楽町又は神田方面）の各駅と、蘇我以遠（鎌取又は浜野方面）の各駅との相互間
+	// 旅客営業規則上は補正する必要がありますが、営業キロが等しく実際の定期券でも補正が行われていないため、特例区間として定義しません。
+
+	// IDを解決
+	bypassRules, err := bypassReg.ResolveIDs(func(name string) (int, bool) {
+		id, ok := g.NameToID[name]
+		return id, ok
+	})
+	if err != nil {
+		return fmt.Errorf("特例ルールのID解決に失敗しました: %w", err)
+	}
+
+	amountCalc := usecase.NewCalculateAmount(
+		g,
+		calcs.Registry,
+		addonFareReg,
+		addonChargeReg,
+		calcs.TrainSpecific,
+		calcs.SpecificRoute,
+		calcs.AdjustedRoute,
+	)
+
+	opt := optimizer.NewDPOptimizer(amountCalc)
+	splitUseCase := usecase.NewFindOptimalSplit(opt, amountCalc)
+	searchUseCase := usecase.NewSearchOptimalSplit(g, splitUseCase, bypassRules)
+
+	// ルーティング
+	mux := http.NewServeMux()
+	splitHandler := handler.NewSplit(g, searchUseCase)
+	mux.HandleFunc("/api/split-pass", splitHandler.HandleCalculate)
+
+	server := &http.Server{
+		Addr:         listenAddr,
+		Handler:      mux,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+
+	// シグナルを受け取ったら graceful shutdown するためのコンテキスト
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// サーバーをgoroutineで起動
+	errChan := make(chan error, 1)
+	go func() {
+		log.Printf("split-pass-api を起動しました: %s", server.Addr)
+		if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			errChan <- err
+		}
+	}()
+
+	// SIGINT / SIGTERM またはサーバーエラーを待機
+	select {
+	case err := <-errChan:
+		return fmt.Errorf("サーバーが異常終了しました: %w", err)
+	case <-ctx.Done():
+		log.Println("シャットダウンシグナルを受信しました。接続の終了を待っています...")
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("graceful shutdown に失敗しました: %w", err)
+	}
+
+	log.Println("サーバーを正常に停止しました")
+	return nil
+}

--- a/split-pass-api/internal/handler/split.go
+++ b/split-pass-api/internal/handler/split.go
@@ -1,0 +1,136 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"split-pass-api/internal/graph"
+	"split-pass-api/internal/usecase"
+)
+
+// Split は分割定期券の最適解を計算するHTTPリクエストを処理します。
+type Split struct {
+	graph  *graph.Graph
+	search *usecase.SearchOptimalSplit
+}
+
+// NewSplit は新しい Split を作成します。
+func NewSplit(g *graph.Graph, search *usecase.SearchOptimalSplit) *Split {
+	return &Split{
+		graph:  g,
+		search: search,
+	}
+}
+
+// CalculateRequest はリクエストのペイロードを表現します。
+type CalculateRequest struct {
+	Start  string `json:"start"`
+	End    string `json:"end"`
+	Months int    `json:"months"`
+}
+
+// SegmentResponse は駅名を含む評価済みの区間を表現します。
+type SegmentResponse struct {
+	Path   []string                   `json:"path"`
+	Via    []string                   `json:"via"`
+	Result *usecase.CalculationResult `json:"result"`
+}
+
+// ResultResponse は1つの最適な分割パターンを表現します。
+type ResultResponse struct {
+	TotalAmount int               `json:"totalAmount"`
+	Segments    []SegmentResponse `json:"segments"`
+}
+
+// CalculateResponse はレスポンスのペイロードを表現します。
+type CalculateResponse struct {
+	Results []ResultResponse `json:"results"`
+	Error   string           `json:"error,omitempty"`
+}
+
+// HandleCalculate は計算リクエストを処理します。
+func (h *Split) HandleCalculate(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		writeErrorResponse(w, http.StatusMethodNotAllowed, "許可されていないメソッドです")
+		return
+	}
+
+	var req CalculateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErrorResponse(w, http.StatusBadRequest, "不正なリクエスト形式です")
+		return
+	}
+
+	if req.Months != 1 && req.Months != 3 && req.Months != 6 {
+		writeErrorResponse(w, http.StatusBadRequest, "定期券の期間は1ヶ月、3ヶ月、6ヶ月のいずれかを指定してください")
+		return
+	}
+
+	startID, okStart := h.graph.NameToID[req.Start]
+	endID, okEnd := h.graph.NameToID[req.End]
+
+	if !okStart || !okEnd {
+		writeErrorResponse(w, http.StatusBadRequest, "存在しない駅名が含まれています")
+		return
+	}
+
+	if startID == endID {
+		writeErrorResponse(w, http.StatusBadRequest, "出発駅と到着駅が同じです")
+		return
+	}
+
+	results, err := h.search.Execute(startID, endID, req.Months)
+	if err != nil {
+		log.Printf("分割定期券の計算エラー: %v", err)
+		writeErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("計算処理に失敗しました: %v", err))
+		return
+	}
+
+	apiResults := make([]ResultResponse, len(results))
+	for i, res := range results {
+		apiSegments := make([]SegmentResponse, len(res.Segments))
+		for j, seg := range res.Segments {
+			pathNames := make([]string, len(seg.Path))
+			for k, id := range seg.Path {
+				pathNames[k] = h.graph.IDToName[id]
+			}
+
+			viaNames := usecase.GetVia(h.graph, seg.Path)
+
+			apiSegments[j] = SegmentResponse{
+				Path:   pathNames,
+				Via:    viaNames,
+				Result: seg.Result,
+			}
+		}
+		apiResults[i] = ResultResponse{
+			TotalAmount: res.TotalAmount,
+			Segments:    apiSegments,
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	if err := json.NewEncoder(w).Encode(CalculateResponse{Results: apiResults}); err != nil {
+		log.Printf("レスポンスのエンコードエラー: %v", err)
+	}
+}
+
+func writeErrorResponse(w http.ResponseWriter, statusCode int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	if err := json.NewEncoder(w).Encode(CalculateResponse{Error: message}); err != nil {
+		log.Printf("エラーレスポンスのエンコードエラー: %v", err)
+	}
+}


### PR DESCRIPTION
Closed #269 

## 概要
コアとなる分割計算アルゴリズム（Usecase層）をHTTP APIとして公開するためのプレゼンテーション層と、アプリケーションの起動元となる `main.go` を実装しました。

本PRは、将来的なWebAssembly（Wasm）化を見据えたアーキテクチャ移行の第1段階として、まずは既存のバックエンドインフラ（Cloud Run）上で安全かつ堅牢に稼働するAPIサーバーを構築することを目的としています。

## 変更内容
- **`internal/handler/split.go` の追加**
  - リクエストのJSONパースと、ビジネスルールに基づく厳格なバリデーション。
  - フロントエンドからの安全な呼び出しを担保するCORSヘッダの付与。
- **`cmd/api/main.go` の追加**
  - アプリケーション全体の依存関係（DI）の初期化。
  - Cloud Runでの運用を前提とした `PORT` バインディング。
  - リクエスト処理中のコンテナ停止要求に対し、処理を安全に完了させてから終了する Graceful Shutdown の実装。