### PR TITLE
chore: Go APIのコンテナ化とCloud Run向けGitHub Actionsパイプラインの構築

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,45 @@
+name: Deploy API to Cloud Run
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  PROJECT_ID: 'bubbly-trail-470023-e4'
+  REGION: 'asia-northeast1'
+  SERVICE_NAME: 'split-pass-api'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    
+    # Workload Identity連携に必要な権限設定
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # 1. GCPへの認証
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'
+          service_account: '${{ secrets.SA_EMAIL }}'
+
+      # 2. Cloud Run へのビルド＆デプロイ
+      - name: Deploy to Cloud Run
+        id: deploy
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ env.SERVICE_NAME }}
+          region: ${{ env.REGION }}
+          source: ./split-pass-api
+          
+      - name: Show Output URL
+        run: echo "Deployed URL - ${{ steps.deploy.outputs.url }}"

--- a/split-pass-api/Dockerfile
+++ b/split-pass-api/Dockerfile
@@ -1,0 +1,28 @@
+# 1. ビルド環境 (コンパイル用)
+FROM golang:1.24-alpine AS builder
+WORKDIR /app
+
+# 依存関係のキャッシュを効かせるため、先にgo.modとgo.sumをコピー
+COPY go.mod go.sum ./
+RUN go mod download
+
+# ソースコード全体をコピー (go:embedされるJSONもここに含まれる)
+COPY . .
+
+# Wasmではなく、Cloud Run向けのAPIサーバーとしてビルド
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o server cmd/api/main.go
+
+# 2. 実行環境 (本番用軽量イメージ)
+FROM alpine:latest
+# タイムゾーンデータとルート証明書（HTTPS通信用）のみインストール
+RUN apk --no-cache add ca-certificates tzdata
+
+WORKDIR /app
+# ビルド環境から生成されたバイナリのみを抽出
+COPY --from=builder /app/server .
+
+# Cloud Runが動的に割り当てるPORT環境変数を利用して起動
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["/app/server"]


### PR DESCRIPTION
Closed #276 

## 概要
分割定期券APIを本番環境に展開するためのインフラ設定を追加しました。

## アーキテクチャ上の改善点
既存のNode.js環境のインフラ構成とは異なり、今回のGoプロジェクトではマスターデータがバイナリに `go:embed` で内包されているため、ビルド時の外部データ注入が不要です。
そのため、Cloud Build（`cloudbuild.yaml`）等の二重管理をせず、GitHub Actions完結型のシンプルかつ高速なCI/CDパイプラインへとアーキテクチャとしました。

## 変更内容
- `Dockerfile` の追加（Go向けマルチステージビルド）
- `.github/workflows/deploy-api.yml` の追加（Workload Identity認証およびCloud Runデプロイ設定）