### PR TITLE
ci: Cloud Runデプロイのビルドリージョン最適化とgo.sumエラーの修正

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'split-pass-api/**'
+      - '.github/workflows/deploy-api.yml'
   workflow_dispatch:
 
 env:
@@ -14,8 +17,6 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    
-    # Workload Identity連携に必要な権限設定
     permissions:
       contents: read
       id-token: write
@@ -24,22 +25,26 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # 1. GCPへの認証
       - name: Authenticate to Google Cloud
-        id: auth
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: '${{ secrets.WIF_PROVIDER }}'
           service_account: '${{ secrets.SA_EMAIL }}'
 
-      # 2. Cloud Run へのビルド＆デプロイ
+      - name: Build Container with Cloud Build
+        run: |
+          gcloud builds submit ./split-pass-api \
+            --region=global \
+            --tag=asia-northeast1-docker.pkg.dev/${{ env.PROJECT_ID }}/cloud-run-source-deploy/${{ env.SERVICE_NAME }}:${{ github.sha }}
+
       - name: Deploy to Cloud Run
         id: deploy
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           service: ${{ env.SERVICE_NAME }}
           region: ${{ env.REGION }}
-          source: ./split-pass-api
+          image: asia-northeast1-docker.pkg.dev/${{ env.PROJECT_ID }}/cloud-run-source-deploy/${{ env.SERVICE_NAME }}:${{ github.sha }}
+          flags: '--allow-unauthenticated'
           
       - name: Show Output URL
         run: echo "Deployed URL - ${{ steps.deploy.outputs.url }}"


### PR DESCRIPTION
## 概要
Closes #278 

Cloud Runへの自動デプロイ設定において発生したビルドエラーの解消と、インフラコスト最適化のためのパイプライン改修を行いました。

## 変更内容
1. **Dockerfileの堅牢化**
   - 外部パッケージ未導入により `go.sum` が存在しない環境でもビルドが通るよう、ワイルドカード(`*`)を追加しました。
2. **ビルドとデプロイの分離（コスト最適化）**
   - Cloud Buildの実行リージョンを `global` に指定してArtifact Registryへ保存し、その後 `asia-northeast1` のCloud Runへデプロイするよう、GitHub Actionsのステップを分割しました。
3. Goのバックエンドに変更があった場合のみ発火させるための記述を追加

## 確認手順
1. 本PRを `main` ブランチへマージする。
2. GitHub Actionsタブにて `Deploy API to Cloud Run` のワークフローが正常に完了することを確認する。
3. ワークフローの最終ステップ `Show Output URL` で出力されたURLにアクセスし、APIが応答することを確認する。

## 備考
- 本構成の実行にあたり、GCP側でデプロイ用サービスアカウントへの権限付与（Storage Admin等）および Artifact Registry (`cloud-run-source-deploy`) の事前作成をCLIより完了済みです。