### PR TITLE
fix: Dockerfileのビルドエラー修正 (go.sumのコピー対応)

### DIFF
--- a/split-pass-api/Dockerfile
+++ b/split-pass-api/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.24-alpine AS builder
 WORKDIR /app
 
 # 依存関係のキャッシュを効かせるため、先にgo.modとgo.sumをコピー
-COPY go.mod go.sum ./
+COPY go.mod go.sum* ./
 RUN go mod download
 
 # ソースコード全体をコピー (go:embedされるJSONもここに含まれる)


### PR DESCRIPTION
## 概要
Closes #280 

CI/CDパイプラインにおいてビルドエラーが発生していたため、Dockerfileの記述を改善しました。

## 変更内容
- `split-pass-api/Dockerfile`
  - `COPY go.mod go.sum ./` を `COPY go.mod go.sum* ./` へ変更。
  - これにより、サードパーティライブラリ未導入で `go.sum` が未生成のプロジェクトでもコンテナビルドが成功するようにしました。

## 確認手順
1. 本PRをマージする。
2. GitHub Actionsのワークフローが正常に完了し、APIがデプロイされることを確認する。