### PR TITLE
ci: Cloud Buildコマンドのログストリーミング無効化

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -35,8 +35,9 @@ jobs:
         run: |
           gcloud builds submit ./split-pass-api \
             --region=global \
-            --tag=asia-northeast1-docker.pkg.dev/${{ env.PROJECT_ID }}/cloud-run-source-deploy/${{ env.SERVICE_NAME }}:${{ github.sha }}
-
+            --tag=asia-northeast1-docker.pkg.dev/${{ env.PROJECT_ID }}/cloud-run-source-deploy/${{ env.SERVICE_NAME }}:${{ github.sha }} \
+            --suppress-logs
+            
       - name: Deploy to Cloud Run
         id: deploy
         uses: google-github-actions/deploy-cloudrun@v2


### PR DESCRIPTION
## 概要
Closes #283 

Cloud Build実行時に発生していた権限エラーによるCIの異常終了を回避するため、ログのストリーミングを抑制する設定へ変更しました。

## 変更内容
- `.github/workflows/deploy-api.yml`
  - `gcloud builds submit` コマンドに `--suppress-logs` オプションを追加。
  - これにより、プロジェクトの閲覧権限がない環境でも、ビルドが成功すれば後続のCloud Runデプロイへ正しく進めるようにしました。

## 確認手順
1. 本PRをマージする。
2. GitHub Actionsのワークフローが「ビルド成功後、デプロイステップまで到達すること」を確認する。
3. ビルド詳細はGitHub Actionsのログに記載されたURLからGCPコンソールで確認可能です。