### PR TITLE
feat: 定期券（1/3/6ヶ月）の最安分割計算API連携および結果画面の実装

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -4,7 +4,6 @@
     "scripts/**/*.ts"
   ],
   "ignoreDependencies": [
-    "prettier",
     "tsx"
   ]
 }

--- a/split-pass-api/go.mod
+++ b/split-pass-api/go.mod
@@ -1,3 +1,3 @@
 module split-pass-api
 
-go 1.22
+go 1.24

--- a/split-pass-api/internal/handler/split.go
+++ b/split-pass-api/internal/handler/split.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"split-pass-api/internal/domain"
 	"split-pass-api/internal/graph"
 	"split-pass-api/internal/usecase"
 )
@@ -32,9 +33,10 @@ type CalculateRequest struct {
 
 // SegmentResponse は駅名を含む評価済みの区間を表現します。
 type SegmentResponse struct {
-	Path   []string                   `json:"path"`
-	Via    []string                   `json:"via"`
-	Result *usecase.CalculationResult `json:"result"`
+	Path           []string                   `json:"path"`
+	Via            []string                   `json:"via"`
+	Result         *usecase.CalculationResult `json:"result"`
+	TotalEigyoKilo domain.DeciKilo            `json:"totalEigyoKilo"`
 }
 
 // ResultResponse は1つの最適な分割パターンを表現します。
@@ -45,6 +47,7 @@ type ResultResponse struct {
 
 // CalculateResponse はレスポンスのペイロードを表現します。
 type CalculateResponse struct {
+	Normal  *ResultResponse  `json:"normal,omitempty"`
 	Results []ResultResponse `json:"results"`
 	Error   string           `json:"error,omitempty"`
 }
@@ -89,40 +92,58 @@ func (h *Split) HandleCalculate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	results, err := h.search.Execute(startID, endID, req.Months)
+	optResult, err := h.search.Execute(startID, endID, req.Months)
 	if err != nil {
 		log.Printf("分割定期券の計算エラー: %v", err)
 		writeErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("計算処理に失敗しました: %v", err))
 		return
 	}
 
-	apiResults := make([]ResultResponse, len(results))
-	for i, res := range results {
+	mapToResultResponse := func(res usecase.SplitResult) ResultResponse {
 		apiSegments := make([]SegmentResponse, len(res.Segments))
 		for j, seg := range res.Segments {
 			pathNames := make([]string, len(seg.Path))
 			for k, id := range seg.Path {
 				pathNames[k] = h.graph.IDToName[id]
 			}
-
 			viaNames := usecase.GetVia(h.graph, seg.Path)
 
+			var eigyo domain.DeciKilo
+			if seg.Result != nil {
+				eigyo = seg.Result.TotalEigyoKilo
+			}
+
 			apiSegments[j] = SegmentResponse{
-				Path:   pathNames,
-				Via:    viaNames,
-				Result: seg.Result,
+				Path:           pathNames,
+				Via:            viaNames,
+				Result:         seg.Result,
+				TotalEigyoKilo: eigyo,
 			}
 		}
-		apiResults[i] = ResultResponse{
+		return ResultResponse{
 			TotalAmount: res.TotalAmount,
 			Segments:    apiSegments,
 		}
 	}
 
+	var normalResp *ResultResponse
+	if optResult.Normal.TotalAmount > 0 {
+		nr := mapToResultResponse(optResult.Normal)
+		normalResp = &nr
+	}
+
+	apiResults := make([]ResultResponse, len(optResult.Optimals))
+	for i, res := range optResult.Optimals {
+		apiResults[i] = mapToResultResponse(res)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
-	if err := json.NewEncoder(w).Encode(CalculateResponse{Results: apiResults}); err != nil {
+	if err := json.NewEncoder(w).Encode(CalculateResponse{
+		Normal:  normalResp,
+		Results: apiResults,
+	}); err != nil {
 		log.Printf("レスポンスのエンコードエラー: %v", err)
 	}
 }

--- a/split-pass-api/internal/usecase/calculate_amount.go
+++ b/split-pass-api/internal/usecase/calculate_amount.go
@@ -7,8 +7,6 @@ import (
 	"split-pass-api/internal/graph"
 )
 
-var ()
-
 // CalculateAmount は経路から定期運賃を計算するユースケースです。
 // グラフ、運賃レジストリ、特定区間加算運賃レジストリを協調させます。
 type CalculateAmount struct {
@@ -61,9 +59,10 @@ type routeSummary struct {
 
 // CalculationResult は、運賃と料金の計算結果の内訳を保持します。
 type CalculationResult struct {
-	Fare           int // 運賃（基本運賃＋加算運賃）
-	BarrierFreeFee int // 鉄道バリアフリー料金
-	Charge         int // 料金（博多南線などの特急料金等）
+	Fare           int             // 運賃（基本運賃＋加算運賃）
+	BarrierFreeFee int             // 鉄道バリアフリー料金
+	Charge         int             // 料金（博多南線などの特急料金等）
+	TotalEigyoKilo domain.DeciKilo // 総営業キロ
 }
 
 // TotalAmount は発売額（運賃と料金の総計）を動的に算出して返します。
@@ -156,6 +155,7 @@ func (u *CalculateAmount) Execute(path []int, months int) (*CalculationResult, e
 				Fare:           val,
 				BarrierFreeFee: barrierFreeFee,
 				Charge:         0,
+				TotalEigyoKilo: summary.totalEigyo,
 			}, nil
 		}
 	}
@@ -177,6 +177,7 @@ func (u *CalculateAmount) Execute(path []int, months int) (*CalculationResult, e
 			Fare:           val,
 			BarrierFreeFee: barrierFreeFee,
 			Charge:         0,
+			TotalEigyoKilo: summary.totalEigyo,
 		}, nil
 	}
 
@@ -209,6 +210,7 @@ func (u *CalculateAmount) Execute(path []int, months int) (*CalculationResult, e
 			Fare:           totalFare,
 			BarrierFreeFee: barrierFreeFee,
 			Charge:         0,
+			TotalEigyoKilo: summary.totalEigyo,
 		}, nil
 	}
 
@@ -255,5 +257,6 @@ func (u *CalculateAmount) Execute(path []int, months int) (*CalculationResult, e
 		Fare:           totalFare,
 		BarrierFreeFee: barrierFreeFee,
 		Charge:         limitedExpressCharge,
+		TotalEigyoKilo: summary.totalEigyo,
 	}, nil
 }

--- a/split-pass-api/internal/usecase/calculate_amount_test.go
+++ b/split-pass-api/internal/usecase/calculate_amount_test.go
@@ -91,9 +91,10 @@ func TestCalculateAmount_Execute(t *testing.T) {
 			path:   []int{id("A"), id("B"), id("C")},
 			months: 1,
 			want: usecase.CalculationResult{
-				Fare:           3100,
+				Fare:           3100, // 会社跨ぎの計算: ((10km JR東日本)+(20km JR東海)) = 30km = 3000円 + 加算 100 = 3100円
 				BarrierFreeFee: 0,
 				Charge:         100,
+				TotalEigyoKilo: 300,
 			},
 			wantErr: false,
 		},
@@ -102,9 +103,10 @@ func TestCalculateAmount_Execute(t *testing.T) {
 			path:   []int{id("X"), id("Y")},
 			months: 1,
 			want: usecase.CalculationResult{
-				Fare:           500,
+				Fare:           500, // 電車特定区間の専用運賃表の1ヶ月が適用される
 				BarrierFreeFee: 0,
 				Charge:         0,
+				TotalEigyoKilo: 50,
 			},
 			wantErr: false,
 		},
@@ -116,6 +118,7 @@ func TestCalculateAmount_Execute(t *testing.T) {
 				Fare:           1000,
 				BarrierFreeFee: 0,
 				Charge:         0,
+				TotalEigyoKilo: 100,
 			},
 			wantErr: false,
 		},

--- a/split-pass-api/internal/usecase/search_optimal_split.go
+++ b/split-pass-api/internal/usecase/search_optimal_split.go
@@ -38,10 +38,45 @@ func NewSearchOptimalSplit(g *graph.Graph, u *FindOptimalSplit, rules []domain.R
 	}
 }
 
-func (u *SearchOptimalSplit) Execute(startID, endID, months int) ([]SplitResult, error) {
-	candidatePathResults, err := u.getCandidatePaths(startID, endID)
+// OptimalSearchResult は探索結果全体（通常運賃と最適分割運賃）を保持します。
+type OptimalSearchResult struct {
+	Normal   SplitResult   // 分割なしの最安結果
+	Optimals []SplitResult // 分割時の最安結果
+}
+
+func (u *SearchOptimalSplit) Execute(startID, endID, months int) (*OptimalSearchResult, error) {
+	shortest, err := u.graph.FindShortestPathGisei(startID, endID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("searchOptimalSplit: 最短経路の検索に失敗: %w", err)
+	}
+
+	if len(shortest.StationIDs) > 100 {
+		return nil, fmt.Errorf("経由駅が多すぎます: %w", err)
+	}
+
+	calcResult, err := u.split.calc.Execute(shortest.StationIDs, months)
+	if err != nil {
+		return nil, fmt.Errorf("searchOptimalSplit: 最短経路の運賃計算に失敗: %w", err)
+	}
+
+	kyotoToOsakaPath, err := u.graph.FindShortestPathGisei(u.graph.NameToID["京都"], u.graph.NameToID["大阪"])
+	if err != nil {
+		return nil, fmt.Errorf("searchOptimalSplit: 京都 -> 大阪の探索に失敗: %w", err)
+	}
+
+	kyotoToOsakaAmount, err := u.split.calc.Execute(kyotoToOsakaPath.StationIDs, months)
+	if err != nil {
+		return nil, fmt.Errorf("searchOptimalSplit: 京都 -> 大阪の運賃計算に失敗: %w", err)
+	}
+
+	cheapestAmountPerDecikilo := float64(kyotoToOsakaAmount.TotalAmount()) / float64(kyotoToOsakaPath.EigyoKilo)
+	normalFare := calcResult.TotalAmount()
+
+	maxGisei := domain.DeciKilo(float64(normalFare) / cheapestAmountPerDecikilo)
+
+	candidatePathResults, err := u.graph.FindAllCandidatePaths(startID, endID, maxGisei)
+	if err != nil {
+		return nil, fmt.Errorf("searchOptimalSplit: 候補経路の検索に失敗: %w", err)
 	}
 
 	paths := make([][]int, len(candidatePathResults))
@@ -56,21 +91,20 @@ func (u *SearchOptimalSplit) Execute(startID, endID, months int) ([]SplitResult,
 		return nil, err
 	}
 
-	return u.filterGlobalOptimal(allPatterns), nil
-}
-
-func (u *SearchOptimalSplit) getCandidatePaths(startID, endID int) ([]*graph.PathResult, error) {
-	shortest, err := u.graph.FindShortestPathGisei(startID, endID)
-	if err != nil {
-		return nil, fmt.Errorf("searchOptimalSplit: 最短経路の検索に失敗: %w", err)
+	normalResult := SplitResult{
+		TotalAmount: normalFare,
+		Segments: []SplitSegment{
+			{
+				Path:   shortest.StationIDs,
+				Result: calcResult,
+			},
+		},
 	}
 
-	maxGisei := shortest.GiseiKilo * 15 / 10
-	candidates, err := u.graph.FindAllCandidatePaths(startID, endID, maxGisei)
-	if err != nil {
-		return nil, fmt.Errorf("searchOptimalSplit: 候補経路の検索に失敗: %w", err)
-	}
-	return candidates, nil
+	return &OptimalSearchResult{
+		Normal:   normalResult,
+		Optimals: u.filterGlobalOptimal(allPatterns),
+	}, nil
 }
 
 func (u *SearchOptimalSplit) generateTasks(paths [][]int, rules []domain.ResolvedBypassRule) []EvaluationTask {

--- a/split-pass-api/internal/usecase/search_optimal_split_test.go
+++ b/split-pass-api/internal/usecase/search_optimal_split_test.go
@@ -54,12 +54,12 @@ func TestSearchOptimalSplit_Execute(t *testing.T) {
 			t.Fatalf("Execute が失敗しました: %v", err)
 		}
 
-		if len(got) == 0 {
+		if len(got.Optimals) == 0 {
 			t.Fatal("結果が空です")
 		}
 
-		if got[0].TotalAmount != 2000 {
-			t.Errorf("TotalAmount = %d, 期待値は 2000", got[0].TotalAmount)
+		if got.Optimals[0].TotalAmount != 2000 {
+			t.Errorf("TotalAmount = %d, 期待値は 2000", got.Optimals[0].TotalAmount)
 		}
 	})
 
@@ -86,14 +86,14 @@ func TestSearchOptimalSplit_Execute(t *testing.T) {
 			t.Fatalf("Execute が失敗しました: %v", err)
 		}
 
-		if len(got) == 0 {
+		if len(got.Optimals) == 0 {
 			t.Fatal("結果が空です")
 		}
 
 		// D-A(5km:1000円) + A-B-C(通し計算で20km:2500円) = 3500円 など、
 		// 補正されたルート群の中でDPが計算した最安値が返ることを確認
-		if got[0].TotalAmount <= 0 {
-			t.Errorf("有効な TotalAmount が期待されますが、%d を取得しました", got[0].TotalAmount)
+		if got.Optimals[0].TotalAmount <= 0 {
+			t.Errorf("有効な TotalAmount が期待されますが、%d を取得しました", got.Optimals[0].TotalAmount)
 		}
 	})
 

--- a/split-pass-api/tests/integration/amount_test.go
+++ b/split-pass-api/tests/integration/amount_test.go
@@ -103,6 +103,7 @@ func TestAmountCalculation_Integration(t *testing.T) {
 				Fare:           7840, // 運賃
 				BarrierFreeFee: 0,
 				Charge:         0,
+				TotalEigyoKilo: 103,
 			},
 		},
 		{
@@ -114,6 +115,7 @@ func TestAmountCalculation_Integration(t *testing.T) {
 				Fare:           5020,
 				BarrierFreeFee: 300, // 電車特定区間はバリアフリー料金対象
 				Charge:         0,
+				TotalEigyoKilo: 38,
 			},
 		},
 		{
@@ -125,6 +127,7 @@ func TestAmountCalculation_Integration(t *testing.T) {
 				Fare:           8350,
 				BarrierFreeFee: 0,
 				Charge:         0,
+				TotalEigyoKilo: 26,
 			},
 		},
 		{
@@ -136,6 +139,7 @@ func TestAmountCalculation_Integration(t *testing.T) {
 				Fare:           6240,
 				BarrierFreeFee: 0,
 				Charge:         0,
+				TotalEigyoKilo: 68,
 			},
 		},
 		{
@@ -147,6 +151,7 @@ func TestAmountCalculation_Integration(t *testing.T) {
 				Fare:           13330,
 				BarrierFreeFee: 300,
 				Charge:         0,
+				TotalEigyoKilo: 111,
 			},
 		},
 		{
@@ -158,6 +163,7 @@ func TestAmountCalculation_Integration(t *testing.T) {
 				Fare:           64650,
 				BarrierFreeFee: 0,
 				Charge:         25270,
+				TotalEigyoKilo: 152,
 			},
 		},
 	}

--- a/split-pass-api/tests/integration/cheapest_split_amount_test.go
+++ b/split-pass-api/tests/integration/cheapest_split_amount_test.go
@@ -127,13 +127,13 @@ func TestSearchOptimalSplit_Integration(t *testing.T) {
 			}
 
 			if err == nil {
-				if len(results) == 0 {
+				if len(results.Optimals) == 0 {
 					t.Error("結果が空です")
 					return
 				}
 
-				if results[0].TotalAmount != tt.want {
-					t.Errorf("Execute() TotalAmount = %d, want %d", results[0].TotalAmount, tt.want)
+				if results.Optimals[0].TotalAmount != tt.want {
+					t.Errorf("Execute() TotalAmount = %d, want %d", results.Optimals[0].TotalAmount, tt.want)
 				}
 			}
 		})

--- a/src/app/split/components/Form.tsx
+++ b/src/app/split/components/Form.tsx
@@ -5,7 +5,7 @@ import { useForm, Controller, SubmitHandler, useWatch } from "react-hook-form";
 import { RiArrowUpDownLine } from "react-icons/ri";
 import { HiChevronDown, HiChevronUp } from "react-icons/hi";
 import { useRouter } from "next/navigation";
-import { sendGAEvent } from '@next/third-parties/google';
+import { sendGAEvent } from "@next/third-parties/google";
 
 import stationDatas from "@/app/split/data/stationDatas.json";
 import SelectStation from "@/app/split/components/SelectStation";
@@ -60,12 +60,12 @@ export default function SplitForm({
     const initialStartStation = initialFrom ? stationDatas.find(s => s.name === initialFrom) || { name: initialFrom, kana: "" } : null;
     const initialEndStation = initialTo ? stationDatas.find(s => s.name === initialTo) || { name: initialTo, kana: "" } : null;
 
-    const defaultSearchType = (initialSearchType === 'pass1' || initialSearchType === 'pass3' || initialSearchType === 'pass6')
+    const defaultSearchType = (initialSearchType === "pass1" || initialSearchType === "pass3" || initialSearchType === "pass6")
         ? initialSearchType
-        : 'ticket';
+        : "ticket";
 
     const { handleSubmit, control, formState: { isValid, errors }, getValues, setValue, reset, trigger } = useForm<ExtendedSplitFormInput>({
-        mode: 'onChange',
+        mode: "onChange",
         defaultValues: {
             startStation: initialStartStation,
             endStation: initialEndStation,
@@ -76,9 +76,9 @@ export default function SplitForm({
     useEffect(() => {
         const startStation = initialFrom ? stationDatas.find(s => s.name === initialFrom) || { name: initialFrom, kana: "" } : null;
         const endStation = initialTo ? stationDatas.find(s => s.name === initialTo) || { name: initialTo, kana: "" } : null;
-        const currentSearchType = (initialSearchType === 'pass1' || initialSearchType === 'pass3' || initialSearchType === 'pass6')
+        const currentSearchType = (initialSearchType === "pass1" || initialSearchType === "pass3" || initialSearchType === "pass6")
             ? initialSearchType
-            : 'ticket';
+            : "ticket";
 
         reset({
             startStation,
@@ -86,6 +86,10 @@ export default function SplitForm({
             searchType: currentSearchType,
         });
     }, [initialFrom, initialTo, initialSearchType, reset]);
+
+    const searchedTypeLabel = SEARCH_TYPE_OPTIONS.find(
+        o => o.value === ((initialSearchType === "pass1" || initialSearchType === "pass3" || initialSearchType === "pass6") ? initialSearchType : "ticket")
+    )?.label || "運賃";
 
     const [showAllPatterns, setShowAllPatterns] = useState(false);
 
@@ -109,7 +113,7 @@ export default function SplitForm({
         const exists = stations.has(value.name);
         if (!exists) return "正しい駅名を選択または入力してください";
         const currentSearchType = getValues("searchType");
-        if (currentSearchType !== 'ticket' && TEMPORARY_STATIONS.includes(value.name)) {
+        if (currentSearchType !== "ticket" && TEMPORARY_STATIONS.includes(value.name)) {
             return "臨時駅発着の定期券は計算できません";
         }
 
@@ -121,8 +125,8 @@ export default function SplitForm({
 
         if (data.startStation?.name && data.endStation?.name) {
             sendGAEvent({
-                event: 'search_split',
-                search_type: data.searchType || 'ticket',
+                event: "search_split",
+                search_type: data.searchType || "ticket",
                 from_station: data.startStation.name,
                 to_station: data.endStation.name
             });
@@ -132,7 +136,7 @@ export default function SplitForm({
         if (data.startStation?.name) searchParams.set("from", data.startStation.name);
         if (data.endStation?.name) searchParams.set("to", data.endStation.name);
 
-        if (data.searchType && data.searchType !== 'ticket') {
+        if (data.searchType && data.searchType !== "ticket") {
             searchParams.set("searchType", data.searchType);
         } else {
             searchParams.delete("searchType");
@@ -247,32 +251,29 @@ export default function SplitForm({
 
             <div className="my-8">
                 {isPending && <p className="py-5 border-t text-center text-gray-500">計算中です...</p>}
-                {!isPending && currentType !== 'ticket' && !initialError && !initialResult && (
-                    <p className="py-8 border-t text-center text-slate-400 text-sm">
-                        ※ {SEARCH_TYPE_OPTIONS.find(o => o.value === currentType)?.label}の最安分割ルート計算ロジックは次のステップで結合されます。
-                    </p>
-                )}
-                {!isPending && initialServerTime != null && currentType === 'ticket' && <p className="text-right text-xs text-gray-400">計算時間: {initialServerTime}ms</p>}
+                {!isPending && initialServerTime != null && <p className="text-right text-xs text-gray-400">計算時間: {initialServerTime}ms</p>}
                 {!isPending && initialError && <p className="py-5 border-t text-red-500 text-center">{initialError}</p>}
 
-                {!isPending && initialResult && currentType === 'ticket' && (
+                {!isPending && initialResult && (
                     <div className="border-t pt-8 space-y-8">
                         <h2 className="text-2xl font-bold text-center mb-6">計算結果</h2>
 
                         <section className="bg-gray-50 p-6 rounded-lg shadow-sm border border-gray-200">
-                            <h3 className="font-bold text-lg mb-4 text-gray-700 border-b pb-2">通常の運賃（分割なし）</h3>
+                            <h3 className="font-bold text-lg mb-4 text-gray-700 border-b pb-2">通常の{searchedTypeLabel}（分割なし）</h3>
                             <div className="flex justify-between items-center">
                                 <div>
                                     <div className="text-lg font-bold">
                                         <span>{initialResult.cheapestKippuData.departureStation}</span>
                                         <span className="text-gray-400 mx-2">→</span>
                                         <span>{initialResult.cheapestKippuData.arrivalStation}</span>
-                                        <span className="text-sm font-normal text-gray-600 ml-1">
-                                            （{(initialResult.cheapestKippuData.totalEigyoKilo / 10).toFixed(1)}km）
-                                        </span>
+                                        {initialResult.cheapestKippuData.totalEigyoKilo > 0 && (
+                                            <span className="text-sm font-normal text-gray-600 ml-1">
+                                                （{(initialResult.cheapestKippuData.totalEigyoKilo / 10).toFixed(1)}km）
+                                            </span>
+                                        )}
                                     </div>
                                     <div className="text-sm text-gray-600 mt-1">
-                                        経由：{initialResult.cheapestKippuData.printedViaLines.join('・') || '---'}
+                                        経由：{initialResult.cheapestKippuData.printedViaLines.join("・") || "---"}
                                     </div>
                                 </div>
                                 <div className="text-3xl font-bold text-gray-800">
@@ -289,7 +290,7 @@ export default function SplitForm({
                                     const isCheaper = diff > 0;
 
                                     return (
-                                        <section className={`p-6 rounded-lg shadow-md border-2 ${isCheaper ? 'border-blue-400 bg-blue-50' : 'border-gray-200 bg-white'}`}>
+                                        <section className={`p-6 rounded-lg shadow-md border-2 ${isCheaper ? "border-blue-400 bg-blue-50" : "border-gray-200 bg-white"}`}>
                                             <div className="flex justify-between items-center">
                                                 <div>
                                                     <h3 className="font-bold text-xl text-blue-800">
@@ -320,10 +321,10 @@ export default function SplitForm({
                                         return (
                                             <div
                                                 key={planIndex}
-                                                className={`bg-gray-50 rounded-lg border border-gray-200 relative transition-all duration-300 ${isFadedItem ? 'h-32 overflow-hidden' : 'p-4'
+                                                className={`bg-gray-50 rounded-lg border border-gray-200 relative transition-all duration-300 ${isFadedItem ? "h-32 overflow-hidden" : "p-4"
                                                     }`}
                                             >
-                                                <div className={isFadedItem ? 'p-4' : ''}>
+                                                <div className={isFadedItem ? "p-4" : ""}>
                                                     {initialResult.splitKippuDatasList.length > 1 && (
                                                         <h4 className="font-bold text-gray-700 mb-3 ml-1">
                                                             パターン {planIndex + 1}
@@ -345,9 +346,11 @@ export default function SplitForm({
                                                                             <span>{segment.kippuData.departureStation}</span>
                                                                             <span className="text-gray-400">→</span>
                                                                             <span>{segment.kippuData.arrivalStation}</span>
-                                                                            <span className="text-sm font-normal text-gray-600 ml-1">
-                                                                                （{(segment.kippuData.totalEigyoKilo / 10).toFixed(1)}km）
-                                                                            </span>
+                                                                            {segment.kippuData.totalEigyoKilo > 0 && (
+                                                                                <span className="text-sm font-normal text-gray-600 ml-1">
+                                                                                    （{(segment.kippuData.totalEigyoKilo / 10).toFixed(1)}km）
+                                                                                </span>
+                                                                            )}
                                                                         </div>
                                                                         <div className="text-xs text-gray-500 mt-1 ml-10">
                                                                             経由：{segment.kippuData.printedViaLines.length === 0 ? "---" : segment.kippuData.printedViaLines.join("・")}

--- a/src/app/split/page.tsx
+++ b/src/app/split/page.tsx
@@ -1,21 +1,98 @@
 import Form, { TEMPORARY_STATIONS } from "@/app/split/components/Form";
 import type { Metadata } from "next";
 import { RiScissorsFill, RiErrorWarningLine } from "react-icons/ri";
-import { getOptimalSplitWithCache } from '@/app/split/lib/getOptimalSplitWithCache';
-import { StationCountLimitExceededError, RouteNotFoundError } from '@/app/utils/errors';
+import { getOptimalSplitWithCache } from "@/app/split/lib/getOptimalSplitWithCache";
+import { StationCountLimitExceededError, RouteNotFoundError } from "@/app/utils/errors";
 import stationDatas from "@/app/split/data/stationDatas.json";
+import { ApiCalculateResponse } from "../types";
 
 export const metadata: Metadata = {
   title: "分割乗車券プログラム",
   description: "発駅と着駅から分割乗車券の最安解を計算します。",
 };
 
+async function fetchPassApi(from: string, to: string, months: number) {
+  const start = performance.now();
+  const response = await fetch("https://split-pass-api-yvgda2swha-an.a.run.app/api/split-pass", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ start: from, end: to, months }),
+    cache: "no-store"
+  });
+
+  if (!response.ok) {
+    const errData = await response.json().catch(() => ({}));
+    throw new Error(errData.error || "サーバー内部でエラーが発生しました。");
+  }
+
+  const data: ApiCalculateResponse = await response.json();
+
+  if (!data.results || data.results.length === 0) {
+    throw new Error("経路が見つかりませんでした。");
+  }
+
+  const normalApiResult = data.normal || data.results[0];
+
+  const normalDeparture = normalApiResult.segments[0].path[0];
+  const normalArrival = normalApiResult.segments[normalApiResult.segments.length - 1].path[normalApiResult.segments[normalApiResult.segments.length - 1].path.length - 1];
+  const normalVia = normalApiResult.segments.flatMap((s) => s.via);
+  const normalTotalEigyoKilo = normalApiResult.segments.reduce((acc, s) => acc + (s.totalEigyoKilo || 0), 0);
+
+  const cheapestKippuData = {
+    totalEigyoKilo: normalTotalEigyoKilo,
+    departureStation: normalDeparture,
+    arrivalStation: normalArrival,
+    printedViaLines: normalVia,
+    fare: normalApiResult.totalAmount,
+    validDays: 0,
+  };
+
+  const splitKippuDatasList = [];
+
+  for (const res of data.results) {
+    const splitKippuDatas = [];
+
+    for (let i = 0; i < res.segments.length; i++) {
+      const seg = res.segments[i];
+      const segDeparture = i == 0 ? normalDeparture : seg.path[0];
+      const segArrival = i === res.segments.length - 1 ? normalArrival : seg.path[seg.path.length - 1];
+      const segFare = seg.result.Fare + seg.result.BarrierFreeFee + seg.result.Charge;
+
+      splitKippuDatas.push({
+        departureStation: segDeparture,
+        arrivalStation: segArrival,
+        kippuData: {
+          totalEigyoKilo: seg.totalEigyoKilo || 0,
+          departureStation: segDeparture,
+          arrivalStation: segArrival,
+          printedViaLines: seg.via,
+          fare: segFare,
+          validDays: 0,
+        }
+      });
+    }
+
+    splitKippuDatasList.push({
+      totalFare: res.totalAmount,
+      splitKippuDatas: splitKippuDatas
+    });
+  }
+
+  return {
+    result: {
+      cheapestKippuData,
+      splitKippuDatasList
+    },
+    serverTime: performance.now() - start
+  };
+}
+
 export default async function Page({ searchParams }: { searchParams: Promise<{ [key: string]: string | string[] | undefined }> }) {
   const params = await searchParams;
-  const from = typeof params.from === 'string' ? params.from : undefined;
-  const to = typeof params.to === 'string' ? params.to : undefined;
+  const from = typeof params.from === "string" ? params.from : undefined;
+  const to = typeof params.to === "string" ? params.to : undefined;
 
-  const searchType = typeof params.searchType === 'string' ? params.searchType : 'normal';
+  const searchType = typeof params.searchType === "string" ? params.searchType : "ticket";
 
   let result = null;
   let error = null;
@@ -29,7 +106,7 @@ export default async function Page({ searchParams }: { searchParams: Promise<{ [
       if (!stations.has(from) || !stations.has(to)) {
         error = "駅名が正しくありません。正しい駅名を選択または入力してください。";
       } else {
-        if (searchType === 'normal') {
+        if (searchType === "normal" || searchType === "ticket") {
           try {
             const cacheResult = await getOptimalSplitWithCache(from, to);
             if (!cacheResult) {
@@ -52,7 +129,18 @@ export default async function Page({ searchParams }: { searchParams: Promise<{ [
             error = "臨時駅発着の定期券は計算できません。";
             result = null;
           } else {
-            error = "【ダミー表示】現在、定期券（通勤１・３・６箇月）の分割計算機能は開発中です。入力値は正常に取得できています。";
+            const months = searchType === "pass1" ? 1 : searchType === "pass3" ? 3 : searchType === "pass6" ? 6 : 1;
+            try {
+              const apiData = await fetchPassApi(from, to, months);
+              result = apiData.result;
+              serverTime = apiData.serverTime;
+            } catch (err: unknown) {
+              if (err instanceof Error) {
+                error = err.message;
+              } else {
+                error = "定期券の計算APIとの通信に失敗しました。";
+              }
+            }
           }
         }
       }

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -160,3 +160,28 @@ export interface SearchOption {
     value: SearchType;
     label: string;
 }
+
+
+interface ApiResult {
+    Fare: number;
+    BarrierFreeFee: number;
+    Charge: number;
+}
+
+interface ApiSegment {
+    path: string[];
+    via: string[];
+    result: ApiResult;
+    totalEigyoKilo?: number;
+}
+
+interface ApiResultResponse {
+    totalAmount: number;
+    segments: ApiSegment[];
+}
+
+export interface ApiCalculateResponse {
+    normal?: ApiResultResponse;
+    results: ApiResultResponse[];
+    error?: string;
+}


### PR DESCRIPTION
## 概要
Closed #290  

#288 で実装したフォームUIから渡される `searchType` パラメータを利用し、定期券（1ヶ月・3ヶ月・6ヶ月）の最安分割計算APIを呼び出して結果を描画する実装を行いました。

## 変更内容
* **サーバーサイド (`page.tsx`):** `searchType` が `pass1`, `pass3`, `pass6` の場合に、定期券の計算ロジックを実行するように条件分岐を更新。
* **型定義:** 定期券用のレスポンス型定義を追加・適用。
* **フロントエンド (`Form.tsx`):** #288 で設置したプレースホルダーメッセージを削除し、APIから返却された定期券の分割内訳（区間・金額）を描画するUIコンポーネントを実装。

## 動作確認手順
1. ローカル環境を起動する。
2. フォームから発駅・着駅を入力し、種別を「通勤 1ヶ月」に変更して検索ボタンを押下する。
3. ローディング表示後、定期券の分割計算結果（総額および各区間の内訳）が正しく表示されることを確認する。
4. 「通勤 3ヶ月」「通勤 6ヶ月」でも同様に正しい金額が表示されることを確認する。
5. 「普通乗車券」に戻して検索し、既存の動作が壊れていないことを確認する。