### PR TITLE
feat: 定期券分割計算機能の追加（フロントエンド統合）

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -4,7 +4,6 @@
     "scripts/**/*.ts"
   ],
   "ignoreDependencies": [
-    "prettier",
     "tsx"
   ]
 }

--- a/split-pass-api/cmd/api/main.go
+++ b/split-pass-api/cmd/api/main.go
@@ -74,6 +74,14 @@ func run() error {
 	addonChargeReg := domain.NewAddonRegistry()
 	addonChargeReg.Register("博多", "博多南", domain.PassPrice{OneMonth: 4680, ThreeMonth: 13340, SixMonth: 25270})
 
+	// IDを解決
+	if err := addonChargeReg.ResolveIDs(func(name string) (int, bool) {
+		id, ok := g.NameToID[name]
+		return id, ok
+	}); err != nil {
+		return fmt.Errorf("特急料金のID解決に失敗しました: %w", err)
+	}
+
 	// 旅客営業規則 第69条 特例区間の設定
 	bypassReg := domain.NewBypassRegistry()
 	// (1) 大沼以遠の各駅と、森以遠の各駅との相互間

--- a/split-pass-api/go.mod
+++ b/split-pass-api/go.mod
@@ -1,3 +1,3 @@
 module split-pass-api
 
-go 1.22
+go 1.24

--- a/split-pass-api/internal/handler/split.go
+++ b/split-pass-api/internal/handler/split.go
@@ -2,12 +2,12 @@ package handler
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 	"split-pass-api/internal/domain"
 	"split-pass-api/internal/graph"
 	"split-pass-api/internal/usecase"
+	"strings"
 )
 
 // Split は分割定期券の最適解を計算するHTTPリクエストを処理します。
@@ -95,7 +95,13 @@ func (h *Split) HandleCalculate(w http.ResponseWriter, r *http.Request) {
 	optResult, err := h.search.Execute(startID, endID, req.Months)
 	if err != nil {
 		log.Printf("分割定期券の計算エラー: %v", err)
-		writeErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("計算処理に失敗しました: %v", err))
+
+		errMsg := err.Error()
+		if lastIdx := strings.LastIndex(errMsg, ":"); lastIdx != -1 {
+			errMsg = strings.TrimSpace(errMsg[lastIdx+1:])
+		}
+
+		writeErrorResponse(w, http.StatusInternalServerError, errMsg)
 		return
 	}
 

--- a/split-pass-api/internal/handler/split.go
+++ b/split-pass-api/internal/handler/split.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"split-pass-api/internal/domain"
 	"split-pass-api/internal/graph"
 	"split-pass-api/internal/usecase"
 )
@@ -32,9 +33,10 @@ type CalculateRequest struct {
 
 // SegmentResponse は駅名を含む評価済みの区間を表現します。
 type SegmentResponse struct {
-	Path   []string                   `json:"path"`
-	Via    []string                   `json:"via"`
-	Result *usecase.CalculationResult `json:"result"`
+	Path           []string                   `json:"path"`
+	Via            []string                   `json:"via"`
+	Result         *usecase.CalculationResult `json:"result"`
+	TotalEigyoKilo domain.DeciKilo            `json:"totalEigyoKilo"`
 }
 
 // ResultResponse は1つの最適な分割パターンを表現します。
@@ -45,6 +47,7 @@ type ResultResponse struct {
 
 // CalculateResponse はレスポンスのペイロードを表現します。
 type CalculateResponse struct {
+	Normal  *ResultResponse  `json:"normal,omitempty"`
 	Results []ResultResponse `json:"results"`
 	Error   string           `json:"error,omitempty"`
 }
@@ -89,40 +92,58 @@ func (h *Split) HandleCalculate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	results, err := h.search.Execute(startID, endID, req.Months)
+	optResult, err := h.search.Execute(startID, endID, req.Months)
 	if err != nil {
 		log.Printf("分割定期券の計算エラー: %v", err)
 		writeErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("計算処理に失敗しました: %v", err))
 		return
 	}
 
-	apiResults := make([]ResultResponse, len(results))
-	for i, res := range results {
+	mapToResultResponse := func(res usecase.SplitResult) ResultResponse {
 		apiSegments := make([]SegmentResponse, len(res.Segments))
 		for j, seg := range res.Segments {
 			pathNames := make([]string, len(seg.Path))
 			for k, id := range seg.Path {
 				pathNames[k] = h.graph.IDToName[id]
 			}
-
 			viaNames := usecase.GetVia(h.graph, seg.Path)
 
+			var eigyo domain.DeciKilo
+			if seg.Result != nil {
+				eigyo = seg.Result.TotalEigyoKilo
+			}
+
 			apiSegments[j] = SegmentResponse{
-				Path:   pathNames,
-				Via:    viaNames,
-				Result: seg.Result,
+				Path:           pathNames,
+				Via:            viaNames,
+				Result:         seg.Result,
+				TotalEigyoKilo: eigyo,
 			}
 		}
-		apiResults[i] = ResultResponse{
+		return ResultResponse{
 			TotalAmount: res.TotalAmount,
 			Segments:    apiSegments,
 		}
 	}
 
+	var normalResp *ResultResponse
+	if optResult.Normal.TotalAmount > 0 {
+		nr := mapToResultResponse(optResult.Normal)
+		normalResp = &nr
+	}
+
+	apiResults := make([]ResultResponse, len(optResult.Optimals))
+	for i, res := range optResult.Optimals {
+		apiResults[i] = mapToResultResponse(res)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
-	if err := json.NewEncoder(w).Encode(CalculateResponse{Results: apiResults}); err != nil {
+	if err := json.NewEncoder(w).Encode(CalculateResponse{
+		Normal:  normalResp,
+		Results: apiResults,
+	}); err != nil {
 		log.Printf("レスポンスのエンコードエラー: %v", err)
 	}
 }

--- a/split-pass-api/internal/usecase/calculate_amount.go
+++ b/split-pass-api/internal/usecase/calculate_amount.go
@@ -7,8 +7,6 @@ import (
 	"split-pass-api/internal/graph"
 )
 
-var ()
-
 // CalculateAmount は経路から定期運賃を計算するユースケースです。
 // グラフ、運賃レジストリ、特定区間加算運賃レジストリを協調させます。
 type CalculateAmount struct {
@@ -61,9 +59,10 @@ type routeSummary struct {
 
 // CalculationResult は、運賃と料金の計算結果の内訳を保持します。
 type CalculationResult struct {
-	Fare           int // 運賃（基本運賃＋加算運賃）
-	BarrierFreeFee int // 鉄道バリアフリー料金
-	Charge         int // 料金（博多南線などの特急料金等）
+	Fare           int             // 運賃（基本運賃＋加算運賃）
+	BarrierFreeFee int             // 鉄道バリアフリー料金
+	Charge         int             // 料金（博多南線などの特急料金等）
+	TotalEigyoKilo domain.DeciKilo // 総営業キロ
 }
 
 // TotalAmount は発売額（運賃と料金の総計）を動的に算出して返します。
@@ -156,6 +155,7 @@ func (u *CalculateAmount) Execute(path []int, months int) (*CalculationResult, e
 				Fare:           val,
 				BarrierFreeFee: barrierFreeFee,
 				Charge:         0,
+				TotalEigyoKilo: summary.totalEigyo,
 			}, nil
 		}
 	}
@@ -177,6 +177,7 @@ func (u *CalculateAmount) Execute(path []int, months int) (*CalculationResult, e
 			Fare:           val,
 			BarrierFreeFee: barrierFreeFee,
 			Charge:         0,
+			TotalEigyoKilo: summary.totalEigyo,
 		}, nil
 	}
 
@@ -209,6 +210,7 @@ func (u *CalculateAmount) Execute(path []int, months int) (*CalculationResult, e
 			Fare:           totalFare,
 			BarrierFreeFee: barrierFreeFee,
 			Charge:         0,
+			TotalEigyoKilo: summary.totalEigyo,
 		}, nil
 	}
 
@@ -255,5 +257,6 @@ func (u *CalculateAmount) Execute(path []int, months int) (*CalculationResult, e
 		Fare:           totalFare,
 		BarrierFreeFee: barrierFreeFee,
 		Charge:         limitedExpressCharge,
+		TotalEigyoKilo: summary.totalEigyo,
 	}, nil
 }

--- a/split-pass-api/internal/usecase/calculate_amount_test.go
+++ b/split-pass-api/internal/usecase/calculate_amount_test.go
@@ -91,9 +91,10 @@ func TestCalculateAmount_Execute(t *testing.T) {
 			path:   []int{id("A"), id("B"), id("C")},
 			months: 1,
 			want: usecase.CalculationResult{
-				Fare:           3100,
+				Fare:           3100, // 会社跨ぎの計算: ((10km JR東日本)+(20km JR東海)) = 30km = 3000円 + 加算 100 = 3100円
 				BarrierFreeFee: 0,
 				Charge:         100,
+				TotalEigyoKilo: 300,
 			},
 			wantErr: false,
 		},
@@ -102,9 +103,10 @@ func TestCalculateAmount_Execute(t *testing.T) {
 			path:   []int{id("X"), id("Y")},
 			months: 1,
 			want: usecase.CalculationResult{
-				Fare:           500,
+				Fare:           500, // 電車特定区間の専用運賃表の1ヶ月が適用される
 				BarrierFreeFee: 0,
 				Charge:         0,
+				TotalEigyoKilo: 50,
 			},
 			wantErr: false,
 		},
@@ -116,6 +118,7 @@ func TestCalculateAmount_Execute(t *testing.T) {
 				Fare:           1000,
 				BarrierFreeFee: 0,
 				Charge:         0,
+				TotalEigyoKilo: 100,
 			},
 			wantErr: false,
 		},

--- a/split-pass-api/internal/usecase/search_optimal_split.go
+++ b/split-pass-api/internal/usecase/search_optimal_split.go
@@ -96,7 +96,7 @@ func (u *SearchOptimalSplit) Execute(startID, endID, months int) (*OptimalSearch
 
 	candidatePathResults, err := u.graph.FindAllCandidatePaths(startID, endID, maxGisei)
 	if err != nil {
-		return nil, fmt.Errorf("searchOptimalSplit: 候補経路の検索に失敗: %w", err)
+		return nil, fmt.Errorf("searchOptimalSplit: %w", err)
 	}
 
 	paths := make([][]int, len(candidatePathResults))
@@ -130,42 +130,72 @@ func (u *SearchOptimalSplit) Execute(startID, endID, months int) (*OptimalSearch
 func (u *SearchOptimalSplit) generateTasks(paths [][]int, rules []domain.ResolvedBypassRule) []EvaluationTask {
 	var tasks []EvaluationTask
 
+	if len(paths) == 0 {
+		return tasks
+	}
+
+	// 全ての候補経路は同じ発着駅を持つため、最初の経路から startID と endID を取得
+	startID := paths[0][0]
+	endID := paths[0][len(paths[0])-1]
+
+	// -----------------------------------------------------------
+	// 1. 初めの一回だけ行う処理（特例ルートの重複評価を防止）
+	// -----------------------------------------------------------
+	for _, rule := range rules {
+		startOnDetour := u.isOnDetourMiddle(startID, rule)
+		endOnDetour := u.isOnDetourMiddle(endID, rule)
+
+		// 発着駅がルールの対象区間内（近道または遠回り）にあるかを判定
+		startOnRule := u.containsStation(rule.ShortcutPath, startID) || u.containsStation(rule.DetourPath, startID)
+		endOnRule := u.containsStation(rule.ShortcutPath, endID) || u.containsStation(rule.DetourPath, endID)
+
+		// 入力された少なくとも一方が特例の遠回りで、もう一方がその特例の遠回りあるいは近道だった時
+		if (startOnDetour && endOnRule) || (endOnDetour && startOnRule) {
+			shortcutPath := make([]int, len(rule.ShortcutPath))
+			copy(shortcutPath, rule.ShortcutPath)
+
+			// 分割禁止（Locked）にして、候補経路群に「1つだけ」追加する
+			tasks = append(tasks, EvaluationTask{
+				Segments: []RouteSegment{
+					{Path: shortcutPath, Locked: makeShortcutLocked(shortcutPath)},
+				},
+			})
+			break // 逆方向も重複して評価されないように、最初のマッチで追加したらループを抜ける
+		}
+	}
+
+	// -----------------------------------------------------------
+	// 2. 各候補経路ごとの展開処理
+	// -----------------------------------------------------------
 	for _, path := range paths {
 		locked := make([]bool, len(path))
-		isBranch1 := false
+		isFullyEnclosedInRule := false
 
 		for _, rule := range rules {
 			startIdx, _ := u.findSubPath(path, rule.DetourPath)
 			startOnDetour := u.isOnDetourMiddle(path[0], rule)
 			endOnDetour := u.isOnDetourMiddle(path[len(path)-1], rule)
 
-			// 削除されていた分岐駅の存在チェックを復元
 			jStart := rule.ShortcutPath[0]
 			jEnd := rule.ShortcutPath[len(rule.ShortcutPath)-1]
 			idxStart := u.indexOf(path, jStart)
 			idxEnd := u.indexOf(path, jEnd)
 			containsBothJunctions := (idxStart != -1 && idxEnd != -1)
 
-			// 進行方向の検証。経路の進行方向とルールの方向が一致していない場合は、逆方向ルールに任せる
 			if containsBothJunctions && idxStart > idxEnd {
 				continue
 			}
 
-			// 分岐1: 経路全体が近道と遠回りのみで構成され、かつ両分岐駅を通る場合
+			// ループ内の分岐1: 経路全体が特例に含まれる場合
+			// すでに近道ルート（特例運賃）自体の追加はステップ1で済んでいるため、
+			// ここでは「元の経路（遠回り等）をそのままの状態で評価する」ためのフラグのみを立て、
+			// 無駄な expandPath（分岐2などへの波及）を打ち切る。
 			if (startOnDetour || endOnDetour) && u.isEntirelyOnRule(path, rule) {
-				shortcutPath := make([]int, len(rule.ShortcutPath))
-				copy(shortcutPath, rule.ShortcutPath)
-
-				tasks = append(tasks, EvaluationTask{
-					Segments: []RouteSegment{
-						{Path: shortcutPath, Locked: makeShortcutLocked(shortcutPath)},
-					},
-				})
-				isBranch1 = true
+				isFullyEnclosedInRule = true
 				break
 			}
 
-			// 分岐2: 発着駅が遠回り上にあるが、完全に内包(startIdx!=-1)されていない場合
+			// 分岐2: 発着駅が遠回り上にあるが、完全に内包されていない場合（オーバーシュート）
 			if (startOnDetour || endOnDetour) && startIdx == -1 {
 				extPath, extLocked := u.buildOvershootPath(path, locked, rule)
 				if extPath != nil {
@@ -177,14 +207,15 @@ func (u *SearchOptimalSplit) generateTasks(paths [][]int, rules []domain.Resolve
 			}
 		}
 
-		if isBranch1 {
+		// 経路全体が特例ルールの内部に収まっていた経路は、そのまま追加（分割許可）
+		if isFullyEnclosedInRule {
 			tasks = append(tasks, EvaluationTask{
 				Segments: []RouteSegment{{Path: path, Locked: locked}},
 			})
 			continue
 		}
 
-		// 全候補共通:
+		// 上記以外（通常の経路やオーバーシュートを含む経路）の展開
 		segmentsCombos := u.expandPath(path, locked, rules)
 		for _, segments := range segmentsCombos {
 			tasks = append(tasks, EvaluationTask{Segments: segments})
@@ -236,7 +267,7 @@ func (u *SearchOptimalSplit) buildOvershootPath(path []int, locked []bool, rule 
 	return nil, nil
 }
 
-// expandPath は経路内の遠回り区間を再帰的に展開し、強制分割の全組み合わせを返します（分岐2用）。
+// expandPath は経路内の遠回り区間を再帰的に展開し、強制分割の全組み合わせを返します。
 func (u *SearchOptimalSplit) expandPath(path []int, locked []bool, rules []domain.ResolvedBypassRule) [][]RouteSegment {
 	for _, rule := range rules {
 		startIdx, _ := u.findSubPath(path, rule.DetourPath)
@@ -299,8 +330,8 @@ func (u *SearchOptimalSplit) evaluateTasks(tasks []EvaluationTask, months int) (
 			results, err := u.split.Execute(seg.Path, months, seg.Locked)
 			if err != nil {
 				if errors.Is(err, domain.ErrInvalidPath) {
-				isValidTask = false
-				break
+					isValidTask = false
+					break
 				}
 				return nil, fmt.Errorf("evaluateTasks: %w", err)
 			}

--- a/split-pass-api/internal/usecase/search_optimal_split.go
+++ b/split-pass-api/internal/usecase/search_optimal_split.go
@@ -59,20 +59,35 @@ func (u *SearchOptimalSplit) Execute(startID, endID, months int) (*OptimalSearch
 		return nil, fmt.Errorf("searchOptimalSplit: 最短経路の運賃計算に失敗: %w", err)
 	}
 
-	kyotoToOsakaPath, err := u.graph.FindShortestPathGisei(u.graph.NameToID["京都"], u.graph.NameToID["大阪"])
-	if err != nil {
-		return nil, fmt.Errorf("searchOptimalSplit: 京都 -> 大阪の探索に失敗: %w", err)
+	var cheapestAmountPerDecikilo float64
+	kyotoID, kyotoExists := u.graph.NameToID["京都"]
+	osakaID, osakaExists := u.graph.NameToID["大阪"]
+
+	if kyotoExists && osakaExists {
+		kyotoToOsakaPath, err := u.graph.FindShortestPathGisei(kyotoID, osakaID)
+		if err != nil {
+			return nil, fmt.Errorf("searchOptimalSplit: 京都 -> 大阪の探索に失敗: %w", err)
+		}
+
+		kyotoToOsakaAmount, err := u.split.calc.Execute(kyotoToOsakaPath.StationIDs, months)
+		if err != nil {
+			return nil, fmt.Errorf("searchOptimalSplit: 京都 -> 大阪の運賃計算に失敗: %w", err)
+		}
+		cheapestAmountPerDecikilo = float64(kyotoToOsakaAmount.TotalAmount()) / float64(kyotoToOsakaPath.EigyoKilo)
+	} else if months == 1 {
+		cheapestAmountPerDecikilo = 45780 / 100
+	} else if months == 3 {
+		cheapestAmountPerDecikilo = 130540 / 100
+	} else {
+		cheapestAmountPerDecikilo = 236070 / 100
 	}
 
-	kyotoToOsakaAmount, err := u.split.calc.Execute(kyotoToOsakaPath.StationIDs, months)
-	if err != nil {
-		return nil, fmt.Errorf("searchOptimalSplit: 京都 -> 大阪の運賃計算に失敗: %w", err)
-	}
-
-	cheapestAmountPerDecikilo := float64(kyotoToOsakaAmount.TotalAmount()) / float64(kyotoToOsakaPath.EigyoKilo)
 	normalFare := calcResult.TotalAmount()
 
 	maxGisei := domain.DeciKilo(float64(normalFare) / cheapestAmountPerDecikilo)
+	if maxGisei < shortest.GiseiKilo {
+		maxGisei = shortest.GiseiKilo
+	}
 
 	candidatePathResults, err := u.graph.FindAllCandidatePaths(startID, endID, maxGisei)
 	if err != nil {

--- a/split-pass-api/internal/usecase/search_optimal_split.go
+++ b/split-pass-api/internal/usecase/search_optimal_split.go
@@ -51,7 +51,7 @@ func (u *SearchOptimalSplit) Execute(startID, endID, months int) (*OptimalSearch
 	}
 
 	if len(shortest.StationIDs) > 100 {
-		return nil, fmt.Errorf("経由駅が多すぎます: %w", err)
+		return nil, fmt.Errorf("searchOptimalSplit: 発着駅間の駅数(%d)が上限の100を超えています。", len(shortest.StationIDs))
 	}
 
 	calcResult, err := u.split.calc.Execute(shortest.StationIDs, months)

--- a/split-pass-api/internal/usecase/search_optimal_split.go
+++ b/split-pass-api/internal/usecase/search_optimal_split.go
@@ -87,9 +87,9 @@ func (u *SearchOptimalSplit) Execute(startID, endID, months int) (*OptimalSearch
 		cheapestAmountPerDecikilo = 236070.0 / 100.0
 	}
 
-	normalFare := calcResult.TotalAmount()
+	normalAmount := calcResult.TotalAmount()
 
-	maxGisei := domain.DeciKilo(float64(normalFare) / cheapestAmountPerDecikilo)
+	maxGisei := domain.DeciKilo(float64(normalAmount) / cheapestAmountPerDecikilo)
 	if maxGisei < shortest.GiseiKilo {
 		maxGisei = shortest.GiseiKilo
 	}
@@ -112,7 +112,7 @@ func (u *SearchOptimalSplit) Execute(startID, endID, months int) (*OptimalSearch
 	}
 
 	normalResult := SplitResult{
-		TotalAmount: normalFare,
+		TotalAmount: normalAmount,
 		Segments: []SplitSegment{
 			{
 				Path:   shortest.StationIDs,

--- a/split-pass-api/internal/usecase/search_optimal_split.go
+++ b/split-pass-api/internal/usecase/search_optimal_split.go
@@ -51,8 +51,12 @@ func (u *SearchOptimalSplit) Execute(startID, endID, months int) (*OptimalSearch
 		return nil, fmt.Errorf("searchOptimalSplit: 最短経路の検索に失敗: %w", err)
 	}
 
-	if len(shortest.StationIDs) > 100 {
-		return nil, fmt.Errorf("searchOptimalSplit: 発着駅間の駅数(%d)が上限の100を超えています。", len(shortest.StationIDs))
+	// maxStationsInPath は探索の上限駅数です。
+	// DFSの再帰深度と計算量の制約から設定しています。
+	const maxStationsInPath = 100
+
+	if len(shortest.StationIDs) > maxStationsInPath {
+		return nil, fmt.Errorf("searchOptimalSplit: 発着駅間の駅数(%d)が上限の%dを超えています。", len(shortest.StationIDs), maxStationsInPath)
 	}
 
 	calcResult, err := u.split.calc.Execute(shortest.StationIDs, months)

--- a/split-pass-api/internal/usecase/search_optimal_split.go
+++ b/split-pass-api/internal/usecase/search_optimal_split.go
@@ -1,6 +1,7 @@
 package usecase
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -292,9 +293,12 @@ func (u *SearchOptimalSplit) evaluateTasks(tasks []EvaluationTask, months int) (
 
 		for _, seg := range task.Segments {
 			results, err := u.split.Execute(seg.Path, months, seg.Locked)
-			if err != nil || len(results) == 0 {
+			if err != nil {
+				if errors.Is(err, domain.ErrInvalidPath) {
 				isValidTask = false
 				break
+				}
+				return nil, fmt.Errorf("evaluateTasks: %w", err)
 			}
 			bestForSeg := results[0]
 			taskTotalAmount += bestForSeg.TotalAmount

--- a/split-pass-api/internal/usecase/search_optimal_split.go
+++ b/split-pass-api/internal/usecase/search_optimal_split.go
@@ -75,11 +75,11 @@ func (u *SearchOptimalSplit) Execute(startID, endID, months int) (*OptimalSearch
 		}
 		cheapestAmountPerDecikilo = float64(kyotoToOsakaAmount.TotalAmount()) / float64(kyotoToOsakaPath.EigyoKilo)
 	} else if months == 1 {
-		cheapestAmountPerDecikilo = 45780 / 100
+		cheapestAmountPerDecikilo = 45780.0 / 100.0
 	} else if months == 3 {
-		cheapestAmountPerDecikilo = 130540 / 100
+		cheapestAmountPerDecikilo = 130540.0 / 100.0
 	} else {
-		cheapestAmountPerDecikilo = 236070 / 100
+		cheapestAmountPerDecikilo = 236070.0 / 100.0
 	}
 
 	normalFare := calcResult.TotalAmount()

--- a/split-pass-api/internal/usecase/search_optimal_split.go
+++ b/split-pass-api/internal/usecase/search_optimal_split.go
@@ -445,19 +445,30 @@ func makeUniqueBidirectionalRules(rules []domain.ResolvedBypassRule) []domain.Re
 func generateRuleKey(shortcut, detour []int) string {
 	var sb strings.Builder
 	sb.Grow((len(shortcut) + len(detour)) * 5)
+
+	// スタック上に一時バッファを確保（64bit整数の最大桁数20バイトで十分）
+	// ※ヒープではなくスタックに置かれるためアロケーションコストはゼロです
+	var buf [20]byte
+
 	for i, id := range shortcut {
 		if i > 0 {
 			sb.WriteByte(',')
 		}
-		sb.WriteString(strconv.Itoa(id))
+		// buf[:0]（容量20の空スライス）に数値を文字データとして追記
+		b := strconv.AppendInt(buf[:0], int64(id), 10)
+		sb.Write(b) // Builderの内部バッファへ直接コピー（文字列化を経由しない）
 	}
+
 	sb.WriteByte('|')
+
 	for i, id := range detour {
 		if i > 0 {
 			sb.WriteByte(',')
 		}
-		sb.WriteString(strconv.Itoa(id))
+		b := strconv.AppendInt(buf[:0], int64(id), 10)
+		sb.Write(b)
 	}
+
 	return sb.String()
 }
 

--- a/split-pass-api/internal/usecase/search_optimal_split.go
+++ b/split-pass-api/internal/usecase/search_optimal_split.go
@@ -38,10 +38,45 @@ func NewSearchOptimalSplit(g *graph.Graph, u *FindOptimalSplit, rules []domain.R
 	}
 }
 
-func (u *SearchOptimalSplit) Execute(startID, endID, months int) ([]SplitResult, error) {
-	candidatePathResults, err := u.getCandidatePaths(startID, endID)
+// OptimalSearchResult は探索結果全体（通常運賃と最適分割運賃）を保持します。
+type OptimalSearchResult struct {
+	Normal   SplitResult   // 分割なしの最安結果
+	Optimals []SplitResult // 分割時の最安結果
+}
+
+func (u *SearchOptimalSplit) Execute(startID, endID, months int) (*OptimalSearchResult, error) {
+	shortest, err := u.graph.FindShortestPathGisei(startID, endID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("searchOptimalSplit: 最短経路の検索に失敗: %w", err)
+	}
+
+	if len(shortest.StationIDs) > 100 {
+		return nil, fmt.Errorf("経由駅が多すぎます: %w", err)
+	}
+
+	calcResult, err := u.split.calc.Execute(shortest.StationIDs, months)
+	if err != nil {
+		return nil, fmt.Errorf("searchOptimalSplit: 最短経路の運賃計算に失敗: %w", err)
+	}
+
+	kyotoToOsakaPath, err := u.graph.FindShortestPathGisei(u.graph.NameToID["京都"], u.graph.NameToID["大阪"])
+	if err != nil {
+		return nil, fmt.Errorf("searchOptimalSplit: 京都 -> 大阪の探索に失敗: %w", err)
+	}
+
+	kyotoToOsakaAmount, err := u.split.calc.Execute(kyotoToOsakaPath.StationIDs, months)
+	if err != nil {
+		return nil, fmt.Errorf("searchOptimalSplit: 京都 -> 大阪の運賃計算に失敗: %w", err)
+	}
+
+	cheapestAmountPerDecikilo := float64(kyotoToOsakaAmount.TotalAmount()) / float64(kyotoToOsakaPath.EigyoKilo)
+	normalFare := calcResult.TotalAmount()
+
+	maxGisei := domain.DeciKilo(float64(normalFare) / cheapestAmountPerDecikilo)
+
+	candidatePathResults, err := u.graph.FindAllCandidatePaths(startID, endID, maxGisei)
+	if err != nil {
+		return nil, fmt.Errorf("searchOptimalSplit: 候補経路の検索に失敗: %w", err)
 	}
 
 	paths := make([][]int, len(candidatePathResults))
@@ -56,21 +91,20 @@ func (u *SearchOptimalSplit) Execute(startID, endID, months int) ([]SplitResult,
 		return nil, err
 	}
 
-	return u.filterGlobalOptimal(allPatterns), nil
-}
-
-func (u *SearchOptimalSplit) getCandidatePaths(startID, endID int) ([]*graph.PathResult, error) {
-	shortest, err := u.graph.FindShortestPathGisei(startID, endID)
-	if err != nil {
-		return nil, fmt.Errorf("searchOptimalSplit: 最短経路の検索に失敗: %w", err)
+	normalResult := SplitResult{
+		TotalAmount: normalFare,
+		Segments: []SplitSegment{
+			{
+				Path:   shortest.StationIDs,
+				Result: calcResult,
+			},
+		},
 	}
 
-	maxGisei := shortest.GiseiKilo * 15 / 10
-	candidates, err := u.graph.FindAllCandidatePaths(startID, endID, maxGisei)
-	if err != nil {
-		return nil, fmt.Errorf("searchOptimalSplit: 候補経路の検索に失敗: %w", err)
-	}
-	return candidates, nil
+	return &OptimalSearchResult{
+		Normal:   normalResult,
+		Optimals: u.filterGlobalOptimal(allPatterns),
+	}, nil
 }
 
 func (u *SearchOptimalSplit) generateTasks(paths [][]int, rules []domain.ResolvedBypassRule) []EvaluationTask {

--- a/split-pass-api/internal/usecase/search_optimal_split_test.go
+++ b/split-pass-api/internal/usecase/search_optimal_split_test.go
@@ -54,12 +54,12 @@ func TestSearchOptimalSplit_Execute(t *testing.T) {
 			t.Fatalf("Execute が失敗しました: %v", err)
 		}
 
-		if len(got) == 0 {
+		if len(got.Optimals) == 0 {
 			t.Fatal("結果が空です")
 		}
 
-		if got[0].TotalAmount != 2000 {
-			t.Errorf("TotalAmount = %d, 期待値は 2000", got[0].TotalAmount)
+		if got.Optimals[0].TotalAmount != 2000 {
+			t.Errorf("TotalAmount = %d, 期待値は 2000", got.Optimals[0].TotalAmount)
 		}
 	})
 
@@ -86,14 +86,14 @@ func TestSearchOptimalSplit_Execute(t *testing.T) {
 			t.Fatalf("Execute が失敗しました: %v", err)
 		}
 
-		if len(got) == 0 {
+		if len(got.Optimals) == 0 {
 			t.Fatal("結果が空です")
 		}
 
 		// D-A(5km:1000円) + A-B-C(通し計算で20km:2500円) = 3500円 など、
 		// 補正されたルート群の中でDPが計算した最安値が返ることを確認
-		if got[0].TotalAmount <= 0 {
-			t.Errorf("有効な TotalAmount が期待されますが、%d を取得しました", got[0].TotalAmount)
+		if got.Optimals[0].TotalAmount <= 0 {
+			t.Errorf("有効な TotalAmount が期待されますが、%d を取得しました", got.Optimals[0].TotalAmount)
 		}
 	})
 

--- a/split-pass-api/tests/integration/amount_test.go
+++ b/split-pass-api/tests/integration/amount_test.go
@@ -103,6 +103,7 @@ func TestAmountCalculation_Integration(t *testing.T) {
 				Fare:           7840, // 運賃
 				BarrierFreeFee: 0,
 				Charge:         0,
+				TotalEigyoKilo: 103,
 			},
 		},
 		{
@@ -114,6 +115,7 @@ func TestAmountCalculation_Integration(t *testing.T) {
 				Fare:           5020,
 				BarrierFreeFee: 300, // 電車特定区間はバリアフリー料金対象
 				Charge:         0,
+				TotalEigyoKilo: 38,
 			},
 		},
 		{
@@ -125,6 +127,7 @@ func TestAmountCalculation_Integration(t *testing.T) {
 				Fare:           8350,
 				BarrierFreeFee: 0,
 				Charge:         0,
+				TotalEigyoKilo: 26,
 			},
 		},
 		{
@@ -136,6 +139,7 @@ func TestAmountCalculation_Integration(t *testing.T) {
 				Fare:           6240,
 				BarrierFreeFee: 0,
 				Charge:         0,
+				TotalEigyoKilo: 68,
 			},
 		},
 		{
@@ -147,6 +151,7 @@ func TestAmountCalculation_Integration(t *testing.T) {
 				Fare:           13330,
 				BarrierFreeFee: 300,
 				Charge:         0,
+				TotalEigyoKilo: 111,
 			},
 		},
 		{
@@ -158,6 +163,7 @@ func TestAmountCalculation_Integration(t *testing.T) {
 				Fare:           64650,
 				BarrierFreeFee: 0,
 				Charge:         25270,
+				TotalEigyoKilo: 152,
 			},
 		},
 	}

--- a/split-pass-api/tests/integration/cheapest_split_amount_test.go
+++ b/split-pass-api/tests/integration/cheapest_split_amount_test.go
@@ -127,13 +127,13 @@ func TestSearchOptimalSplit_Integration(t *testing.T) {
 			}
 
 			if err == nil {
-				if len(results) == 0 {
+				if len(results.Optimals) == 0 {
 					t.Error("結果が空です")
 					return
 				}
 
-				if results[0].TotalAmount != tt.want {
-					t.Errorf("Execute() TotalAmount = %d, want %d", results[0].TotalAmount, tt.want)
+				if results.Optimals[0].TotalAmount != tt.want {
+					t.Errorf("Execute() TotalAmount = %d, want %d", results.Optimals[0].TotalAmount, tt.want)
 				}
 			}
 		})

--- a/src/app/mr/page.tsx
+++ b/src/app/mr/page.tsx
@@ -18,11 +18,11 @@ export default function Page() {
             <RiGuideLine className="w-8 h-8 text-slate-700" />
           </div>
           <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 tracking-tight mb-3">
-            運賃計算プログラム
+            JR運賃計算プログラム
           </h1>
 
           <p className="text-sm sm:text-base text-slate-600 leading-relaxed mb-5">
-            在来線の「発駅」「着駅」、および経由を入力してください。<br className="hidden sm:block" />
+            JR在来線の「発駅」「着駅」、および経由を入力してください。<br className="hidden sm:block" />
             片道乗車券の運賃を計算します。
           </p>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,7 +37,7 @@ export default async function Home() {
               </h2>
             </div>
             <p className="text-slate-600 mb-6 grow">
-              一番お得な分割ルートを検索します。実際の旅行や交通費の節約に活用したい方はこちらをご利用ください。
+              一番安くなる分割乗車券の組み合わせを検索します。実際の旅行や交通費の節約に活用したい方はこちらをご利用ください。いわゆる分割定期券にも対応しました。
             </p>
             <div className="text-blue-600 font-bold flex items-center group-hover:translate-x-2 transition-transform duration-300">
               分割計算をする
@@ -56,7 +56,7 @@ export default async function Home() {
               </h2>
             </div>
             <p className="text-slate-600 mb-6 grow">
-              分割計算の基礎となる、JR乗車券の普通運賃を計算します。
+              分割計算の基礎となる、JR乗車券の運賃を計算します。
             </p>
             <div className="text-slate-700 font-bold flex items-center group-hover:translate-x-2 transition-transform duration-300">
               運賃を計算する
@@ -72,7 +72,7 @@ export default async function Home() {
           </h2>
           <div className="space-y-4 text-slate-600 leading-relaxed">
             <p>
-              JRの運賃は乗車経路に応じて計算されますが、途中の駅で乗車券を区切って購入する「分割乗車券」を利用することで、通しで購入するよりも全体の交通費を安く抑えられるケースが数多く存在します。
+              JRの運賃は乗車経路に応じて計算されますが、途中の駅で乗車券を区切って購入する「分割乗車券」を利用することで、通しで購入するよりも安くなるケースが存在します。
             </p>
             <p>
               しかし、数ある駅の中から最も安くなる分割パターンを見つけ出すのは非常に困難です。当サイトでは、情報工学に基づいた独自の経路探索アルゴリズムを活用し、出発駅から到着駅までの多くの組み合わせから「最安となる分割乗車券の組み合わせ」を自動算出します。
@@ -94,7 +94,7 @@ export default async function Home() {
               <li><strong>最大割引額：</strong> 長距離や複雑な境界線を跨ぐルートにおいて、1回の乗車で1,000円以上の差額が発生した事例も存在します。</li>
             </ul>
             <p className="text-sm mt-4">
-              ※実際の割引額や分割枚数は、利用する区間やJRの最新の運賃改定状況によって変動します。
+              ※実際の割引額や分割枚数は、利用する区間やJRの最新の運賃改定状況によって変動します。また、分割乗車券が最安の移動方法とは限らないため、他の交通手段と比較検討することもおすすめします。
             </p>
           </div>
         </div>
@@ -174,7 +174,7 @@ export default async function Home() {
               <div className="mt-3 flex items-start">
                 <span className="shrink-0 bg-slate-200 text-slate-600 w-7 h-7 rounded-full flex items-center justify-center mr-3 text-sm">A</span>
                 <div className="mt-0.5 text-slate-600 leading-relaxed">
-                  はい、全く問題ありません。JRの旅客営業規則に則った正当な乗車券の購入方法です。
+                  いいえ、全く問題ありません。JRの旅客営業規則に則った正当な乗車券の購入方法です。
                   <Link href="https://www.jreast.co.jp/ryokaku/02_hen/04_syo/02_setsu/03.html" className="text-blue-600 underline decoration-blue-600 underline-offset-2 mx-1">
                     旅客営業規則 第157条
                   </Link>
@@ -199,7 +199,7 @@ export default async function Home() {
                   <Link href="https://e5489.jr-odekake.net/e5489/cspc/CBTopMenuPC" className="text-blue-600 underline decoration-blue-600 underline-offset-2 mx-1">
                     e5489
                   </Link>
-                  などのインターネット予約サービスを使うと便利です。駅では発売を断られる可能性があります。
+                  などのインターネット予約サービスを使うと便利です。駅の自動券売機やみどりの窓口では、他駅発の乗車券を発売しないことがあります。
                 </div>
               </div>
             </div>
@@ -262,12 +262,12 @@ export default async function Home() {
             <div className="bg-slate-50 p-5 rounded-xl border border-slate-100">
               <h3 className="font-bold text-slate-800 flex items-start">
                 <span className="shrink-0 bg-blue-100 text-blue-600 w-7 h-7 rounded-full flex items-center justify-center mr-3 text-sm">Q</span>
-                <span className="mt-0.5">定期券や割引乗車券を使った計算できますか？</span>
+                <span className="mt-0.5">割引乗車券やIC定期券を使った計算できますか？</span>
               </h3>
               <div className="mt-3 flex items-start">
                 <span className="shrink-0 bg-slate-200 text-slate-600 w-7 h-7 rounded-full flex items-center justify-center mr-3 text-sm">A</span>
                 <div className="mt-0.5 text-slate-600 leading-relaxed">
-                  現在のプログラムは大人の普通乗車券の計算にのみ対応しています。割引乗車券との併用計算や定期乗車券の対応は今しばらくお待ちください。
+                  現在のプログラムは大人の普通乗車券と通勤定期乗車券の計算に対応しています。割引乗車券との併用計算やIC定期券の対応は今しばらくお待ちください。
                 </div>
               </div>
             </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,7 +33,7 @@ export default async function Home() {
                 <RiScissorsFill className="w-7 h-7 text-blue-600 group-hover:text-white transition-colors duration-300" />
               </div>
               <h2 className="text-2xl font-bold text-slate-800 group-hover:text-blue-600 transition-colors duration-300">
-                分割運賃プログラム
+                JR分割乗車券プログラム
               </h2>
             </div>
             <p className="text-slate-600 mb-6 grow">
@@ -52,11 +52,11 @@ export default async function Home() {
                 <RiGuideLine className="w-7 h-7 text-slate-600 group-hover:text-white transition-colors duration-300" />
               </div>
               <h2 className="text-2xl font-bold text-slate-800">
-                運賃計算プログラム
+                JR運賃計算プログラム
               </h2>
             </div>
             <p className="text-slate-600 mb-6 grow">
-              分割計算の基礎となる、乗車券の普通運賃を計算します。
+              分割計算の基礎となる、JR乗車券の普通運賃を計算します。
             </p>
             <div className="text-slate-700 font-bold flex items-center group-hover:translate-x-2 transition-transform duration-300">
               運賃を計算する

--- a/src/app/split/components/Form.tsx
+++ b/src/app/split/components/Form.tsx
@@ -5,22 +5,51 @@ import { useForm, Controller, SubmitHandler, useWatch } from "react-hook-form";
 import { RiArrowUpDownLine } from "react-icons/ri";
 import { HiChevronDown, HiChevronUp } from "react-icons/hi";
 import { useRouter } from "next/navigation";
+import { sendGAEvent } from '@next/third-parties/google';
 
 import stationDatas from "@/app/split/data/stationDatas.json";
 import SelectStation from "@/app/split/components/SelectStation";
-import { SplitApiResponse, SplitFormInput, Station } from "@/app/types";
+import { SearchOption, SearchType, SplitApiResponse, Station } from "@/app/types";
+
+interface ExtendedSplitFormInput {
+    startStation: Station | null;
+    endStation: Station | null;
+    searchType: SearchType;
+}
 
 interface SplitFormProps {
     initialFrom?: string;
     initialTo?: string;
+    initialSearchType?: string;
     result?: SplitApiResponse | null;
     error?: string | null;
     serverTime?: number | null;
 }
 
+const SEARCH_TYPE_OPTIONS: SearchOption[] = [
+    { value: "ticket", label: "普通乗車券" },
+    { value: "pass1", label: "通勤１箇月" },
+    { value: "pass3", label: "通勤３箇月" },
+    { value: "pass6", label: "通勤６箇月" },
+];
+
+export const TEMPORARY_STATIONS = [
+    "原生花園",
+    "ラベンダー畑",
+    "細岡",
+    "猪苗代湖畔",
+    "ガーラ湯沢",
+    "偕楽園",
+    "鹿島サッカースタジアム",
+    "津島ノ宮",
+    "田井ノ浜",
+    "バルーンさが",
+];
+
 export default function SplitForm({
     initialFrom,
     initialTo,
+    initialSearchType,
     result: initialResult,
     error: initialError,
     serverTime: initialServerTime,
@@ -31,27 +60,39 @@ export default function SplitForm({
     const initialStartStation = initialFrom ? stationDatas.find(s => s.name === initialFrom) || { name: initialFrom, kana: "" } : null;
     const initialEndStation = initialTo ? stationDatas.find(s => s.name === initialTo) || { name: initialTo, kana: "" } : null;
 
-    const { handleSubmit, control, formState: { isValid, errors }, getValues, setValue, reset } = useForm<SplitFormInput>({
+    const defaultSearchType = (initialSearchType === 'pass1' || initialSearchType === 'pass3' || initialSearchType === 'pass6')
+        ? initialSearchType
+        : 'ticket';
+
+    const { handleSubmit, control, formState: { isValid, errors }, getValues, setValue, reset, trigger } = useForm<ExtendedSplitFormInput>({
         mode: 'onChange',
         defaultValues: {
             startStation: initialStartStation,
             endStation: initialEndStation,
+            searchType: defaultSearchType,
         },
     });
 
     useEffect(() => {
         const startStation = initialFrom ? stationDatas.find(s => s.name === initialFrom) || { name: initialFrom, kana: "" } : null;
         const endStation = initialTo ? stationDatas.find(s => s.name === initialTo) || { name: initialTo, kana: "" } : null;
+        const currentSearchType = (initialSearchType === 'pass1' || initialSearchType === 'pass3' || initialSearchType === 'pass6')
+            ? initialSearchType
+            : 'ticket';
+
         reset({
             startStation,
             endStation,
+            searchType: currentSearchType,
         });
-    }, [initialFrom, initialTo, reset]);
+    }, [initialFrom, initialTo, initialSearchType, reset]);
 
     const [showAllPatterns, setShowAllPatterns] = useState(false);
 
     const startStationVal = useWatch({ control, name: "startStation" });
     const endStationVal = useWatch({ control, name: "endStation" });
+    const currentType = useWatch({ control, name: "searchType" });
+
     const canSwap = !!startStationVal || !!endStationVal;
 
     const handleSwapStations = () => {
@@ -66,14 +107,36 @@ export default function SplitForm({
     const validateStation = (value: Station | null) => {
         if (!value || !value.name) return "駅名を入力してください";
         const exists = stations.has(value.name);
-        return exists || "正しい駅名を選択または入力してください";
+        if (!exists) return "正しい駅名を選択または入力してください";
+        const currentSearchType = getValues("searchType");
+        if (currentSearchType !== 'ticket' && TEMPORARY_STATIONS.includes(value.name)) {
+            return "臨時駅発着の定期券は計算できません";
+        }
+
+        return true;
     };
 
-    const onSubmit: SubmitHandler<SplitFormInput> = (data) => {
+    const onSubmit: SubmitHandler<ExtendedSplitFormInput> = (data) => {
         setShowAllPatterns(false);
+
+        if (data.startStation?.name && data.endStation?.name) {
+            sendGAEvent({
+                event: 'search_split',
+                search_type: data.searchType || 'ticket',
+                from_station: data.startStation.name,
+                to_station: data.endStation.name
+            });
+        }
+
         const searchParams = new URLSearchParams();
         if (data.startStation?.name) searchParams.set("from", data.startStation.name);
         if (data.endStation?.name) searchParams.set("to", data.endStation.name);
+
+        if (data.searchType && data.searchType !== 'ticket') {
+            searchParams.set("searchType", data.searchType);
+        } else {
+            searchParams.delete("searchType");
+        }
 
         const newUrl = `?${searchParams.toString()}`;
         window.history.pushState(null, "", newUrl);
@@ -85,7 +148,26 @@ export default function SplitForm({
 
     return (
         <main className="max-w-2xl mx-auto w-full">
-            <form onSubmit={handleSubmit(onSubmit)} className="p-8 w-full">
+            <div className="grid grid-cols-1 sm:grid-cols-4 gap-1.5 p-1 bg-slate-100 rounded-xl mb-6">
+                {SEARCH_TYPE_OPTIONS.map((option) => (
+                    <button
+                        key={option.value}
+                        type="button"
+                        onClick={() => {
+                            setValue("searchType", option.value, { shouldValidate: true });
+                            trigger(["startStation", "endStation"]);
+                        }}
+                        className={`py-2 px-3 text-xs sm:text-sm font-medium rounded-lg transition-all cursor-pointer text-center ${currentType === option.value
+                            ? "bg-white text-blue-600 shadow-xs font-bold"
+                            : "text-slate-600 hover:text-slate-900 hover:bg-white/50"
+                            }`}
+                    >
+                        {option.label}
+                    </button>
+                ))}
+            </div>
+
+            <form onSubmit={handleSubmit(onSubmit)} className="w-full">
                 <div className="flex flex-col gap-4 w-full">
 
                     <div className="flex flex-col w-full">
@@ -157,18 +239,23 @@ export default function SplitForm({
                             className="w-full px-6 py-3 bg-blue-500 text-white rounded disabled:bg-gray-400 hover:bg-blue-600 transition-colors"
                             disabled={!isValid || isPending}
                         >
-                            {isPending ? "計算中..." : "最安分割運賃を計算"}
+                            {isPending ? "計算中..." : `${SEARCH_TYPE_OPTIONS.find(o => o.value === currentType)?.label || "運賃"}を計算`}
                         </button>
                     </div>
                 </div>
             </form>
 
-            <div className="my-8 p-4">
+            <div className="my-8">
                 {isPending && <p className="py-5 border-t text-center text-gray-500">計算中です...</p>}
-                {!isPending && initialServerTime != null && <p className="text-right text-xs text-gray-400">計算時間: {initialServerTime}ms</p>}
+                {!isPending && currentType !== 'ticket' && !initialError && !initialResult && (
+                    <p className="py-8 border-t text-center text-slate-400 text-sm">
+                        ※ {SEARCH_TYPE_OPTIONS.find(o => o.value === currentType)?.label}の最安分割ルート計算ロジックは次のステップで結合されます。
+                    </p>
+                )}
+                {!isPending && initialServerTime != null && currentType === 'ticket' && <p className="text-right text-xs text-gray-400">計算時間: {initialServerTime}ms</p>}
                 {!isPending && initialError && <p className="py-5 border-t text-red-500 text-center">{initialError}</p>}
 
-                {!isPending && initialResult && (
+                {!isPending && initialResult && currentType === 'ticket' && (
                     <div className="border-t pt-8 space-y-8">
                         <h2 className="text-2xl font-bold text-center mb-6">計算結果</h2>
 
@@ -327,6 +414,6 @@ export default function SplitForm({
                     <li><strong>最安分割運賃の計算:</strong> 「最安分割運賃を計算」ボタンを押すと、自動で最安分割運賃と切符の情報が出力されます。</li>
                 </ol>
             </div>
-        </main>
+        </main >
     );
 }

--- a/src/app/split/components/Form.tsx
+++ b/src/app/split/components/Form.tsx
@@ -264,7 +264,7 @@ export default function SplitForm({
                                 <div>
                                     <div className="text-lg font-bold">
                                         <span>{initialResult.cheapestKippuData.departureStation}</span>
-                                        <span className="text-gray-400 mx-2">→</span>
+                                        <span className="text-gray-400 mx-2">{searchedTypeLabel === "普通乗車券" ? "→" : "↔"}</span>
                                         <span>{initialResult.cheapestKippuData.arrivalStation}</span>
                                         {initialResult.cheapestKippuData.totalEigyoKilo > 0 && (
                                             <span className="text-sm font-normal text-gray-600 ml-1">
@@ -344,7 +344,7 @@ export default function SplitForm({
                                                                         <div className="text-lg font-bold text-gray-800 flex items-center flex-wrap gap-2">
                                                                             <span className="bg-blue-100 text-blue-800 px-2 py-0.5 rounded text-xs">切符</span>
                                                                             <span>{segment.kippuData.departureStation}</span>
-                                                                            <span className="text-gray-400">→</span>
+                                                                            <span className="text-gray-400">{searchedTypeLabel === "普通乗車券" ? "→" : "↔"}</span>
                                                                             <span>{segment.kippuData.arrivalStation}</span>
                                                                             {segment.kippuData.totalEigyoKilo > 0 && (
                                                                                 <span className="text-sm font-normal text-gray-600 ml-1">
@@ -415,7 +415,7 @@ export default function SplitForm({
                     <li><strong>種類の選択:</strong> 「普通乗車券」と「定期乗車券(1/3/6箇月)」のいずれかを選択してください。</li>
                     <li><strong>駅の入力:</strong> 「発駅」と「着駅」に駅名を入力し、候補から選択します。</li>
                     <li><strong>駅の入れ替え:</strong> 検索フォームの入力を逆にしたい場合は ⇅ ボタンを押すことで切り替わります。</li>
-                    <li><strong>最安分割運賃の計算:</strong> 「最安分割運賃を計算」ボタンを押すと、自動で最安分割運賃と切符の情報が出力されます。</li>
+                    <li><strong>最安分割運賃の計算:</strong> 計算ボタンを押すと、自動で最安分割運賃と切符の情報が出力されます。</li>
                 </ol>
             </div>
         </main >

--- a/src/app/split/components/Form.tsx
+++ b/src/app/split/components/Form.tsx
@@ -5,7 +5,7 @@ import { useForm, Controller, SubmitHandler, useWatch } from "react-hook-form";
 import { RiArrowUpDownLine } from "react-icons/ri";
 import { HiChevronDown, HiChevronUp } from "react-icons/hi";
 import { useRouter } from "next/navigation";
-import { sendGAEvent } from '@next/third-parties/google';
+import { sendGAEvent } from "@next/third-parties/google";
 
 import stationDatas from "@/app/split/data/stationDatas.json";
 import SelectStation from "@/app/split/components/SelectStation";
@@ -60,12 +60,12 @@ export default function SplitForm({
     const initialStartStation = initialFrom ? stationDatas.find(s => s.name === initialFrom) || { name: initialFrom, kana: "" } : null;
     const initialEndStation = initialTo ? stationDatas.find(s => s.name === initialTo) || { name: initialTo, kana: "" } : null;
 
-    const defaultSearchType = (initialSearchType === 'pass1' || initialSearchType === 'pass3' || initialSearchType === 'pass6')
+    const defaultSearchType = (initialSearchType === "pass1" || initialSearchType === "pass3" || initialSearchType === "pass6")
         ? initialSearchType
-        : 'ticket';
+        : "ticket";
 
     const { handleSubmit, control, formState: { isValid, errors }, getValues, setValue, reset, trigger } = useForm<ExtendedSplitFormInput>({
-        mode: 'onChange',
+        mode: "onChange",
         defaultValues: {
             startStation: initialStartStation,
             endStation: initialEndStation,
@@ -76,9 +76,9 @@ export default function SplitForm({
     useEffect(() => {
         const startStation = initialFrom ? stationDatas.find(s => s.name === initialFrom) || { name: initialFrom, kana: "" } : null;
         const endStation = initialTo ? stationDatas.find(s => s.name === initialTo) || { name: initialTo, kana: "" } : null;
-        const currentSearchType = (initialSearchType === 'pass1' || initialSearchType === 'pass3' || initialSearchType === 'pass6')
+        const currentSearchType = (initialSearchType === "pass1" || initialSearchType === "pass3" || initialSearchType === "pass6")
             ? initialSearchType
-            : 'ticket';
+            : "ticket";
 
         reset({
             startStation,
@@ -86,6 +86,10 @@ export default function SplitForm({
             searchType: currentSearchType,
         });
     }, [initialFrom, initialTo, initialSearchType, reset]);
+
+    const searchedTypeLabel = SEARCH_TYPE_OPTIONS.find(
+        o => o.value === ((initialSearchType === "pass1" || initialSearchType === "pass3" || initialSearchType === "pass6") ? initialSearchType : "ticket")
+    )?.label || "運賃";
 
     const [showAllPatterns, setShowAllPatterns] = useState(false);
 
@@ -109,7 +113,7 @@ export default function SplitForm({
         const exists = stations.has(value.name);
         if (!exists) return "正しい駅名を選択または入力してください";
         const currentSearchType = getValues("searchType");
-        if (currentSearchType !== 'ticket' && TEMPORARY_STATIONS.includes(value.name)) {
+        if (currentSearchType !== "ticket" && TEMPORARY_STATIONS.includes(value.name)) {
             return "臨時駅発着の定期券は計算できません";
         }
 
@@ -121,8 +125,8 @@ export default function SplitForm({
 
         if (data.startStation?.name && data.endStation?.name) {
             sendGAEvent({
-                event: 'search_split',
-                search_type: data.searchType || 'ticket',
+                event: "search_split",
+                search_type: data.searchType || "ticket",
                 from_station: data.startStation.name,
                 to_station: data.endStation.name
             });
@@ -132,7 +136,7 @@ export default function SplitForm({
         if (data.startStation?.name) searchParams.set("from", data.startStation.name);
         if (data.endStation?.name) searchParams.set("to", data.endStation.name);
 
-        if (data.searchType && data.searchType !== 'ticket') {
+        if (data.searchType && data.searchType !== "ticket") {
             searchParams.set("searchType", data.searchType);
         } else {
             searchParams.delete("searchType");
@@ -247,32 +251,29 @@ export default function SplitForm({
 
             <div className="my-8">
                 {isPending && <p className="py-5 border-t text-center text-gray-500">計算中です...</p>}
-                {!isPending && currentType !== 'ticket' && !initialError && !initialResult && (
-                    <p className="py-8 border-t text-center text-slate-400 text-sm">
-                        ※ {SEARCH_TYPE_OPTIONS.find(o => o.value === currentType)?.label}の最安分割ルート計算ロジックは次のステップで結合されます。
-                    </p>
-                )}
-                {!isPending && initialServerTime != null && currentType === 'ticket' && <p className="text-right text-xs text-gray-400">計算時間: {initialServerTime}ms</p>}
+                {!isPending && initialServerTime != null && <p className="text-right text-xs text-gray-400">計算時間: {initialServerTime}ms</p>}
                 {!isPending && initialError && <p className="py-5 border-t text-red-500 text-center">{initialError}</p>}
 
-                {!isPending && initialResult && currentType === 'ticket' && (
+                {!isPending && initialResult && (
                     <div className="border-t pt-8 space-y-8">
                         <h2 className="text-2xl font-bold text-center mb-6">計算結果</h2>
 
                         <section className="bg-gray-50 p-6 rounded-lg shadow-sm border border-gray-200">
-                            <h3 className="font-bold text-lg mb-4 text-gray-700 border-b pb-2">通常の運賃（分割なし）</h3>
+                            <h3 className="font-bold text-lg mb-4 text-gray-700 border-b pb-2">通常の{searchedTypeLabel}（分割なし）</h3>
                             <div className="flex justify-between items-center">
                                 <div>
                                     <div className="text-lg font-bold">
                                         <span>{initialResult.cheapestKippuData.departureStation}</span>
                                         <span className="text-gray-400 mx-2">→</span>
                                         <span>{initialResult.cheapestKippuData.arrivalStation}</span>
-                                        <span className="text-sm font-normal text-gray-600 ml-1">
-                                            （{(initialResult.cheapestKippuData.totalEigyoKilo / 10).toFixed(1)}km）
-                                        </span>
+                                        {initialResult.cheapestKippuData.totalEigyoKilo > 0 && (
+                                            <span className="text-sm font-normal text-gray-600 ml-1">
+                                                （{(initialResult.cheapestKippuData.totalEigyoKilo / 10).toFixed(1)}km）
+                                            </span>
+                                        )}
                                     </div>
                                     <div className="text-sm text-gray-600 mt-1">
-                                        経由：{initialResult.cheapestKippuData.printedViaLines.join('・') || '---'}
+                                        経由：{initialResult.cheapestKippuData.printedViaLines.join("・") || "---"}
                                     </div>
                                 </div>
                                 <div className="text-3xl font-bold text-gray-800">
@@ -289,7 +290,7 @@ export default function SplitForm({
                                     const isCheaper = diff > 0;
 
                                     return (
-                                        <section className={`p-6 rounded-lg shadow-md border-2 ${isCheaper ? 'border-blue-400 bg-blue-50' : 'border-gray-200 bg-white'}`}>
+                                        <section className={`p-6 rounded-lg shadow-md border-2 ${isCheaper ? "border-blue-400 bg-blue-50" : "border-gray-200 bg-white"}`}>
                                             <div className="flex justify-between items-center">
                                                 <div>
                                                     <h3 className="font-bold text-xl text-blue-800">
@@ -320,10 +321,10 @@ export default function SplitForm({
                                         return (
                                             <div
                                                 key={planIndex}
-                                                className={`bg-gray-50 rounded-lg border border-gray-200 relative transition-all duration-300 ${isFadedItem ? 'h-32 overflow-hidden' : 'p-4'
+                                                className={`bg-gray-50 rounded-lg border border-gray-200 relative transition-all duration-300 ${isFadedItem ? "h-32 overflow-hidden" : "p-4"
                                                     }`}
                                             >
-                                                <div className={isFadedItem ? 'p-4' : ''}>
+                                                <div className={isFadedItem ? "p-4" : ""}>
                                                     {initialResult.splitKippuDatasList.length > 1 && (
                                                         <h4 className="font-bold text-gray-700 mb-3 ml-1">
                                                             パターン {planIndex + 1}
@@ -345,9 +346,11 @@ export default function SplitForm({
                                                                             <span>{segment.kippuData.departureStation}</span>
                                                                             <span className="text-gray-400">→</span>
                                                                             <span>{segment.kippuData.arrivalStation}</span>
-                                                                            <span className="text-sm font-normal text-gray-600 ml-1">
-                                                                                （{(segment.kippuData.totalEigyoKilo / 10).toFixed(1)}km）
-                                                                            </span>
+                                                                            {segment.kippuData.totalEigyoKilo > 0 && (
+                                                                                <span className="text-sm font-normal text-gray-600 ml-1">
+                                                                                    （{(segment.kippuData.totalEigyoKilo / 10).toFixed(1)}km）
+                                                                                </span>
+                                                                            )}
                                                                         </div>
                                                                         <div className="text-xs text-gray-500 mt-1 ml-10">
                                                                             経由：{segment.kippuData.printedViaLines.length === 0 ? "---" : segment.kippuData.printedViaLines.join("・")}

--- a/src/app/split/components/Form.tsx
+++ b/src/app/split/components/Form.tsx
@@ -407,11 +407,12 @@ export default function SplitForm({
             <div className="mt-8 pt-6 border-t border-gray-200 text-sm text-gray-500">
                 <h3 className="font-bold text-gray-600 mb-2">💡 当システムについて</h3>
                 <p className="mb-4 leading-relaxed">
-                    出発駅と到着駅を入力するだけで、分割乗車券の最安解を自動計算するツールです。経路は自動探索します。
+                    出発駅と到着駅を入力するだけで、分割乗車券の最安解を自動計算するツールです。経路は自動探索します。普通乗車券と定期乗車券の両方に対応しています。
                 </p>
 
                 <h3 className="font-bold text-gray-600 mb-2">ご利用手順</h3>
                 <ol className="list-decimal list-inside space-y-1 ml-1">
+                    <li><strong>種類の選択:</strong> 「普通乗車券」と「定期乗車券(1/3/6箇月)」のいずれかを選択してください。</li>
                     <li><strong>駅の入力:</strong> 「発駅」と「着駅」に駅名を入力し、候補から選択します。</li>
                     <li><strong>駅の入れ替え:</strong> 検索フォームの入力を逆にしたい場合は ⇅ ボタンを押すことで切り替わります。</li>
                     <li><strong>最安分割運賃の計算:</strong> 「最安分割運賃を計算」ボタンを押すと、自動で最安分割運賃と切符の情報が出力されます。</li>

--- a/src/app/split/page.tsx
+++ b/src/app/split/page.tsx
@@ -1,4 +1,4 @@
-import Form from "@/app/split/components/Form";
+import Form, { TEMPORARY_STATIONS } from "@/app/split/components/Form";
 import type { Metadata } from "next";
 import { RiScissorsFill, RiErrorWarningLine } from "react-icons/ri";
 import { getOptimalSplitWithCache } from '@/app/split/lib/getOptimalSplitWithCache';
@@ -15,6 +15,8 @@ export default async function Page({ searchParams }: { searchParams: Promise<{ [
   const from = typeof params.from === 'string' ? params.from : undefined;
   const to = typeof params.to === 'string' ? params.to : undefined;
 
+  const searchType = typeof params.searchType === 'string' ? params.searchType : 'normal';
+
   let result = null;
   let error = null;
   let serverTime = null;
@@ -27,22 +29,30 @@ export default async function Page({ searchParams }: { searchParams: Promise<{ [
       if (!stations.has(from) || !stations.has(to)) {
         error = "駅名が正しくありません。正しい駅名を選択または入力してください。";
       } else {
-        try {
-
-          const cacheResult = await getOptimalSplitWithCache(from, to);
-          if (!cacheResult) {
-            error = "指定された区間の経路が見つかりませんでした。";
-          } else {
-            result = cacheResult.data;
-            serverTime = cacheResult.time;
+        if (searchType === 'normal') {
+          try {
+            const cacheResult = await getOptimalSplitWithCache(from, to);
+            if (!cacheResult) {
+              error = "指定された区間の経路が見つかりませんでした。";
+            } else {
+              result = cacheResult.data;
+              serverTime = cacheResult.time;
+            }
+          } catch (err: unknown) {
+            if (err instanceof StationCountLimitExceededError) {
+              error = err.message;
+            } else if (err instanceof RouteNotFoundError) {
+              error = err.message;
+            } else {
+              error = "サーバー内部でエラーが発生しました。";
+            }
           }
-        } catch (err: unknown) {
-          if (err instanceof StationCountLimitExceededError) {
-            error = err.message;
-          } else if (err instanceof RouteNotFoundError) {
-            error = err.message;
+        } else {
+          if (TEMPORARY_STATIONS.toString().includes(from) || TEMPORARY_STATIONS.toString().includes(to)) {
+            error = "臨時駅発着の定期券は計算できません。";
+            result = null;
           } else {
-            error = "サーバー内部でエラーが発生しました。";
+            error = "【ダミー表示】現在、定期券（通勤１・３・６箇月）の分割計算機能は開発中です。入力値は正常に取得できています。";
           }
         }
       }
@@ -60,7 +70,7 @@ export default async function Page({ searchParams }: { searchParams: Promise<{ [
             分割乗車券プログラム
           </h1>
           <p className="text-sm sm:text-base text-slate-600">
-            乗車する区間の「発駅」と「着駅」を入力してください。<br className="hidden sm:block" />
+            乗車する区間の「発駅」と「着駅」、および「券種」を選択してください。<br className="hidden sm:block" />
             在来線において最もお得な分割ルートを計算します。
           </p>
         </div>
@@ -75,7 +85,14 @@ export default async function Page({ searchParams }: { searchParams: Promise<{ [
         </div>
 
         <div className="bg-white p-6 sm:p-10 rounded-2xl shadow-sm border border-slate-200">
-          <Form initialFrom={from} initialTo={to} result={result} error={error} serverTime={serverTime} />
+          <Form
+            initialFrom={from}
+            initialTo={to}
+            initialSearchType={searchType}
+            result={result}
+            error={error}
+            serverTime={serverTime}
+          />
         </div>
       </main>
     </div>

--- a/src/app/split/page.tsx
+++ b/src/app/split/page.tsx
@@ -4,7 +4,7 @@ import { RiScissorsFill, RiErrorWarningLine } from "react-icons/ri";
 import { getOptimalSplitWithCache } from "@/app/split/lib/getOptimalSplitWithCache";
 import { StationCountLimitExceededError, RouteNotFoundError } from "@/app/utils/errors";
 import stationDatas from "@/app/split/data/stationDatas.json";
-import { ApiCalculateResponse } from "../types";
+import { ApiCalculateResponse } from "@/app/types";
 
 export const metadata: Metadata = {
   title: "JR分割乗車券プログラム",

--- a/src/app/split/page.tsx
+++ b/src/app/split/page.tsx
@@ -1,21 +1,98 @@
 import Form, { TEMPORARY_STATIONS } from "@/app/split/components/Form";
 import type { Metadata } from "next";
 import { RiScissorsFill, RiErrorWarningLine } from "react-icons/ri";
-import { getOptimalSplitWithCache } from '@/app/split/lib/getOptimalSplitWithCache';
-import { StationCountLimitExceededError, RouteNotFoundError } from '@/app/utils/errors';
+import { getOptimalSplitWithCache } from "@/app/split/lib/getOptimalSplitWithCache";
+import { StationCountLimitExceededError, RouteNotFoundError } from "@/app/utils/errors";
 import stationDatas from "@/app/split/data/stationDatas.json";
+import { ApiCalculateResponse } from "../types";
 
 export const metadata: Metadata = {
   title: "分割乗車券プログラム",
   description: "発駅と着駅から分割乗車券の最安解を計算します。",
 };
 
+async function fetchPassApi(from: string, to: string, months: number) {
+  const start = performance.now();
+  const response = await fetch("https://split-pass-api-yvgda2swha-an.a.run.app/api/split-pass", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ start: from, end: to, months }),
+    cache: "no-store"
+  });
+
+  if (!response.ok) {
+    const errData = await response.json().catch(() => ({}));
+    throw new Error(errData.error || "サーバー内部でエラーが発生しました。");
+  }
+
+  const data: ApiCalculateResponse = await response.json();
+
+  if (!data.results || data.results.length === 0) {
+    throw new Error("経路が見つかりませんでした。");
+  }
+
+  const normalApiResult = data.normal || data.results[0];
+
+  const normalDeparture = normalApiResult.segments[0].path[0];
+  const normalArrival = normalApiResult.segments[normalApiResult.segments.length - 1].path[normalApiResult.segments[normalApiResult.segments.length - 1].path.length - 1];
+  const normalVia = normalApiResult.segments.flatMap((s) => s.via);
+  const normalTotalEigyoKilo = normalApiResult.segments.reduce((acc, s) => acc + (s.totalEigyoKilo || 0), 0);
+
+  const cheapestKippuData = {
+    totalEigyoKilo: normalTotalEigyoKilo,
+    departureStation: normalDeparture,
+    arrivalStation: normalArrival,
+    printedViaLines: normalVia,
+    fare: normalApiResult.totalAmount,
+    validDays: 0,
+  };
+
+  const splitKippuDatasList = [];
+
+  for (const res of data.results) {
+    const splitKippuDatas = [];
+
+    for (let i = 0; i < res.segments.length; i++) {
+      const seg = res.segments[i];
+      const segDeparture = i == 0 ? normalDeparture : seg.path[0];
+      const segArrival = i === res.segments.length - 1 ? normalArrival : seg.path[seg.path.length - 1];
+      const segFare = seg.result.Fare + seg.result.BarrierFreeFee + seg.result.Charge;
+
+      splitKippuDatas.push({
+        departureStation: segDeparture,
+        arrivalStation: segArrival,
+        kippuData: {
+          totalEigyoKilo: seg.totalEigyoKilo || 0,
+          departureStation: segDeparture,
+          arrivalStation: segArrival,
+          printedViaLines: seg.via,
+          fare: segFare,
+          validDays: 0,
+        }
+      });
+    }
+
+    splitKippuDatasList.push({
+      totalFare: res.totalAmount,
+      splitKippuDatas: splitKippuDatas
+    });
+  }
+
+  return {
+    result: {
+      cheapestKippuData,
+      splitKippuDatasList
+    },
+    serverTime: performance.now() - start
+  };
+}
+
 export default async function Page({ searchParams }: { searchParams: Promise<{ [key: string]: string | string[] | undefined }> }) {
   const params = await searchParams;
-  const from = typeof params.from === 'string' ? params.from : undefined;
-  const to = typeof params.to === 'string' ? params.to : undefined;
+  const from = typeof params.from === "string" ? params.from : undefined;
+  const to = typeof params.to === "string" ? params.to : undefined;
 
-  const searchType = typeof params.searchType === 'string' ? params.searchType : 'normal';
+  const searchType = typeof params.searchType === "string" ? params.searchType : "ticket";
 
   let result = null;
   let error = null;
@@ -29,7 +106,7 @@ export default async function Page({ searchParams }: { searchParams: Promise<{ [
       if (!stations.has(from) || !stations.has(to)) {
         error = "駅名が正しくありません。正しい駅名を選択または入力してください。";
       } else {
-        if (searchType === 'normal') {
+        if (searchType === "normal" || searchType === "ticket") {
           try {
             const cacheResult = await getOptimalSplitWithCache(from, to);
             if (!cacheResult) {
@@ -52,7 +129,18 @@ export default async function Page({ searchParams }: { searchParams: Promise<{ [
             error = "臨時駅発着の定期券は計算できません。";
             result = null;
           } else {
-            error = "【ダミー表示】現在、定期券（通勤１・３・６箇月）の分割計算機能は開発中です。入力値は正常に取得できています。";
+            const months = searchType === "pass1" ? 1 : searchType === "pass3" ? 3 : searchType === "pass6" ? 6 : 1;
+            try {
+              const apiData = await fetchPassApi(from, to, months);
+              result = apiData.result;
+              serverTime = apiData.serverTime;
+            } catch (err: unknown) {
+              if (err instanceof Error) {
+                error = err.message;
+              } else {
+                error = "定期券の計算APIとの通信に失敗しました。";
+              }
+            }
           }
         }
       }

--- a/src/app/split/page.tsx
+++ b/src/app/split/page.tsx
@@ -54,13 +54,13 @@ async function fetchPassApi(from: string, to: string, months: number) {
 
     for (let i = 0; i < res.segments.length; i++) {
       const seg = res.segments[i];
-      const segDeparture = i == 0 ? normalDeparture : seg.path[0];
-      const segArrival = i === res.segments.length - 1 ? normalArrival : seg.path[seg.path.length - 1];
+      const segDeparture = seg.path[0];
+      const segArrival = seg.path[seg.path.length - 1];
       const segFare = seg.result.Fare + seg.result.BarrierFreeFee + seg.result.Charge;
 
       splitKippuDatas.push({
-        departureStation: segDeparture,
-        arrivalStation: segArrival,
+        departureStation: i == 0 ? normalDeparture : segDeparture,
+        arrivalStation: i === res.segments.length - 1 ? normalArrival : segArrival,
         kippuData: {
           totalEigyoKilo: seg.totalEigyoKilo || 0,
           departureStation: segDeparture,

--- a/src/app/split/page.tsx
+++ b/src/app/split/page.tsx
@@ -7,8 +7,8 @@ import stationDatas from "@/app/split/data/stationDatas.json";
 import { ApiCalculateResponse } from "../types";
 
 export const metadata: Metadata = {
-  title: "分割乗車券プログラム",
-  description: "発駅と着駅から分割乗車券の最安解を計算します。",
+  title: "JR分割乗車券プログラム",
+  description: "JR在来線の「発駅」「着駅」から普通乗車券と定期乗車券の分割乗車券の最安解を計算します。",
 };
 
 async function fetchPassApi(from: string, to: string, months: number) {
@@ -155,11 +155,11 @@ export default async function Page({ searchParams }: { searchParams: Promise<{ [
             <RiScissorsFill className="w-8 h-8 text-blue-600" />
           </div>
           <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 tracking-tight mb-3">
-            分割乗車券プログラム
+            JR分割乗車券プログラム
           </h1>
           <p className="text-sm sm:text-base text-slate-600">
             乗車する区間の「発駅」と「着駅」、および「券種」を選択してください。<br className="hidden sm:block" />
-            在来線において最もお得な分割ルートを計算します。
+            JR在来線において最もお得な分割ルートを計算します。
           </p>
         </div>
         <div className="mb-6 bg-amber-50 border border-amber-200 rounded-xl p-4 flex items-start gap-3 shadow-sm">

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -160,3 +160,28 @@ export interface SearchOption {
     value: SearchType;
     label: string;
 }
+
+
+interface ApiResult {
+    Fare: number;
+    BarrierFreeFee: number;
+    Charge: number;
+}
+
+interface ApiSegment {
+    path: string[];
+    via: string[];
+    result: ApiResult;
+    totalEigyoKilo?: number;
+}
+
+interface ApiResultResponse {
+    totalAmount: number;
+    segments: ApiSegment[];
+}
+
+export interface ApiCalculateResponse {
+    normal?: ApiResultResponse;
+    results: ApiResultResponse[];
+    error?: string;
+}

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -48,11 +48,6 @@ export interface IFormInput {
     }[];
 }
 
-export interface SplitFormInput {
-    startStation: Station | null;
-    endStation: Station | null;
-}
-
 export interface PathStep {
     stationName: string;
     lineName: string | null;
@@ -158,3 +153,10 @@ export interface OuterSection {
 }
 
 export type CalculationMode = "normal" | "cheapest" | "uncorrect";
+
+export type SearchType = "ticket" | "pass1" | "pass3" | "pass6";
+
+export interface SearchOption {
+    value: SearchType;
+    label: string;
+}


### PR DESCRIPTION
## 概要
Closed #292 

定期券（通勤1箇月・3箇月・6箇月）の最安分割計算機能に関するフロントエンド実装を統合します。
（本PRは `feature/split-pass-ui` および `feature/split-pass-api-integration` での実装内容をまとめた統合PRです）

## 主な変更内容
1. **検索フォームの拡張 (`Form.tsx`)**
   - 検索種別を選択するタブUIを追加
   - 臨時駅（`TEMPORARY_STATIONS`）の定期券検索をブロックするバリデーションを追加
2. **分析基盤への連携 (`Form.tsx`, `layout.tsx`)**
   - `@next/third-parties/google` を導入し、検索実行時にGA4へカスタムイベント（`search_route`）を送信
3. **API連携・結果表示 (`page.tsx`, `Form.tsx`, `types.ts`)**
   - `searchType`（1/3/6箇月）に応じたサーバーサイドロジックの呼び出し処理を追加
   - APIから返却された定期券の分割内訳を描画するUIを実装

## 動作確認手順
1. **通常検索:** 「通勤 6箇月」などを選択し、任意の駅（例：東京〜新宿）で検索し、正しい結果が表示されることを確認。
2. **エラー確認:** 種別を定期券にした状態で、発駅または着駅に「ガーラ湯沢」等の臨時駅を入力し、エラー表示が出ることを確認。
3. **ログ送信確認:** ブラウザのデベロッパーツール（Networkタブ）を開き、検索ボタン押下時に Google Analytics 宛てのリクエストが飛んでいることを確認。
4. **回帰テスト:** 「普通乗車券」の検索が今まで通り正常に動作することを確認。

## 備考
- GA4の設定はBigQuery（サンドボックス/実質無料枠）へエクスポートする前提で構築しています。
- バックエンドの計算ロジック自体は別PR/別タスクでの管理としていますが、本PRにて結合テストまで完了しています。