### PR TITLE
chore: CSPヘッダーの最適化（GA4/AdSense通信許可とセキュリティ強化）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
-## [2.0.0](https://github.com/tojoryohei/kippu-navi/compare/kippu-navi-v1.32.2...kippu-navi-v1.33.0) (2026-06-07)
+## [2.0.0](https://github.com/tojoryohei/kippu-navi/compare/kippu-navi-v1.22.2...kippu-navi-v2.0.0) (2026-06-07)
 
 
 ### Features
 
-* 定期券分割計算機能の追加（フロントエンド統合） ([#293](https://github.com/tojoryohei/kippu-navi/issues/293)) ([81bae9c](https://github.com/tojoryohei/kippu-navi/commit/81bae9cf101e1faf168bcea661f4d848e49c2de1))
+* 定期券分割計算機能の追加 ([#293](https://github.com/tojoryohei/kippu-navi/issues/293)) ([81bae9c](https://github.com/tojoryohei/kippu-navi/commit/81bae9cf101e1faf168bcea661f4d848e49c2de1))
 
 ## [1.22.2](https://github.com/tojoryohei/kippu-navi/compare/kippu-navi-v1.22.1...kippu-navi-v1.22.2) (2026-05-29)
 
@@ -14,7 +14,7 @@
 
 * トップへ戻るボタンの描画パフォーマンス向上およびフッター干渉回避の構造改善 ([#202](https://github.com/tojoryohei/kippu-navi/issues/202)) ([2d2a7d6](https://github.com/tojoryohei/kippu-navi/commit/2d2a7d6bd710341317a38fded1871118df58a245))
 
-## [1.22.1](https://github.com/tojoryohei/kippu-navi/compare/kippu-navi-v1.22.0...kippu-navi-v1.22.1) (2026-05-29)
+## [1.22.1](https://github.com/tojoryohei/kippu-navi/compare/kippu-navi-v1.18.2...kippu-navi-v1.22.1) (2026-05-29)
 
 
 ### Bug Fixes

--- a/next.config.ts
+++ b/next.config.ts
@@ -28,7 +28,7 @@ const nextConfig: NextConfig = {
           },
           {
             key: 'Content-Security-Policy',
-            value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.google-analytics.com https://www.googletagmanager.com https://pagead2.googlesyndication.com https://partner.googleadservices.com https://tpc.googlesyndication.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://*.firebaseio.com https://*.googleapis.com https://www.google-analytics.com https://region1.google-analytics.com https://pagead2.googlesyndication.com; frame-src 'self' https://googleads.g.doubleclick.net https://tpc.googlesyndication.com https://docs.google.com;",
+            value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.google-analytics.com https://www.googletagmanager.com https://pagead2.googlesyndication.com https://partner.googleadservices.com https://tpc.googlesyndication.com https://adservice.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://*.firebaseio.com https://*.googleapis.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.g.doubleclick.net https://pagead2.googlesyndication.com; frame-src 'self' https://googleads.g.doubleclick.net https://tpc.googlesyndication.com https://docs.google.com; frame-ancestors 'self';",
           }
         ],
       },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,7 +59,7 @@ export default async function Home() {
               分割計算の基礎となる、JR乗車券の運賃を計算します。
             </p>
             <div className="text-slate-700 font-bold flex items-center group-hover:translate-x-2 transition-transform duration-300">
-              運賃を計算する
+              運賃計算する
               <svg className="w-5 h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" /></svg>
             </div>
           </Link>


### PR DESCRIPTION
## 概要
Closed #300 
GA4およびAdSenseの通信を安定させるためのインフラ層（セキュリティヘッダー）の修正です。

## 変更内容
- `next.config.ts` の CSP文字列を更新
  - `connect-src` に `*.google-analytics.com`, `*.analytics.google.com` などを追加
  - `frame-ancestors 'self'` を追加し、X-Frame-Optionsの代替措置を実装

## 確認手順
1. このPRのプレビュー環境を開く
2. 開発者ツールのConsoleタブで、CSP違反の赤文字エラーが出ないことを確認する
3. NetworkタブでGA4の初期化通信やAdSenseのスクリプト取得がブロックされていないことを確認する