### PR TITLE
chore: ページタイトルを「JR運賃計算プログラム」に変更し、対象路線を明確化

### DIFF
--- a/src/app/mr/page.tsx
+++ b/src/app/mr/page.tsx
@@ -4,7 +4,7 @@ import { RiGuideLine } from "react-icons/ri";
 
 export const metadata: Metadata = {
   title: "JR運賃計算プログラム",
-  description: "経路を入力してJRの運賃を計算するためのページです。",
+  description: "経路を入力してJRの運賃と営業キロを計算するためのページです。有効期限も正しく計算されます。",
 };
 
 export default function Page() {

--- a/src/app/mr/page.tsx
+++ b/src/app/mr/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { RiGuideLine } from "react-icons/ri";
 
 export const metadata: Metadata = {
-  title: "運賃計算プログラム",
+  title: "JR運賃計算プログラム",
   description: "経路を入力してJRの運賃を計算するためのページです。",
 };
 


### PR DESCRIPTION
## 概要
メタデータの `title` を「運賃計算プログラム」から「JR運賃計算プログラム」に変更しました。
メタデータの `description` を「経路を入力してJRの運賃を計算するためのページです。」から「経路を入力してJRの運賃と営業キロを計算するためのページです。有効期限も正しく計算されます。」に変更しました。

## 変更の背景・目的
これまでのタイトルでは、JR以外の私鉄なども計算できる汎用的なプログラムであるとユーザーに誤解を与える可能性がありました。
タイトルに「JR」と明記することで、当ページが提供する機能を正確に伝え、ユーザーのミスマッチを防ぐとともに、検索エンジン経由での適切なアクセス向上（SEO効果）を目的としています。
また、本文では、営業キロや有効期限についても正しく計算されることを追記しました。

## 変更内容
- `src/app/mr/page.tsx`

## 影響範囲
- 当該ページのブラウザタブの表示名
- 検索エンジン等の検索結果におけるタイトル表示
- OGP等のメタデータ展開時におけるタイトル表示
※ロジックやUIレイアウトへの影響はありません。

## 確認事項
- [x] ローカル環境で正しく「JR運賃計算プログラム」となっていることを確認した
- [x] ビルドエラーが発生しないことを確認した

closed #304 