### PR TITLE
refactor: グラフ依存関係の抽象化とユースケースの疎結合化

### DIFF
--- a/split-pass-api/cmd/api/main.go
+++ b/split-pass-api/cmd/api/main.go
@@ -64,8 +64,7 @@ func run() error {
 
 	// IDを解決
 	if err := addonFareReg.ResolveIDs(func(name string) (int, bool) {
-		id, ok := g.NameToID[name]
-		return id, ok
+		return g.GetID(name)
 	}); err != nil {
 		return fmt.Errorf("加算運賃のID解決に失敗しました: %w", err)
 	}
@@ -76,8 +75,7 @@ func run() error {
 
 	// IDを解決
 	if err := addonChargeReg.ResolveIDs(func(name string) (int, bool) {
-		id, ok := g.NameToID[name]
-		return id, ok
+		return g.GetID(name)
 	}); err != nil {
 		return fmt.Errorf("特急料金のID解決に失敗しました: %w", err)
 	}
@@ -109,8 +107,7 @@ func run() error {
 
 	// IDを解決
 	bypassRules, err := bypassReg.ResolveIDs(func(name string) (int, bool) {
-		id, ok := g.NameToID[name]
-		return id, ok
+		return g.GetID(name)
 	})
 	if err != nil {
 		return fmt.Errorf("特例ルールのID解決に失敗しました: %w", err)

--- a/split-pass-api/cmd/convert-graph/main.go
+++ b/split-pass-api/cmd/convert-graph/main.go
@@ -58,7 +58,7 @@ func run(args []string) error {
 	if err != nil {
 		return fmt.Errorf("バイナリの再読み込みに失敗しました: %w", err)
 	}
-	log.Printf("読み込み完了: 駅数 = %d", len(g2.IDToName))
+	log.Printf("読み込み完了: 駅数 = %d", g2.NumStations())
 
 	return nil
 }

--- a/split-pass-api/internal/fare/route_matcher.go
+++ b/split-pass-api/internal/fare/route_matcher.go
@@ -45,8 +45,8 @@ func routeToPseudoFNV(route []int) uint64 {
 	return h
 }
 
-// LoadFromDomain は JSON からロードしたドメインモデルの配列と Graph (名前解決用) を用いてデータを構築します。
-func (m *RouteMatcher) LoadFromDomain(route_and_fares []domain.RouteAndFare, g *graph.Graph) error {
+// LoadFromDomain は JSON からロードしたドメインモデル의 配列と Graph (名前解決用) を用いてデータを構築します。
+func (m *RouteMatcher) LoadFromDomain(route_and_fares []domain.RouteAndFare, g graph.Graph) error {
 	if g == nil {
 		return fmt.Errorf("LoadFromDomain: %w", graph.ErrInvalidGraph)
 	}

--- a/split-pass-api/internal/graph/dijkstra.go
+++ b/split-pass-api/internal/graph/dijkstra.go
@@ -47,7 +47,7 @@ func (pq *priorityQueue) Pop() interface{} {
 }
 
 // FindShortestPathGisei はダイクストラ法を用いて最短擬制キロ経路を検索します。
-func (g *Graph) FindShortestPathGisei(startID, endID int) (*PathResult, error) {
+func (g *RailwayGraph) FindShortestPathGisei(startID, endID int) (*PathResult, error) {
 	if startID < 0 || startID >= len(g.IDToName) {
 		return nil, fmt.Errorf("FindShortestPathGisei: %w: ID %d", domain.ErrStationNotFound, startID)
 	}
@@ -109,7 +109,7 @@ func (g *Graph) FindShortestPathGisei(startID, endID int) (*PathResult, error) {
 
 // FindAllCandidatePaths は指定された最短擬制キロ以内に収まる全ての合理的な経路を探索します。
 // これにより、分割購入で安くなる可能性がある経路を網羅します。
-func (g *Graph) FindAllCandidatePaths(startID, endID int, maxGisei domain.DeciKilo) ([]*PathResult, error) {
+func (g *RailwayGraph) FindAllCandidatePaths(startID, endID int, maxGisei domain.DeciKilo) ([]*PathResult, error) {
 	if startID < 0 || startID >= len(g.IDToName) {
 		return nil, fmt.Errorf("FindAllCandidatePaths: %w: ID %d", domain.ErrStationNotFound, startID)
 	}

--- a/split-pass-api/internal/graph/graph.go
+++ b/split-pass-api/internal/graph/graph.go
@@ -15,15 +15,41 @@ type StationNameIDMapper struct {
 	IDToName []string
 }
 
-// Graph は駅データとネットワーク構造を統合して管理します。
-type Graph struct {
+// StationProvider は駅名と数値IDの相互変換を処理するためのインターフェースです。
+type StationProvider interface {
+	GetID(name string) (int, bool)
+	GetName(id int) string
+	NumStations() int
+}
+
+// TopologyProvider は駅間の接続情報を取得するためのインターフェースです。
+type TopologyProvider interface {
+	GetEdges(stationID int) []domain.Edge
+}
+
+// PathFinder はグラフ上の経路探索を行うためのインターフェースです。
+type PathFinder interface {
+	FindShortestPathGisei(startID, endID int) (*PathResult, error)
+	FindAllCandidatePaths(startID, endID int, maxGisei domain.DeciKilo) ([]*PathResult, error)
+}
+
+// Graph は駅データとネットワーク構造を統合して管理するためのインターフェースです。
+type Graph interface {
+	StationProvider
+	TopologyProvider
+	PathFinder
+	Validate() error
+}
+
+// RailwayGraph は Graph インターフェースの具象実装です。
+type RailwayGraph struct {
 	*FastGraph
 	*StationNameIDMapper
 }
 
 // NewGraph は空のグラフインスタンスを作成します。
-func NewGraph(numStations int) *Graph {
-	return &Graph{
+func NewGraph(numStations int) *RailwayGraph {
+	return &RailwayGraph{
 		FastGraph:           NewFastGraph(numStations),
 		StationNameIDMapper: NewStationNameIDMapper(),
 	}
@@ -34,6 +60,14 @@ func NewFastGraph(numStations int) *FastGraph {
 	return &FastGraph{
 		Edges: make([][]domain.Edge, numStations),
 	}
+}
+
+// GetEdges は指定された駅IDに隣接するエッジのリストを返します。
+func (g *FastGraph) GetEdges(id int) []domain.Edge {
+	if id < 0 || id >= len(g.Edges) {
+		return nil
+	}
+	return g.Edges[id]
 }
 
 // AddEdge は駅間に有向エッジを追加します。
@@ -84,6 +118,11 @@ func (m *StationNameIDMapper) GetName(id int) string {
 		return ""
 	}
 	return m.IDToName[id]
+}
+
+// NumStations は登録されている駅の総数を返します。
+func (m *StationNameIDMapper) NumStations() int {
+	return len(m.IDToName)
 }
 
 // GetStation は指定されたIDの domain.Station オブジェクトを返します。

--- a/split-pass-api/internal/graph/validate.go
+++ b/split-pass-api/internal/graph/validate.go
@@ -2,7 +2,7 @@ package graph
 
 // Validate はグラフの内部状態が正常であることを検証します。
 // gobデシリアライズ後などにnilスライス・nilマップが残っていないかを確認します。
-func (g *Graph) Validate() error {
+func (g *RailwayGraph) Validate() error {
 	if g.FastGraph == nil || g.Edges == nil {
 		return ErrInvalidGraph
 	}

--- a/split-pass-api/internal/handler/split.go
+++ b/split-pass-api/internal/handler/split.go
@@ -12,12 +12,21 @@ import (
 
 // Split は分割定期券の最適解を計算するHTTPリクエストを処理します。
 type Split struct {
-	graph  *graph.Graph
+	graph interface {
+		graph.StationProvider
+		graph.TopologyProvider
+	}
 	search *usecase.SearchOptimalSplit
 }
 
 // NewSplit は新しい Split を作成します。
-func NewSplit(g *graph.Graph, search *usecase.SearchOptimalSplit) *Split {
+func NewSplit(
+	g interface {
+		graph.StationProvider
+		graph.TopologyProvider
+	},
+	search *usecase.SearchOptimalSplit,
+) *Split {
 	return &Split{
 		graph:  g,
 		search: search,
@@ -79,8 +88,8 @@ func (h *Split) HandleCalculate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	startID, okStart := h.graph.NameToID[req.Start]
-	endID, okEnd := h.graph.NameToID[req.End]
+	startID, okStart := h.graph.GetID(req.Start)
+	endID, okEnd := h.graph.GetID(req.End)
 
 	if !okStart || !okEnd {
 		writeErrorResponse(w, http.StatusBadRequest, "存在しない駅名が含まれています")
@@ -110,7 +119,7 @@ func (h *Split) HandleCalculate(w http.ResponseWriter, r *http.Request) {
 		for j, seg := range res.Segments {
 			pathNames := make([]string, len(seg.Path))
 			for k, id := range seg.Path {
-				pathNames[k] = h.graph.IDToName[id]
+				pathNames[k] = h.graph.GetName(id)
 			}
 			viaNames := usecase.GetVia(h.graph, seg.Path)
 

--- a/split-pass-api/internal/infra/fareio/registry.go
+++ b/split-pass-api/internal/infra/fareio/registry.go
@@ -106,7 +106,7 @@ type Calculators struct {
 }
 
 // InitRegistry はJSONデータをデコードし、全ての運賃計算機を初期化して返します。
-func InitRegistry(g *graph.Graph) (*Calculators, error) {
+func InitRegistry(g graph.Graph) (*Calculators, error) {
 	eastTrunk, err := loadFareTable(eastTrunkFaresJSON)
 	if err != nil {
 		return nil, fmt.Errorf("eastTrunkFaresの読み込みに失敗: %w", err)

--- a/split-pass-api/internal/infra/graphio/gob.go
+++ b/split-pass-api/internal/infra/graphio/gob.go
@@ -15,8 +15,8 @@ type GobLoader struct{}
 
 // Load はバイナリ形式のデータを読み込み、Graph を返します。
 // デシリアライズ後に内部データが nil の場合はエラーを返します。
-func (l *GobLoader) Load(r io.Reader) (*graph.Graph, error) {
-	var g graph.Graph
+func (l *GobLoader) Load(r io.Reader) (graph.Graph, error) {
+	var g graph.RailwayGraph
 	if err := gob.NewDecoder(r).Decode(&g); err != nil {
 		return nil, fmt.Errorf("graphio: gobのデコードに失敗しました: %w", err)
 	}
@@ -29,7 +29,7 @@ func (l *GobLoader) Load(r io.Reader) (*graph.Graph, error) {
 }
 
 // SaveBinary はグラフ全体をバイナリ形式で書き込みます。
-func SaveBinary(g *graph.Graph, w io.Writer) error {
+func SaveBinary(g graph.Graph, w io.Writer) error {
 	if err := g.Validate(); err != nil {
 		return fmt.Errorf("graphio: 保存前の検証に失敗しました: %w", err)
 	}
@@ -40,3 +40,4 @@ func SaveBinary(g *graph.Graph, w io.Writer) error {
 
 	return nil
 }
+

--- a/split-pass-api/internal/infra/graphio/graphio_test.go
+++ b/split-pass-api/internal/infra/graphio/graphio_test.go
@@ -15,8 +15,9 @@ import (
 //
 //	A --(100)--> B --(200)--> C
 //	A --(400)--------------> C
-func newTestGraph() (*graph.Graph, int, int, int) {
+func newTestGraph() (graph.Graph, int, int, int) {
 	g := graph.NewGraph(10)
+
 	startID := g.GetOrAddID("A")
 	midID := g.GetOrAddID("B")
 	endID := g.GetOrAddID("C")
@@ -71,7 +72,7 @@ func TestGobLoader_Load_EmptyReader(t *testing.T) {
 
 func TestSaveBinary_InvalidGraph(t *testing.T) {
 	var buf bytes.Buffer
-	err := graphio.SaveBinary(&graph.Graph{}, &buf)
+	err := graphio.SaveBinary(&graph.RailwayGraph{}, &buf)
 
 	if err == nil {
 		t.Error("不正なグラフに対してエラーが返されませんでした")

--- a/split-pass-api/internal/infra/graphio/json.go
+++ b/split-pass-api/internal/infra/graphio/json.go
@@ -27,7 +27,7 @@ type rawEdge struct {
 
 // Load は JSON データを読み込み、新しい Graph を構築して返します。
 // データが空またはエッジが0件の場合はエラーを返します。
-func (l *JSONLoader) Load(r io.Reader) (*graph.Graph, error) {
+func (l *JSONLoader) Load(r io.Reader) (graph.Graph, error) {
 	var edges []rawEdge
 	decoder := json.NewDecoder(r)
 	decoder.DisallowUnknownFields()

--- a/split-pass-api/internal/infra/graphio/loader.go
+++ b/split-pass-api/internal/infra/graphio/loader.go
@@ -8,5 +8,5 @@ import (
 // Loader はグラフをロードするインターフェースです。
 // JSON・Gobなど形式の異なる実装を統一的に扱えます。
 type Loader interface {
-	Load(r io.Reader) (*graph.Graph, error)
+	Load(r io.Reader) (graph.Graph, error)
 }

--- a/split-pass-api/internal/usecase/calculate_amount.go
+++ b/split-pass-api/internal/usecase/calculate_amount.go
@@ -10,7 +10,7 @@ import (
 // CalculateAmount は経路から定期運賃を計算するユースケースです。
 // グラフ、運賃レジストリ、特定区間加算運賃レジストリを協調させます。
 type CalculateAmount struct {
-	graph                    *graph.Graph
+	graph                    graph.TopologyProvider
 	reg                      *fare.Registry
 	addonFareReg             *domain.AddonRegistry
 	addonChargeReg           *domain.AddonRegistry
@@ -21,7 +21,7 @@ type CalculateAmount struct {
 
 // NewCalculateAmount は新しい CalculateAmount を作成します。
 func NewCalculateAmount(
-	g *graph.Graph,
+	g graph.TopologyProvider,
 	reg *fare.Registry,
 	addonFareReg *domain.AddonRegistry,
 	addonChargeReg *domain.AddonRegistry,
@@ -81,9 +81,10 @@ func (u *CalculateAmount) analyzeRoute(path []int) (*routeSummary, error) {
 
 		// エッジを検索
 		var edge *domain.Edge
-		for j := range u.graph.Edges[fromID] {
-			if u.graph.Edges[fromID][j].ToID == toID {
-				edge = &u.graph.Edges[fromID][j]
+		edges := u.graph.GetEdges(fromID)
+		for j := range edges {
+			if edges[j].ToID == toID {
+				edge = &edges[j]
 				break
 			}
 		}

--- a/split-pass-api/internal/usecase/search_optimal_split.go
+++ b/split-pass-api/internal/usecase/search_optimal_split.go
@@ -24,13 +24,23 @@ type EvaluationTask struct {
 
 // SearchOptimalSplit は候補経路の探索・補正・分割最適化を統括するユースケースです。
 type SearchOptimalSplit struct {
-	graph *graph.Graph
+	graph interface {
+		graph.PathFinder
+		graph.StationProvider
+	}
 	split *FindOptimalSplit
 	rules []domain.ResolvedBypassRule
 }
 
 // NewSearchOptimalSplit は新しい SearchOptimalSplit を作成します。
-func NewSearchOptimalSplit(g *graph.Graph, u *FindOptimalSplit, rules []domain.ResolvedBypassRule) *SearchOptimalSplit {
+func NewSearchOptimalSplit(
+	g interface {
+		graph.PathFinder
+		graph.StationProvider
+	},
+	u *FindOptimalSplit,
+	rules []domain.ResolvedBypassRule,
+) *SearchOptimalSplit {
 	// サーバー起動時に1回だけ、衝突のない安全な双方向ルールを生成・保持する
 	return &SearchOptimalSplit{
 		graph: g,
@@ -65,8 +75,8 @@ func (u *SearchOptimalSplit) Execute(startID, endID, months int) (*OptimalSearch
 	}
 
 	var cheapestAmountPerDecikilo float64
-	kyotoID, kyotoExists := u.graph.NameToID["京都"]
-	osakaID, osakaExists := u.graph.NameToID["大阪"]
+	kyotoID, kyotoExists := u.graph.GetID("京都")
+	osakaID, osakaExists := u.graph.GetID("大阪")
 
 	if kyotoExists && osakaExists {
 		kyotoToOsakaPath, err := u.graph.FindShortestPathGisei(kyotoID, osakaID)

--- a/split-pass-api/internal/usecase/via.go
+++ b/split-pass-api/internal/usecase/via.go
@@ -168,14 +168,20 @@ var viaRules = []viaBypassRule{
 }
 
 // GetVia は経路中の分岐駅の名前リストを返します。
-func GetVia(g *graph.Graph, path []int) []string {
+func GetVia(
+	g interface {
+		graph.StationProvider
+		graph.TopologyProvider
+	},
+	path []int,
+) []string {
 	if len(path) < 2 {
 		return []string{}
 	}
 
 	stationNameList := make([]string, len(path))
 	for i, stationID := range path {
-		stationNameList[i] = g.IDToName[stationID]
+		stationNameList[i] = g.GetName(stationID)
 	}
 
 	var via []string
@@ -193,11 +199,11 @@ func GetVia(g *graph.Graph, path []int) []string {
 		}
 
 		// 2. 通常の分岐駅判定（3駅以上の経路でのみ実行される）
-		if len(g.Edges[path[i]]) > 2 {
+		if len(g.GetEdges(path[i])) > 2 {
 			if i < len(path)-2 {
 				via = append(via, stationNameList[i+1])
 			} else {
-				if i > 0 && !(len(g.Edges[path[i-1]]) > 2) {
+				if i > 0 && !(len(g.GetEdges(path[i-1])) > 2) {
 					via = append(via, stationNameList[i])
 				} else if i == 0 {
 					via = append(via, stationNameList[i])

--- a/split-pass-api/tests/integration/amount_test.go
+++ b/split-pass-api/tests/integration/amount_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // setup はテスト用に本番データを含むユースケースを初期化します。
-func setup(t *testing.T) (*usecase.CalculateAmount, *graph.Graph) {
+func setup(t *testing.T) (*usecase.CalculateAmount, graph.Graph) {
 	t.Helper()
 
 	// 1. グラフのロード
@@ -42,15 +42,13 @@ func setup(t *testing.T) (*usecase.CalculateAmount, *graph.Graph) {
 
 	// 5. ID解決
 	if err := addonFareReg.ResolveIDs(func(name string) (int, bool) {
-		id, ok := g.NameToID[name]
-		return id, ok
+		return g.GetID(name)
 	}); err != nil {
 		t.Fatalf("加算運賃のID解決に失敗しました: %v", err)
 	}
 
 	if err := addonChargeReg.ResolveIDs(func(name string) (int, bool) {
-		id, ok := g.NameToID[name]
-		return id, ok
+		return g.GetID(name)
 	}); err != nil {
 		t.Fatalf("加算料金のID解決に失敗しました: %v", err)
 	}
@@ -78,7 +76,7 @@ func TestAmountCalculation_Integration(t *testing.T) {
 	getIDs := func(names ...string) []int {
 		ids := make([]int, len(names))
 		for i, name := range names {
-			id, ok := g.NameToID[name]
+			id, ok := g.GetID(name)
 			if !ok {
 				t.Fatalf("駅名が見つかりません: %s", name)
 			}


### PR DESCRIPTION
## 概要
Closed #306 

IC定期券専用の分割計算機能の追加に向けた、基盤整理のためのリファクタリングです。
ドメインロジックが具体的なグラフ構造体（`RailwayGraph`）に依存していた問題を解消し、各ユースケースが必要最小限のインターフェースにのみ依存するクリーンなアーキテクチャへと変更しました。

## 変更内容
- **インターフェースの分離 (ISP準拠):**
  - `StationProvider`, `TopologyProvider`, `PathFinder` を新規定義。
- **具象実装の隠蔽:**
  - 従来の `Graph` を `RailwayGraph` へリネーム。
  - `.Edges` や `.NameToID` への直接アクセスを禁止し、ゲッターメソッド経由に修正。
- **DI（依存性の注入）の改善:**
  - `CalculateAmount` は `TopologyProvider` のみに依存。
  - `SearchOptimalSplit` は `PathFinder` と `StationProvider` のみに依存。

## 影響範囲とテスト結果
本PRは純粋なリファクタリングであり、外部の振る舞い（APIレスポンスや計算結果）には一切影響を与えません。

- `go test ./...` 実行結果: 全件Pass
- 既存の運賃計算、最短経路探索、分割最適化のロジックが破壊されていないことを確認済みです。

## 次のステップ (Out of Scope)
本PRマージ後、このインターフェースを利用して `icGraph` （ICエリア専用の非連結グラフ）を生成し、IC専用の探索エンドポイントを追加する機能を別PRにて実装します。