### PR TITLE
feat: GA4トラッキング強化（分割成果の可視化とエラー検知の実装）

### DIFF
--- a/src/app/split/components/Form.tsx
+++ b/src/app/split/components/Form.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useState, useTransition, useEffect } from "react";
+import { useState, useTransition, useEffect, useRef } from "react";
 import { useForm, Controller, SubmitHandler, useWatch } from "react-hook-form";
 import { RiArrowUpDownLine } from "react-icons/ri";
 import { HiChevronDown, HiChevronUp } from "react-icons/hi";
 import { useRouter } from "next/navigation";
-import { sendGAEvent } from "@next/third-parties/google";
 
 import stationDatas from "@/app/split/data/stationDatas.json";
 import SelectStation from "@/app/split/components/SelectStation";
@@ -57,6 +56,8 @@ export default function SplitForm({
     const router = useRouter();
     const [isPending, startTransition] = useTransition();
 
+    const lastTrackedSearch = useRef<string>("");
+
     const initialStartStation = initialFrom ? stationDatas.find(s => s.name === initialFrom) || { name: initialFrom, kana: "" } : null;
     const initialEndStation = initialTo ? stationDatas.find(s => s.name === initialTo) || { name: initialTo, kana: "" } : null;
 
@@ -86,6 +87,51 @@ export default function SplitForm({
             searchType: currentSearchType,
         });
     }, [initialFrom, initialTo, initialSearchType, reset]);
+
+    // GA4 計測用 useEffect (計算結果またはエラーが返ってきたタイミングで実行)
+    useEffect(() => {
+        if (typeof window === "undefined" || typeof window.gtag !== "function") return;
+
+        if (initialFrom && initialTo) {
+            const currentSearchKey = `${initialFrom}_${initialTo}_${initialSearchType || "ticket"}`;
+
+            // 同じ検索条件での重複送信を防止
+            if (lastTrackedSearch.current !== currentSearchKey) {
+                // 1. 正常に計算結果が返ってきた場合
+                if (initialResult) {
+                    const normalFare = initialResult.cheapestKippuData?.fare || 0;
+                    const bestFare = initialResult.splitKippuDatasList?.length > 0
+                        ? initialResult.splitKippuDatasList[0].totalFare
+                        : normalFare;
+
+                    const savedAmount = Math.max(0, normalFare - bestFare);
+                    const isSplitFound = savedAmount > 0;
+
+                    window.gtag("event", "search_split", {
+                        search_type: initialSearchType || "ticket",
+                        from_station: initialFrom,
+                        to_station: initialTo,
+                        is_split_found: isSplitFound,
+                        saved_amount: savedAmount
+                    });
+
+                    lastTrackedSearch.current = currentSearchKey;
+                }
+                // 2. エラーが返ってきた場合
+                else if (initialError) {
+                    window.gtag("event", "search_error", {
+                        search_type: initialSearchType || "ticket",
+                        from_station: initialFrom,
+                        to_station: initialTo,
+                        error_type: "calculation_error",
+                        error_message: initialError
+                    });
+
+                    lastTrackedSearch.current = currentSearchKey;
+                }
+            }
+        }
+    }, [initialFrom, initialTo, initialSearchType, initialResult, initialError]);
 
     const searchedTypeLabel = SEARCH_TYPE_OPTIONS.find(
         o => o.value === ((initialSearchType === "pass1" || initialSearchType === "pass3" || initialSearchType === "pass6") ? initialSearchType : "ticket")
@@ -122,15 +168,6 @@ export default function SplitForm({
 
     const onSubmit: SubmitHandler<ExtendedSplitFormInput> = (data) => {
         setShowAllPatterns(false);
-
-        if (data.startStation?.name && data.endStation?.name) {
-            sendGAEvent({
-                event: "search_split",
-                search_type: data.searchType || "ticket",
-                from_station: data.startStation.name,
-                to_station: data.endStation.name
-            });
-        }
 
         const searchParams = new URLSearchParams();
         if (data.startStation?.name) searchParams.set("from", data.startStation.name);


### PR DESCRIPTION
## 概要
Closed #310 
経路検索のデータ収集基盤において、単なる「検索実行」だけでなく、「アルゴリズムの成果（実用性）」と「異常系の検知」を可能にするための機能拡張を行います。

## 変更内容
- `@next/third-parties` の `sendGAEvent` を削除し、生の `window.gtag` APIへの直接呼び出しへ変更（カスタムパラメータの欠落防止のため）。
- イベント送信のタイミングを `onSubmit` から、サーバーからの結果を受け取った `useEffect` 内へ移動。
- `search_split` イベントに新たなパラメータを追加：
  - `is_split_found` (boolean): 分割解が見つかったか
  - `saved_amount` (number): 通常運賃からいくら安くなったか
- 異常系イベント `search_error` の計測を実装：
  - 計算エラー時に、検索条件とともにエラー内容をGA4へ送信。
- Reactの再レンダリングによるイベントの二重送信を防ぐため、`useRef` を用いた重複防止ロジックを導入。

## 確認手順
1. 本番（またはプレビュー）環境で検索を実行する。
2. 計算結果が表示された後、開発者ツールの Network タブで `collect` 通信を確認する。
3. Payload内に `ep.is_split_found` や `ep.saved_amount` の値が正しく格納されていることを確認する。
4. 存在しない経路などでエラーを発生させ、`en: search_error` イベントが飛ぶことを確認する。