### PR TITLE
feat: PostHogの直接通信への切り替え・負荷遮断およびプライバシーポリシーの改訂

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -28,25 +28,9 @@ const nextConfig: NextConfig = {
           },
           {
             key: 'Content-Security-Policy',
-            value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.google-analytics.com https://www.googletagmanager.com https://pagead2.googlesyndication.com https://partner.googleadservices.com https://tpc.googlesyndication.com https://adservice.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://*.firebaseio.com https://*.googleapis.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.g.doubleclick.net https://pagead2.googlesyndication.com https://*.adtrafficquality.google; frame-src 'self' https://googleads.g.doubleclick.net https://tpc.googlesyndication.com https://docs.google.com; frame-ancestors 'self';",
+            value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.google-analytics.com https://www.googletagmanager.com https://pagead2.googlesyndication.com https://partner.googleadservices.com https://tpc.googlesyndication.com https://adservice.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://*.posthog.com https://*.firebaseio.com https://*.googleapis.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.g.doubleclick.net https://pagead2.googlesyndication.com https://*.adtrafficquality.google; frame-src 'self' https://googleads.g.doubleclick.net https://tpc.googlesyndication.com https://docs.google.com; frame-ancestors 'self';",
           }
         ],
-      },
-    ];
-  },
-  async rewrites() {
-    return [
-      {
-        source: "/ingest/static/:path*",
-        destination: "https://us-assets.i.posthog.com/static/:path*",
-      },
-      {
-        source: "/ingest/:path*",
-        destination: "https://us.i.posthog.com/:path*",
-      },
-      {
-        source: "/ingest/decide",
-        destination: "https://us.i.posthog.com/decide",
       },
     ];
   },

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -24,48 +24,64 @@ export default function PrivacyPage() {
                         アクセス解析ツールについて
                     </h2>
                     <p>
-                        当サイトでは，Googleによるアクセス解析ツール「Google Analytics」を利用しています．
-                        このGoogle Analyticsはトラフィックデータの収集のためにCookieを使用しています．トラフィックデータは匿名で収集されており，個人を特定するものではありません．
+                        当サイトでは、サービスの品質向上や利用状況の分析のため、プロダクト分析ツール「PostHog」および、「Google Analytics」を利用しています。
                     </p>
                     <p className="mt-4">
-                        この機能はCookieを無効にすることで収集を拒否することが出来ますので，お使いのブラウザの設定をご確認ください．
-                        <br />
-                        Google Analyticsの利用規約や，Googleによるデータ使用の仕組みについては，以下のリンクからご確認いただけます．
+                        これらのツールはトラフィックデータやサイト内での行動履歴（検索条件やエラーの発生等）を収集するためにCookieを使用しています。データは匿名で収集されており、個人を特定するものではありません。
                     </p>
-                    <ul className="mt-4 space-y-2 list-disc list-inside ml-2">
-                        <li>
+                    <p className="mt-4">
+                        この機能はCookieを無効にすることで収集を拒否することが出来ますので、お使いのブラウザの設定や、各種ブラウザ拡張機能等をご確認ください。
+                        各ツールの利用規約や、データ使用の仕組みについては、以下のリンクからご確認いただけます。
+                    </p>
+
+                    <ul className="mt-6 space-y-4 list-none ml-1 sm:ml-2">
+                        <li className="flex flex-col space-y-1">
+                            <span className="font-bold text-slate-800 border-l-4 border-slate-300 pl-2 mb-1">
+                                Google Analytics
+                            </span>
                             <Link
                                 href="https://marketingplatform.google.com/about/analytics/terms/jp/"
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="text-blue-600 hover:underline underline-offset-2"
+                                className="text-blue-600 hover:underline underline-offset-2 before:content-['・'] before:mr-1"
                             >
                                 Google Analytics利用規約
                             </Link>
-                        </li>
-                        <li>
                             <Link
                                 href="https://policies.google.com/technologies/partner-sites?hl=ja"
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="text-blue-600 hover:underline underline-offset-2"
+                                className="text-blue-600 hover:underline underline-offset-2 before:content-['・'] before:mr-1"
                             >
                                 Googleのサービスを使用するサイトやアプリから収集した情報のGoogleによる使用
                             </Link>
                         </li>
+
+                        <li className="flex flex-col space-y-1 pt-2">
+                            <span className="font-bold text-slate-800 border-l-4 border-slate-300 pl-2 mb-1">
+                                PostHog
+                            </span>
+                            <Link
+                                href="https://posthog.com/privacy"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-blue-600 hover:underline underline-offset-2 before:content-['・'] before:mr-1"
+                            >
+                                PostHog Privacy Policy
+                            </Link>
+                        </li>
                     </ul>
                 </section>
-
                 <section>
                     <h2 className="text-xl font-bold text-slate-900 border-b pb-2 mb-4">
                         広告の配信について
                     </h2>
                     <p>
-                        当サイトでは，第三者配信の広告サービス（Google AdSense）を利用しています．
-                        広告配信事業者は，ユーザーの興味に応じた広告を表示するためにCookieを使用することがあります．
+                        当サイトでは、第三者配信の広告サービス（Google AdSense）を利用しています。
+                        広告配信事業者は、ユーザーの興味に応じた広告を表示するためにCookieを使用することがあります。
                     </p>
                     <p className="mt-4">
-                        Googleによる広告におけるCookieの取り扱いについては，
+                        Googleによる広告におけるCookieの取り扱いについては、
                         <Link
                             href="https://policies.google.com/technologies/ads?hl=ja"
                             target="_blank"
@@ -74,10 +90,9 @@ export default function PrivacyPage() {
                         >
                             Googleのポリシーと規約ページ
                         </Link>
-                        をご参照ください．
+                        をご参照ください。
                     </p>
                 </section>
-
             </div>
         </div>
     );

--- a/src/app/providers/PostHogProvider.tsx
+++ b/src/app/providers/PostHogProvider.tsx
@@ -15,6 +15,7 @@ if (typeof window !== 'undefined') {
       capture_pageview: false,
       disable_session_recording: true,
       autocapture: false,
+      capture_performance: false,
     });
   }
 }


### PR DESCRIPTION
## 概要
Resolves #321 
PostHog導入に伴う本番環境向けの最終調整とコンプライアンス対応を行いました。
インフラの複雑化とCloud Runの課金リスクを排除するため、リバースプロキシを廃止し、最もシンプルで安全な直接通信のアーキテクチャに変更しています。また、ユーザーへの説明責任を果たすためプライバシーポリシーを更新しました。

## 主な変更内容
1. **インフラの最適化（プロキシ廃止）**
   * `next.config.ts` の `rewrites` 設定を削除。
   * 通信先が自身のドメイン（Cloud Run）を経由しなくなったため、インフラの負荷が完全にゼロになりました。
2. **無料枠の保護（Web Vitalsの遮断）**
   * `src/app/providers/PostHogProvider.tsx` において `capture_performance: false` を追記。
   * ページを開くたびに発火するLCP/CLS等のパフォーマンスイベントを完全にブロックし、月間100万イベントの無料枠を意図したトラッキング（PVと検索結果）のみに集中させます。
3. **プライバシーポリシーの改訂**
   * プライバシーポリシーのコンポーネントを編集し、GA4と併せてPostHogをアクセス解析ツールとして利用している旨を追記しました。

## 影響範囲
* 広告ブロッカーを使用している一部のユーザーのデータは欠損するようになりますが、これはインフラコストとシステムの安定性を優先した仕様上のトレードオフです。
* 一般ユーザーのIPアドレスおよびGeoIP（位置情報）がプロキシを経由せず直接PostHogに届くため、より正確に記録されるようになります。

## 確認手順（How to Test）
### 動作確認
1. `.env.local` の `NEXT_PUBLIC_POSTHOG_HOST` を `https://us.i.posthog.com` に変更して `npm run dev` を起動。
2. ブラウザのNetworkタブを開き、経路検索を実行。
3. PostHogへのリクエスト先が `localhost:3000/ingest/...` ではなく、`https://us.i.posthog.com/e/...` となっていることを確認する。
4. ページ遷移時に `LCP` などの `$performance` 関連のイベントが飛んでいないことを確認する。

### ドキュメント確認
1. サイト上の「プライバシーポリシー」ページへアクセスし、PostHogの記述が正しくレンダリングされていることを確認する。