### PR TITLE
feat: 遅延評価とDFSを用いた同額経路の全列挙および特例ルールの厳格化

### DIFF
--- a/split-pass-api/internal/usecase/search_optimal_split.go
+++ b/split-pass-api/internal/usecase/search_optimal_split.go
@@ -581,8 +581,28 @@ func (u *SearchOptimalSplit) backtrackZeroAlloc(
 }
 
 func (u *SearchOptimalSplit) getCheapestNoSplitSegments(start, end, months int) ([]SplitSegment, error) {
-	cands, err := u.getNoSplitCandidates(start, end)
-	if err != nil || len(cands) == 0 {
+	shortest, err := u.graph.FindShortestPathGisei(start, end)
+	if err != nil {
+		return nil, domain.ErrInvalidPath
+	}
+	maxGisei := shortest.GiseiKilo + 50
+
+	dfsPaths := u.dfsFindPaths(start, end, maxGisei)
+	bypassPaths := u.getBypassCandidates(start, end)
+
+	allPaths := append(dfsPaths, bypassPaths...)
+
+	var validPaths [][]int
+	for _, path := range allPaths {
+		if !u.checkMixedRouteConflict(path) {
+			continue
+		}
+		if !containsPath(validPaths, path) {
+			validPaths = append(validPaths, path)
+		}
+	}
+
+	if len(validPaths) == 0 {
 		return nil, domain.ErrInvalidPath
 	}
 
@@ -590,7 +610,7 @@ func (u *SearchOptimalSplit) getCheapestNoSplitSegments(start, end, months int) 
 	var bestPaths [][]int
 	var bestResults []*CalculationResult
 
-	for _, path := range cands {
+	for _, path := range validPaths {
 		res, err := u.split.calc.Execute(path, months)
 		if err != nil {
 			continue
@@ -623,6 +643,159 @@ func (u *SearchOptimalSplit) getCheapestNoSplitSegments(start, end, months int) 
 	}
 
 	return segs, nil
+}
+
+func (u *SearchOptimalSplit) checkMixedRouteConflict(path []int) bool {
+	pathSet := make(map[int]bool, len(path))
+	for _, sid := range path {
+		pathSet[sid] = true
+	}
+
+	for _, rule := range u.rules {
+		hasShortcutInner := false
+		if len(rule.ShortcutPath) > 2 {
+			for i := 1; i < len(rule.ShortcutPath)-1; i++ {
+				if pathSet[rule.ShortcutPath[i]] {
+					hasShortcutInner = true
+					break
+				}
+			}
+		}
+
+		if !hasShortcutInner {
+			continue
+		}
+
+		hasAllDetour := true
+		for _, detID := range rule.DetourPath {
+			if !pathSet[detID] {
+				hasAllDetour = false
+				break
+			}
+		}
+
+		if hasShortcutInner && hasAllDetour {
+			return false
+		}
+	}
+	return true
+}
+
+func (u *SearchOptimalSplit) dfsFindPaths(start, end int, maxGisei domain.DeciKilo) [][]int {
+	var paths [][]int
+	numStations := int(u.numStations)
+	visited := make([]bool, numStations)
+	currentPath := make([]int, 0, 64)
+
+	currentPath = append(currentPath, start)
+	visited[start] = true
+
+	const maxPathsLimit = 5000
+
+	var dfs func(curr int, currentGisei domain.DeciKilo) bool
+	dfs = func(curr int, currentGisei domain.DeciKilo) bool {
+		if len(paths) >= maxPathsLimit {
+			return false
+		}
+
+		if curr == end {
+			pathCopy := make([]int, len(currentPath))
+			copy(pathCopy, currentPath)
+			paths = append(paths, pathCopy)
+			return true
+		}
+
+		edges := u.graph.GetEdges(curr)
+		for _, edge := range edges {
+			next := edge.ToID
+			if next < 0 || next >= numStations {
+				continue
+			}
+			if visited[next] {
+				continue
+			}
+
+			nextGisei := currentGisei + edge.GiseiKilo
+			if nextGisei > maxGisei {
+				continue
+			}
+
+			visited[next] = true
+			currentPath = append(currentPath, next)
+
+			if !dfs(next, nextGisei) {
+				return false
+			}
+
+			currentPath = currentPath[:len(currentPath)-1]
+			visited[next] = false
+		}
+		return true
+	}
+
+	dfs(start, 0)
+	return paths
+}
+
+func (u *SearchOptimalSplit) getBypassCandidates(start, end int) [][]int {
+	rg := u.graph
+	var cands [][]int
+
+	for _, rule := range u.rules {
+		aOnRule := u.containsStation(rule.ShortcutPath, start) || u.containsStation(rule.DetourPath, start)
+		bOnRule := u.containsStation(rule.ShortcutPath, end) || u.containsStation(rule.DetourPath, end)
+		if aOnRule && bOnRule {
+			aOnDetourMiddle := u.isOnDetourMiddle(start, rule)
+			bOnDetourMiddle := u.isOnDetourMiddle(end, rule)
+			if aOnDetourMiddle || bOnDetourMiddle {
+				shortcutPath := make([]int, len(rule.ShortcutPath))
+				copy(shortcutPath, rule.ShortcutPath)
+				cands = append(cands, shortcutPath)
+				break // 特例区間内での双方向重複生成を遮断
+			}
+		}
+	}
+
+	for _, rule := range u.rules {
+		startOnDetour := u.isOnDetourMiddle(start, rule)
+		endOnDetour := u.isOnDetourMiddle(end, rule)
+
+		if startOnDetour {
+			pathJ2ToEnd, err := rg.FindShortestPathGisei(rule.ShortcutPath[len(rule.ShortcutPath)-1], end)
+			if err == nil && len(pathJ2ToEnd.StationIDs) >= 2 {
+				cand := append([]int(nil), rule.ShortcutPath...)
+				cand = append(cand, pathJ2ToEnd.StationIDs[1:]...)
+				cands = append(cands, cand)
+			}
+
+			pathJ1ToEnd, err := rg.FindShortestPathGisei(rule.ShortcutPath[0], end)
+			if err == nil && len(pathJ1ToEnd.StationIDs) >= 2 {
+				revShortcut := reverseSlice(rule.ShortcutPath)
+				cand := append([]int(nil), revShortcut...)
+				cand = append(cand, pathJ1ToEnd.StationIDs[1:]...)
+				cands = append(cands, cand)
+			}
+		}
+
+		if endOnDetour {
+			pathStartToJ1, err := rg.FindShortestPathGisei(start, rule.ShortcutPath[0])
+			if err == nil && len(pathStartToJ1.StationIDs) >= 2 {
+				cand := append([]int(nil), pathStartToJ1.StationIDs...)
+				cand = append(cand, rule.ShortcutPath[1:]...)
+				cands = append(cands, cand)
+			}
+
+			pathStartToJ2, err := rg.FindShortestPathGisei(start, rule.ShortcutPath[len(rule.ShortcutPath)-1])
+			if err == nil && len(pathStartToJ2.StationIDs) >= 2 {
+				revShortcut := reverseSlice(rule.ShortcutPath)
+				cand := append([]int(nil), pathStartToJ2.StationIDs...)
+				cand = append(cand, revShortcut[1:]...)
+				cands = append(cands, cand)
+			}
+		}
+	}
+
+	return cands
 }
 
 func containsPath(paths [][]int, target []int) bool {
@@ -666,146 +839,6 @@ func generateCombinations(candidates [][]SplitSegment) [][]SplitSegment {
 
 	helper(0, nil)
 	return result
-}
-
-func reconstructPathFromFlat(prev []int16, numStations, start, end int) []int {
-	if len(prev) == 0 || end < 0 || end >= numStations {
-		if start == end {
-			return []int{start}
-		}
-		return nil
-	}
-	idx := start*numStations + end
-	if prev[idx] == -1 && start != end {
-		return nil
-	}
-
-	path := make([]int, 0, 32)
-	curr := end
-	loopCount := 0
-	for curr != start {
-		if curr == -1 || loopCount > numStations {
-			return nil
-		}
-		path = append(path, curr)
-		curr = int(prev[start*numStations+curr])
-		loopCount++
-	}
-	path = append(path, start)
-
-	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
-		path[i], path[j] = path[j], path[i]
-	}
-	return path
-}
-
-func (u *SearchOptimalSplit) getNoSplitCandidates(start, end int) ([][]int, error) {
-	rg := u.graph
-	numStations := int(u.numStations)
-
-	var cands [][]int
-
-	// ① 最短営業キロ経路
-	var pathEigyo []int
-	if len(rg.PrevEigyo) > 0 {
-		pathEigyo = reconstructPathFromFlat(rg.PrevEigyo, numStations, start, end)
-	} else {
-		_, prevEigyo := rg.FindAllShortestPathsEigyo(start)
-		pathEigyo = reconstructPath(prevEigyo, start, end)
-	}
-	if len(pathEigyo) >= 2 {
-		cands = append(cands, pathEigyo)
-	}
-
-	// ② 最短擬制キロ経路
-	var pathGisei []int
-	if len(rg.PrevGisei) > 0 {
-		pathGisei = reconstructPathFromFlat(rg.PrevGisei, numStations, start, end)
-	} else {
-		_, prevGisei := rg.FindAllShortestPathsGisei(start)
-		pathGisei = reconstructPath(prevGisei, start, end)
-	}
-	if len(pathGisei) >= 2 {
-		cands = append(cands, pathGisei)
-	}
-
-	// ③ 経路全体が1つの特例に含まれる場合のみ、近道の経路
-	for _, rule := range u.rules {
-		aOnRule := u.containsStation(rule.ShortcutPath, start) || u.containsStation(rule.DetourPath, start)
-		bOnRule := u.containsStation(rule.ShortcutPath, end) || u.containsStation(rule.DetourPath, end)
-		if aOnRule && bOnRule {
-			aOnDetourMiddle := u.isOnDetourMiddle(start, rule)
-			bOnDetourMiddle := u.isOnDetourMiddle(end, rule)
-			if aOnDetourMiddle || bOnDetourMiddle {
-				shortcutPath := make([]int, len(rule.ShortcutPath))
-				copy(shortcutPath, rule.ShortcutPath)
-				cands = append(cands, shortcutPath)
-			}
-		}
-	}
-
-	// ④ 発着駅が遠回り上にあるが、完全に内包されていない場合、経由していない方の分岐駅まで特例の近道経路（オーバーシュート）
-	for _, rule := range u.rules {
-		startOnDetour := u.isOnDetourMiddle(start, rule)
-		endOnDetour := u.isOnDetourMiddle(end, rule)
-
-		if startOnDetour {
-			// Option A: J1 から進入
-			pathJ2ToEnd, err := rg.FindShortestPathGisei(rule.ShortcutPath[len(rule.ShortcutPath)-1], end)
-			if err == nil && len(pathJ2ToEnd.StationIDs) >= 2 {
-				cand := append([]int(nil), rule.ShortcutPath...)
-				cand = append(cand, pathJ2ToEnd.StationIDs[1:]...)
-				cands = append(cands, cand)
-			}
-
-			// Option B: J2 から進入
-			pathJ1ToEnd, err := rg.FindShortestPathGisei(rule.ShortcutPath[0], end)
-			if err == nil && len(pathJ1ToEnd.StationIDs) >= 2 {
-				revShortcut := reverseSlice(rule.ShortcutPath)
-				cand := append([]int(nil), revShortcut...)
-				cand = append(cand, pathJ1ToEnd.StationIDs[1:]...)
-				cands = append(cands, cand)
-			}
-		}
-
-		if endOnDetour {
-			// Option A: J1 から退出
-			pathStartToJ1, err := rg.FindShortestPathGisei(start, rule.ShortcutPath[0])
-			if err == nil && len(pathStartToJ1.StationIDs) >= 2 {
-				cand := append([]int(nil), pathStartToJ1.StationIDs...)
-				cand = append(cand, rule.ShortcutPath[1:]...)
-				cands = append(cands, cand)
-			}
-
-			// Option B: J2 から退出
-			pathStartToJ2, err := rg.FindShortestPathGisei(start, rule.ShortcutPath[len(rule.ShortcutPath)-1])
-			if err == nil && len(pathStartToJ2.StationIDs) >= 2 {
-				revShortcut := reverseSlice(rule.ShortcutPath)
-				cand := append([]int(nil), pathStartToJ2.StationIDs...)
-				cand = append(cand, revShortcut[1:]...)
-				cands = append(cands, cand)
-			}
-		}
-	}
-
-	return cands, nil
-}
-
-func reconstructPath(prev []int, start, end int) []int {
-	if prev == nil || end < 0 || end >= len(prev) || prev[end] == -1 {
-		if start == end {
-			return []int{start}
-		}
-		return nil
-	}
-	path := []int{}
-	for i := end; i != -1; i = prev[i] {
-		path = append(path, i)
-	}
-	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
-		path[i], path[j] = path[j], path[i]
-	}
-	return path
 }
 
 func (u *SearchOptimalSplit) containsStation(path []int, stationID int) bool {

--- a/split-pass-api/internal/usecase/search_optimal_split_test.go
+++ b/split-pass-api/internal/usecase/search_optimal_split_test.go
@@ -294,6 +294,150 @@ func TestSearchOptimalSplit_Execute(t *testing.T) {
 			t.Errorf("A-B-D または A-C-D の経路組み合わせが不足しています: ABD=%v, ACD=%v", hasABD, hasACD)
 		}
 	})
+
+	t.Run("DFSによる経路列挙とバウンダリ制限の検証", func(t *testing.T) {
+		g4 := graph.NewGraph(10)
+		id4 := func(name string) int { return g4.GetOrAddID(name) }
+
+		// A --(2km)--> B --(2km)--> D (A-B-D: 4km = 40DeciKilo)
+		// A --(4km)--> C --(4km)--> D (A-C-D: 8km = 80DeciKilo)
+		// A --(10km)--> E --(10km)--> D (A-E-D: 200DeciKilo, 制限90を超えるため除外されるべき)
+		g4.AddEdge(domain.Edge{FromID: id4("A"), ToID: id4("B"), EigyoKilo: 20, GiseiKilo: 20, Company: domain.JREast})
+		g4.AddEdge(domain.Edge{FromID: id4("B"), ToID: id4("A"), EigyoKilo: 20, GiseiKilo: 20, Company: domain.JREast})
+		g4.AddEdge(domain.Edge{FromID: id4("B"), ToID: id4("D"), EigyoKilo: 20, GiseiKilo: 20, Company: domain.JREast})
+		g4.AddEdge(domain.Edge{FromID: id4("D"), ToID: id4("B"), EigyoKilo: 20, GiseiKilo: 20, Company: domain.JREast})
+
+		g4.AddEdge(domain.Edge{FromID: id4("A"), ToID: id4("C"), EigyoKilo: 40, GiseiKilo: 40, Company: domain.JREast})
+		g4.AddEdge(domain.Edge{FromID: id4("C"), ToID: id4("A"), EigyoKilo: 40, GiseiKilo: 40, Company: domain.JREast})
+		g4.AddEdge(domain.Edge{FromID: id4("C"), ToID: id4("D"), EigyoKilo: 40, GiseiKilo: 40, Company: domain.JREast})
+		g4.AddEdge(domain.Edge{FromID: id4("D"), ToID: id4("C"), EigyoKilo: 40, GiseiKilo: 40, Company: domain.JREast})
+
+		g4.AddEdge(domain.Edge{FromID: id4("A"), ToID: id4("E"), EigyoKilo: 100, GiseiKilo: 100, Company: domain.JREast})
+		g4.AddEdge(domain.Edge{FromID: id4("E"), ToID: id4("A"), EigyoKilo: 100, GiseiKilo: 100, Company: domain.JREast})
+		g4.AddEdge(domain.Edge{FromID: id4("E"), ToID: id4("D"), EigyoKilo: 100, GiseiKilo: 100, Company: domain.JREast})
+		g4.AddEdge(domain.Edge{FromID: id4("D"), ToID: id4("E"), EigyoKilo: 100, GiseiKilo: 100, Company: domain.JREast})
+
+		reg4 := fare.NewRegistry()
+		var dummyTable4 [101]domain.PassPrice
+		for i := range dummyTable4 {
+			if i <= 10 {
+				dummyTable4[i] = domain.PassPrice{OneMonth: 1000}
+			} else {
+				dummyTable4[i] = domain.PassPrice{OneMonth: 2000}
+			}
+		}
+		reg4.Register(domain.JREast, fare.NewEastCalculator(dummyTable4, dummyTable4))
+		reg4.Register(domain.JRCentral, fare.NewStandardCalculator(dummyTable4, dummyTable4))
+
+		calcAmount4 := usecase.NewCalculateAmount(
+			g4, reg4, domain.NewAddonRegistry(), domain.NewAddonRegistry(),
+			fare.NewTrainSpecificSectionCalculator(dummyTable4),
+			fare.NewRouteMatcher(), fare.NewRouteMatcher(),
+		)
+		split4 := usecase.NewFindOptimalSplit(optimizer.NewDPOptimizer(calcAmount4), calcAmount4)
+		fares4 := precomputeFaresForTest(g4, calcAmount4, nil)
+
+		search := usecase.NewSearchOptimalSplit(g4, split4, nil, 0, fares4, int32(g4.NumStations()))
+
+		got, err := search.Execute(id4("A"), id4("D"), 1)
+		if err != nil {
+			t.Fatalf("Execute が失敗しました: %v", err)
+		}
+
+		if got.Normal.TotalAmount != 1000 {
+			t.Errorf("TotalAmount = %d, 期待値は 1000", got.Normal.TotalAmount)
+		}
+
+		hasACD := false
+		hasABD := false
+		hasAED := false
+		for _, opt := range got.Optimals {
+			for _, seg := range opt.Segments {
+				if isMatch(seg.Path, []int{id4("A"), id4("C"), id4("D")}) {
+					hasACD = true
+				}
+				if isMatch(seg.Path, []int{id4("A"), id4("B"), id4("D")}) {
+					hasABD = true
+				}
+				if isMatch(seg.Path, []int{id4("A"), id4("E"), id4("D")}) {
+					hasAED = true
+				}
+			}
+		}
+
+		if !hasABD {
+			t.Errorf("最短経路 A-B-D が検出されませんでした")
+		}
+		if !hasACD {
+			t.Errorf("バウンダリ以内の迂回経路 A-C-D が検出されませんでした")
+		}
+		if hasAED {
+			t.Errorf("バウンダリ制限を超える経路 A-E-D が検出されてしまいました")
+		}
+	})
+
+	t.Run("特例ルート混在排除ルールの検証", func(t *testing.T) {
+		g5 := graph.NewGraph(10)
+		id5 := func(name string) int { return g5.GetOrAddID(name) }
+
+		// A --(1km)--> B --(1km)--> C (近道 A-B-C: 2km = 20DeciKilo, 内側駅 B)
+		// A --(2km)--> D --(2km)--> C (遠回り A-D-C: 4km = 40DeciKilo, 遠回り駅 A, D, C)
+		g5.AddEdge(domain.Edge{FromID: id5("A"), ToID: id5("B"), EigyoKilo: 10, GiseiKilo: 10, Company: domain.JREast})
+		g5.AddEdge(domain.Edge{FromID: id5("B"), ToID: id5("A"), EigyoKilo: 10, GiseiKilo: 10, Company: domain.JREast})
+		g5.AddEdge(domain.Edge{FromID: id5("B"), ToID: id5("C"), EigyoKilo: 10, GiseiKilo: 10, Company: domain.JREast})
+		g5.AddEdge(domain.Edge{FromID: id5("C"), ToID: id5("B"), EigyoKilo: 10, GiseiKilo: 10, Company: domain.JREast})
+
+		g5.AddEdge(domain.Edge{FromID: id5("A"), ToID: id5("D"), EigyoKilo: 20, GiseiKilo: 20, Company: domain.JREast})
+		g5.AddEdge(domain.Edge{FromID: id5("D"), ToID: id5("A"), EigyoKilo: 20, GiseiKilo: 20, Company: domain.JREast})
+		g5.AddEdge(domain.Edge{FromID: id5("D"), ToID: id5("C"), EigyoKilo: 20, GiseiKilo: 20, Company: domain.JREast})
+		g5.AddEdge(domain.Edge{FromID: id5("C"), ToID: id5("D"), EigyoKilo: 20, GiseiKilo: 20, Company: domain.JREast})
+
+		g5.AddEdge(domain.Edge{FromID: id5("B"), ToID: id5("D"), EigyoKilo: 10, GiseiKilo: 10, Company: domain.JREast})
+		g5.AddEdge(domain.Edge{FromID: id5("D"), ToID: id5("B"), EigyoKilo: 10, GiseiKilo: 10, Company: domain.JREast})
+
+		rules := []domain.ResolvedBypassRule{
+			{
+				ShortcutPath: []int{id5("A"), id5("B"), id5("C")},
+				DetourPath:   []int{id5("A"), id5("D"), id5("C")},
+			},
+		}
+
+		reg5 := fare.NewRegistry()
+		var dummyTable5 [101]domain.PassPrice
+		for i := range dummyTable5 {
+			dummyTable5[i] = domain.PassPrice{OneMonth: 1000}
+		}
+		reg5.Register(domain.JREast, fare.NewEastCalculator(dummyTable5, dummyTable5))
+		reg5.Register(domain.JRCentral, fare.NewStandardCalculator(dummyTable5, dummyTable5))
+
+		calcAmount5 := usecase.NewCalculateAmount(
+			g5, reg5, domain.NewAddonRegistry(), domain.NewAddonRegistry(),
+			fare.NewTrainSpecificSectionCalculator(dummyTable5),
+			fare.NewRouteMatcher(), fare.NewRouteMatcher(),
+		)
+		split5 := usecase.NewFindOptimalSplit(optimizer.NewDPOptimizer(calcAmount5), calcAmount5)
+		fares5 := precomputeFaresForTest(g5, calcAmount5, rules)
+
+		search := usecase.NewSearchOptimalSplit(g5, split5, rules, 0, fares5, int32(g5.NumStations()))
+
+		got, err := search.Execute(id5("B"), id5("C"), 1)
+		if err != nil {
+			t.Fatalf("Execute が失敗しました: %v", err)
+		}
+
+		hasMixedRoute := false
+		for _, opt := range got.Optimals {
+			for _, seg := range opt.Segments {
+				if isMatch(seg.Path, []int{id5("B"), id5("A"), id5("D"), id5("C")}) {
+					hasMixedRoute = true
+				}
+			}
+		}
+
+		if hasMixedRoute {
+			t.Errorf("特例ルート混在排除ルールに違反する経路 (B-A-D-C) が除外されませんでした")
+		}
+	})
 }
 
 // テスト用運賃事前計算ヘルパー


### PR DESCRIPTION
## 概要
Closed #337 
経路復元フェーズ（`getCheapestNoSplitSegments`）において遅延評価を導入し、同額最安となるすべての経路を漏れなく抽出してレスポンスに含める大規模なリファクタリングを行いました。

## 変更内容
1. **DFSによる単純パス列挙 (`dfsFindPaths`) の実装**
   - 探索の上限バウンダリを `最短擬制キロ + 50 DeciKilo (5km)` に設定し、条件内の全経路を列挙するDFSを実装しました。
   - サーバー保護の観点から、パス生成数のハードリミットを `5000` 件に設定し、超過時は安全に打ち切るフェールセーフを設けています。
2. **特例ルート混在排除ルールの実装 (`checkMixedRouteConflict`)**
   - 「近道ルートの内側駅」と「遠回りルートのすべての駅」の両方を同時に通る異常な迂回経路を検知し、重い運賃計算APIに投げる前に $O(1)$ の配列チェックで破棄するバリデーションを追加しました。
3. **既存ロジックの整理**
   - 旧 `getNoSplitCandidates` から距離ベースの抽出処理を削除し、特例区間の候補抽出に限定した `getBypassCandidates` へ責務を分離・整理しました。

## ⚠️ アーキテクチャ上の決定（Decision Record）
- **上限バウンダリの設定基準:** 当初、「最も単価の安い区間（京都ー大阪）のキロ単価」を用いた理論上の最大上限距離を採用する案もありましたが、都市部の密なグラフでは経路数が指数関数的に爆発し、5000件の制限に即座に到達して正しい経路が押し出される危険性がありました。「5km以上遠回りして安くなるケースは実用上存在しない」というヒューリスティックに基づき、固定バッファ（+50）を採用することで、網羅性とパフォーマンスの最適なバランスを担保しています。
- **特例バリデーションの条件:** 合法な経路（遠回りルートの"一部"だけを経由して他路線に抜ける迂回）を誤って枝刈りして False Positive を起こさないよう、排除条件を「遠回りルートの"すべての"駅を通る場合」に限定し、JR旅客営業規則に準拠した厳格なモデリングとしています。

## 検証結果
- `search_optimal_split_test.go` に追加したDFS列挙および混在ルールのユニットテストを通過。
- 既存テストにデグレードが発生していないことを確認。