### PR TITLE
ci: WIF認証引き継ぎの修正とgcloud storageコマンドへの移行による高速化

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Get precomputed_server.bin Metadata
         id: gcs-meta
         run: |
-          MD5=$(gsutil stat gs://kippu-navi-build-secrets/data/precomputed_server.bin | grep "Hash (md5):" | awk '{print $3}')
+          MD5=$(gcloud storage objects describe gs://kippu-navi-build-secrets/data/precomputed_server.bin --format="value(md5Hash)")
           CLEAN_MD5=$(echo "$MD5" | tr -dc 'a-zA-Z0-9')
           echo "md5=$CLEAN_MD5" >> $GITHUB_OUTPUT
 
@@ -61,7 +61,7 @@ jobs:
       - name: Download Precomputed Server Binary
         if: steps.cache-bin.outputs.cache-hit != 'true'
         run: |
-          gsutil cp gs://kippu-navi-build-secrets/data/precomputed_server.bin ./split-pass-api/internal/graph/data/
+          gcloud storage cp gs://kippu-navi-build-secrets/data/precomputed_server.bin ./split-pass-api/internal/graph/data/
 
       - name: Build and Push Docker Image
         run: |

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -34,6 +34,9 @@ jobs:
           service_account: '${{ secrets.SA_EMAIL }}'
           token_format: 'access_token'
 
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
       - name: Login to Artifact Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,10 +103,10 @@ jobs:
       - name: Download data from private GCS
         if: steps.cache.outputs.cache-hit != 'true' && github.actor != 'dependabot[bot]'
         run: |
-          gsutil -m cp gs://kippu-navi-build-secrets/data/*.db ./src/data/
-          gsutil -m cp gs://kippu-navi-build-secrets/data/*.json ./src/data/
-          gsutil -m cp gs://kippu-navi-build-secrets/mr/data/*.json ./src/app/mr/data/
-          gsutil -m cp gs://kippu-navi-build-secrets/split/data/*.json ./src/app/split/data/
+          gcloud storage cp gs://kippu-navi-build-secrets/data/*.db ./src/data/
+          gcloud storage cp gs://kippu-navi-build-secrets/data/*.json ./src/data/
+          gcloud storage cp gs://kippu-navi-build-secrets/mr/data/*.json ./src/app/mr/data/
+          gcloud storage cp gs://kippu-navi-build-secrets/split/data/*.json ./src/app/split/data/
 
       - name: Install dependencies
         run: npm ci
@@ -176,7 +176,7 @@ jobs:
       - name: Download data from private GCS
         if: steps.cache.outputs.cache-hit != 'true' && github.actor != 'dependabot[bot]'
         run: |
-          gsutil -m cp gs://kippu-navi-build-secrets/data/routes.json ./src/data/
+          gcloud storage cp gs://kippu-navi-build-secrets/data/routes.json ./src/data/
 
       - name: Run Go Test
         working-directory: split-pass-api

--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -1,21 +1,21 @@
 steps:
   # 1. 秘匿バケットから DB・JSON データをダウンロードし、所定のディレクトリに配置する（本番と同様）
-  - name: 'gcr.io/cloud-builders/gsutil'
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: 'bash'
     args:
       - '-c'
       - |
         mkdir -p src/data
-        gsutil -m cp gs://kippu-navi-build-secrets/data/*.db ./src/data/
-        gsutil -m cp gs://kippu-navi-build-secrets/data/*.json ./src/data/
+        gcloud storage cp gs://kippu-navi-build-secrets/data/*.db ./src/data/
+        gcloud storage cp gs://kippu-navi-build-secrets/data/*.json ./src/data/
         mkdir -p src/app/mr/data
-        gsutil -m cp gs://kippu-navi-build-secrets/mr/data/*.json ./src/app/mr/data/
+        gcloud storage cp gs://kippu-navi-build-secrets/mr/data/*.json ./src/app/mr/data/
         mkdir -p src/app/split/data
-        gsutil -m cp gs://kippu-navi-build-secrets/split/data/*.json ./src/app/split/data/
+        gcloud storage cp gs://kippu-navi-build-secrets/split/data/*.json ./src/app/split/data/
         
         # Wasm and Graph data injection
-        gsutil cp gs://kippu-navi-build-secrets/wasm/split_pass.wasm ./public/
-        gsutil cp gs://kippu-navi-build-secrets/wasm/graph_data.bin ./public/
+        gcloud storage cp gs://kippu-navi-build-secrets/wasm/split_pass.wasm ./public/
+        gcloud storage cp gs://kippu-navi-build-secrets/wasm/graph_data.bin ./public/
 
   # 2. JSON が揃った状態で Docker ビルドを実行する（タグを PR 番号に変更）
   - name: 'gcr.io/cloud-builders/docker'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,21 +1,21 @@
 steps:
   # 1. 秘匿バケットから DB・JSON データをダウンロードし、所定のディレクトリに配置する
-  - name: 'gcr.io/cloud-builders/gsutil'
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: 'bash'
     args:
       - '-c'
       - |
         mkdir -p src/data
-        gsutil -m cp gs://kippu-navi-build-secrets/data/*.db ./src/data/
-        gsutil -m cp gs://kippu-navi-build-secrets/data/*.json ./src/data/
+        gcloud storage cp gs://kippu-navi-build-secrets/data/*.db ./src/data/
+        gcloud storage cp gs://kippu-navi-build-secrets/data/*.json ./src/data/
         mkdir -p src/app/mr/data
-        gsutil -m cp gs://kippu-navi-build-secrets/mr/data/*.json ./src/app/mr/data/
+        gcloud storage cp gs://kippu-navi-build-secrets/mr/data/*.json ./src/app/mr/data/
         mkdir -p src/app/split/data
-        gsutil -m cp gs://kippu-navi-build-secrets/split/data/*.json ./src/app/split/data/
+        gcloud storage cp gs://kippu-navi-build-secrets/split/data/*.json ./src/app/split/data/
         
         # Wasm and Graph data injection
-        gsutil cp gs://kippu-navi-build-secrets/wasm/split_pass.wasm ./public/
-        gsutil cp gs://kippu-navi-build-secrets/wasm/graph_data.bin ./public/
+        gcloud storage cp gs://kippu-navi-build-secrets/wasm/split_pass.wasm ./public/
+        gcloud storage cp gs://kippu-navi-build-secrets/wasm/graph_data.bin ./public/
 
   # 2. JSON が揃った状態で Docker ビルドを実行する
   - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
## 関連Issue
Resolves #346 

## 変更内容
1. **WIF認証コンテキストの引き継ぎ修正**
   - `google-github-actions/setup-gcloud@v2` ステップを追加し、`gsutil` および `gcloud` コマンドが匿名ユーザー（Anonymous）として弾かれる問題を解消しました。
2. **gcloud storage コマンドへの移行**
   - 巨大なバイナリファイル（500MB超）の転送を最適化するため、レガシーな `gsutil` を次世代の `gcloud storage` にリプレイスしました。
   - キャッシュキー生成のためのMD5取得処理を、`grep/awk` による文字列操作から `gcloud storage objects describe ... --format="value(md5Hash)"` に変更し、シェルスクリプトの堅牢性を向上させました。

## 検証手順
1. 本PRのブランチにてActionsを手動実行（`workflow_dispatch` またはダミーコミットのPush）する。
2. `Authenticate to Google Cloud` 後の `Setup gcloud CLI` が正常に完了していることを確認する。
3. `Get precomputed_server.bin Metadata` ステップにて、MD5ハッシュが正しく取得され、次ステップのキャッシュキーとして解決されていることを確認する。
4. `Download Precomputed Server Binary` ステップにて、`401` エラーが発生せず、高速にダウンロードが完了することを確認する。

## レビュアーへの特記事項（改善点）
本PRによりCIのデプロイエラーは解消され、ダウンロード自体も高速化されます。しかし、`actions/cache@v4` によるキャッシュ容量（上限10GB）の圧迫問題は依然として残っています。
ハッシュキーが変わる（グラフデータが更新される）頻度を監視し、必要に応じてキャッシュの自動パージを行う別ワークフローの導入、またはデプロイ対象ブランチの厳格化を次のフェーズで検討する必要があります。