### PR TITLE
fix: 分割候補がない短距離区間でのエラー表示を解消し、通し運賃へフォールバックする

### DIFF
--- a/src/app/split/components/Form.tsx
+++ b/src/app/split/components/Form.tsx
@@ -469,11 +469,6 @@ export default function SplitForm({
                 setIsCalculating(false);
             } else if (res.result && "passStations" in res.result) {
                 const { passStations } = res.result as { passStations: { normal: string[], results: string[][] } };
-                if (!passStations.results || passStations.results.length === 0) {
-                    setError("有効な分割候補が見つかりませんでした。");
-                    setIsCalculating(false);
-                    return;
-                }
 
                 if (!workerRef.current) {
                     setError("計算エンジン (Web Worker) が初期化されていません。しばらく待ってから再度お試しください。");
@@ -484,10 +479,14 @@ export default function SplitForm({
                 const monthsMap: Record<string, number> = { pass1: 1, pass3: 3, pass6: 6 };
                 const months = monthsMap[data.searchType] || 1;
 
+                const splitPaths = (passStations.results && passStations.results.length > 0)
+                    ? passStations.results
+                    : [passStations.normal];
+
                 workerRef.current.postMessage({
                     type: "calculate",
                     payload: {
-                        splitPaths: passStations.results,
+                        splitPaths,
                         months,
                         isIc: isIcPass
                     }


### PR DESCRIPTION
## 関連Issue
Resolves #351 

## 変更内容
フロントエンド（`Form.tsx`）における、APIレスポンスのハンドリングロジックを修正しました。
- 分割候補（`results`）が空配列（`[]`）であってもエラー状態へ遷移させないよう条件分岐を修正しました。
- 分割による節約ルートが存在しない場合、フォールバックデータである通し運賃（`normal`）を正しく結果表示コンポーネントへ渡し、「通し運賃のみ」として画面にレンダリングできるように改善しました。

## 影響範囲・検証手順
1. 本PRの環境にて、分割の余地がない短距離区間（例：茂原 ⇄ 新茂原）を入力し、計算を実行する。
2. 画面上に「有効な分割候補が見つかりませんでした。」というエラーが表示されないことを確認する。
3. 結果エリアに「通し運賃」の金額と経路が正しく表示され、分割による節約額が「0円」または該当なしとして適切にレンダリングされることを確認する。

## レビュアーへの特記事項
本修正により、エンドユーザーが短距離区間を検索した際の意図しないエラー画面への遷移（UXの低下）を解消しました。
事象の根本原因である「フロントエンド側での境界値テストの不足」については、次回の品質改善スプリントにて、隣接駅や短距離区間を想定したUIテストケース（Jest / Playwright等）を拡充するIssueを別途起票します。