### PR TITLE
feat: /mr への定期乗車券計算機能の追加および経由印字ロジックのGo側への集約

### DIFF
--- a/split-pass-api/cmd/wasm/main.go
+++ b/split-pass-api/cmd/wasm/main.go
@@ -321,12 +321,12 @@ func reconstructAndCalculate(this js.Value, args []js.Value) interface{} {
 	combinations := generateCombinationsWasm(allSegCandidates)
 
 	type SegmentResponse struct {
-		Path           []string                  `json:"path"`
-		Via            []string                  `json:"via"`
+		Path           []string                   `json:"path"`
+		Via            []string                   `json:"via"`
 		Result         *usecase.CalculationResult `json:"result"`
-		TotalEigyoKilo domain.DeciKilo           `json:"totalEigyoKilo"`
-		Start          string                    `json:"start"`
-		End            string                    `json:"end"`
+		TotalEigyoKilo domain.DeciKilo            `json:"totalEigyoKilo"`
+		Start          string                     `json:"start"`
+		End            string                     `json:"end"`
 	}
 
 	type ResultResponse struct {
@@ -704,12 +704,72 @@ func generateCombinationsWasm(segs [][]SplitSegment) [][]SplitSegment {
 	return helper(0)
 }
 
+func calculateRoutePass(this js.Value, args []js.Value) interface{} {
+	stationNamesJson := args[0].String()
+	months := args[1].Int()
+	isIc := args[2].Bool()
+
+	if isIc {
+		activeGraph = icGraph
+		activeAmountCalc = icAmountCalc
+	} else {
+		activeGraph = baseGraph
+		activeAmountCalc = baseAmountCalc
+	}
+
+	var stationNames []string
+	if err := json.Unmarshal([]byte(stationNamesJson), &stationNames); err != nil {
+		return js.ValueOf(fmt.Sprintf(`{"error":"JSON unmarshal failed: %v"}`, err))
+	}
+
+	if len(stationNames) < 2 {
+		return js.ValueOf(`{"error":"at least 2 stations required"}`)
+	}
+
+	stationIDs := make([]int, len(stationNames))
+	for i, name := range stationNames {
+		id, ok := wasmGraph.GetID(name)
+		if !ok {
+			return js.ValueOf(fmt.Sprintf(`{"error":"station not found: %s"}`, name))
+		}
+		stationIDs[i] = id
+	}
+
+	res, err := activeAmountCalc.Execute(stationIDs, months)
+	if err != nil {
+		return js.ValueOf(fmt.Sprintf(`{"error":"calculation failed: %v"}`, err))
+	}
+
+	viaList := usecase.GetVia(wasmGraph, stationIDs)
+
+	type RoutePassResponse struct {
+		Fare            int      `json:"fare"`
+		BarrierFreeFee  int      `json:"barrierFreeFee"`
+		Charge          int      `json:"charge"`
+		TotalEigyoKilo  int      `json:"totalEigyoKilo"`
+		PrintedViaLines []string `json:"printedViaLines"`
+		Error           string   `json:"error,omitempty"`
+	}
+
+	resp := RoutePassResponse{
+		Fare:            res.Fare,
+		BarrierFreeFee:  res.BarrierFreeFee,
+		Charge:          res.Charge,
+		TotalEigyoKilo:  int(res.TotalEigyoKilo),
+		PrintedViaLines: viaList,
+	}
+
+	resBytes, _ := json.Marshal(resp)
+	return js.ValueOf(string(resBytes))
+}
+
 func main() {
-	c := make(chan struct{}, 0)
+	c := make(chan struct{})
 
 	js.Global().Set("prepareGraphBuffer", js.FuncOf(prepareGraphBuffer))
 	js.Global().Set("initGraphFromBuffer", js.FuncOf(initGraphFromBuffer))
 	js.Global().Set("reconstructAndCalculate", js.FuncOf(reconstructAndCalculate))
+	js.Global().Set("calculateRoutePass", js.FuncOf(calculateRoutePass))
 
 	<-c
 }

--- a/split-pass-api/cmd/wasm/main.go
+++ b/split-pass-api/cmd/wasm/main.go
@@ -271,6 +271,7 @@ func initGraphFromBuffer(this js.Value, args []js.Value) interface{} {
 		return js.ValueOf(fmt.Sprintf("error: ResolveIDs failed: %v", err))
 	}
 	bypassRules = rules
+	initPassBypassRules()
 
 	// 初期化完了に伴い、一時バッファへのピン留めを解除しGCに開放
 	tempBuffer = nil
@@ -704,10 +705,245 @@ func generateCombinationsWasm(segs [][]SplitSegment) [][]SplitSegment {
 	return helper(0)
 }
 
+type passBypassRule struct {
+	detour   []int
+	shortcut []int
+}
+
+var passBypassRules []passBypassRule
+
+func initPassBypassRules() {
+	rawRules := []struct {
+		detour   []string
+		shortcut []string
+	}{
+		{
+			detour:   []string{"大沼", "鹿部", "渡島沼尻", "渡島砂原", "掛澗", "尾白内", "東森", "森"},
+			shortcut: []string{"大沼", "大沼公園", "赤井川", "駒ケ岳", "森"},
+		},
+		{
+			detour:   []string{"日暮里", "西日暮里", "田端", "上中里", "王子", "東十条", "赤羽"},
+			shortcut: []string{"日暮里", "尾久", "赤羽"},
+		},
+		{
+			detour:   []string{"赤羽", "北赤羽", "浮間舟渡", "戸田公園", "（北）戸田", "北戸田", "武蔵浦和", "中浦和", "南与野", "与野本町", "北与野", "大宮"},
+			shortcut: []string{"赤羽", "川口", "西川口", "蕨", "南浦和", "浦和", "北浦和", "与野", "さいたま新都心", "大宮"},
+		},
+		{
+			detour:   []string{"品川", "西大井", "武蔵小杉", "新川崎", "鶴見"},
+			shortcut: []string{"品川", "大井町", "大森", "蒲田", "川崎", "鶴見"},
+		},
+	}
+
+	passBypassRules = nil
+	for _, r := range rawRules {
+		detIDs := make([]int, len(r.detour))
+		for i, name := range r.detour {
+			id, _ := wasmGraph.GetID(name)
+			detIDs[i] = id
+		}
+		shIDs := make([]int, len(r.shortcut))
+		for i, name := range r.shortcut {
+			id, _ := wasmGraph.GetID(name)
+			shIDs[i] = id
+		}
+		passBypassRules = append(passBypassRules, passBypassRule{
+			detour:   detIDs,
+			shortcut: shIDs,
+		})
+	}
+}
+
+func applyNormalBypassCorrection(path []int) []int {
+	for _, rule := range passBypassRules {
+		if index, ok := findSubslice(path, rule.detour); ok {
+			if !hasAnyInnerShortcut(path, rule.shortcut) {
+				path, _ = replaceSubsliceAt(path, index, len(rule.detour), rule.shortcut)
+			}
+		} else if index, ok := findSubslice(path, reverseSlice(rule.detour)); ok {
+			if !hasAnyInnerShortcut(path, rule.shortcut) {
+				path, _ = replaceSubsliceAt(path, index, len(rule.detour), reverseSlice(rule.shortcut))
+			}
+		}
+	}
+	return path
+}
+
+func findSubslice(slice []int, target []int) (int, bool) {
+	n := len(slice)
+	m := len(target)
+	if m == 0 || n < m {
+		return -1, false
+	}
+	for i := 0; i <= n-m; i++ {
+		match := true
+		for j := 0; j < m; j++ {
+			if slice[i+j] != target[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func replaceSubsliceAt(slice []int, start, length int, newSeq []int) ([]int, bool) {
+	res := make([]int, 0, len(slice)-length+len(newSeq))
+	res = append(res, slice[:start]...)
+	res = append(res, newSeq...)
+	res = append(res, slice[start+length:]...)
+	return res, true
+}
+
+func hasAnyInnerShortcut(path []int, shortcut []int) bool {
+	inner := shortcut[1 : len(shortcut)-1]
+	for _, sID := range inner {
+		for _, pID := range path {
+			if sID == pID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func generateCheapestCandidates(path []int) [][]int {
+	var candidates [][]int
+	normalPath := applyNormalBypassCorrection(path)
+	candidates = append(candidates, normalPath)
+
+	start := path[0]
+	end := path[len(path)-1]
+
+	var startExtensions [][]int
+	for _, rule := range passBypassRules {
+		if isStationInMiddle(start, rule.shortcut) {
+			p1 := getSubpathOnRule(rule.shortcut, rule.shortcut[0], start)
+			startExtensions = append(startExtensions, p1)
+			p2 := getSubpathOnRule(rule.shortcut, rule.shortcut[len(rule.shortcut)-1], start)
+			startExtensions = append(startExtensions, p2)
+		}
+		if isStationInMiddle(start, rule.detour) {
+			p1 := getSubpathOnRule(rule.detour, rule.detour[0], start)
+			startExtensions = append(startExtensions, p1)
+			p2 := getSubpathOnRule(rule.detour, rule.detour[len(rule.detour)-1], start)
+			startExtensions = append(startExtensions, p2)
+		}
+	}
+
+	var endExtensions [][]int
+	for _, rule := range passBypassRules {
+		if isStationInMiddle(end, rule.shortcut) {
+			p1 := getSubpathOnRule(rule.shortcut, end, rule.shortcut[0])
+			endExtensions = append(endExtensions, p1)
+			p2 := getSubpathOnRule(rule.shortcut, end, rule.shortcut[len(rule.shortcut)-1])
+			endExtensions = append(endExtensions, p2)
+		}
+		if isStationInMiddle(end, rule.detour) {
+			p1 := getSubpathOnRule(rule.detour, end, rule.detour[0])
+			endExtensions = append(endExtensions, p1)
+			p2 := getSubpathOnRule(rule.detour, end, rule.detour[len(rule.detour)-1])
+			endExtensions = append(endExtensions, p2)
+		}
+	}
+
+	var basePaths [][]int
+	basePaths = append(basePaths, normalPath)
+
+	for _, ext := range startExtensions {
+		if len(ext) > 1 {
+			cand := append([]int(nil), ext...)
+			cand = append(cand, normalPath[1:]...)
+			basePaths = append(basePaths, cand)
+		}
+	}
+
+	var finalCandidates [][]int
+	finalCandidates = append(finalCandidates, basePaths...)
+	for _, bp := range basePaths {
+		for _, ext := range endExtensions {
+			if len(ext) > 1 {
+				cand := append([]int(nil), bp...)
+				cand = append(cand, ext[1:]...)
+				finalCandidates = append(finalCandidates, cand)
+			}
+		}
+	}
+
+	var finalCorrected [][]int
+	for _, cand := range finalCandidates {
+		corr := applyNormalBypassCorrection(cand)
+		if !containsPath(finalCorrected, corr) {
+			finalCorrected = append(finalCorrected, corr)
+		}
+	}
+
+	return finalCorrected
+}
+
+func isStationInMiddle(stationID int, rulePath []int) bool {
+	if len(rulePath) < 3 {
+		return false
+	}
+	for i := 1; i < len(rulePath)-1; i++ {
+		if rulePath[i] == stationID {
+			return true
+		}
+	}
+	return false
+}
+
+func getSubpathOnRule(rulePath []int, from, to int) []int {
+	fromIdx := -1
+	toIdx := -1
+	for i, id := range rulePath {
+		if id == from {
+			fromIdx = i
+		}
+		if id == to {
+			toIdx = i
+		}
+	}
+	if fromIdx == -1 || toIdx == -1 {
+		return nil
+	}
+
+	if fromIdx < toIdx {
+		res := make([]int, toIdx-fromIdx+1)
+		copy(res, rulePath[fromIdx:toIdx+1])
+		return res
+	} else {
+		res := make([]int, fromIdx-toIdx+1)
+		for i := 0; i < len(res); i++ {
+			res[i] = rulePath[fromIdx-i]
+		}
+		return res
+	}
+}
+
+func isPathValidWasm(path []int) bool {
+	if len(path) < 2 {
+		return true
+	}
+	firstPart := path[:len(path)-1]
+	seen := make(map[int]bool)
+	for _, id := range firstPart {
+		if seen[id] {
+			return false
+		}
+		seen[id] = true
+	}
+	return true
+}
+
 func calculateRoutePass(this js.Value, args []js.Value) interface{} {
 	stationNamesJson := args[0].String()
 	months := args[1].Int()
 	isIc := args[2].Bool()
+	calculationMode := args[3].String()
 
 	if isIc {
 		activeGraph = icGraph
@@ -735,12 +971,49 @@ func calculateRoutePass(this js.Value, args []js.Value) interface{} {
 		stationIDs[i] = id
 	}
 
-	res, err := activeAmountCalc.Execute(stationIDs, months)
+	var finalPath []int
+	if calculationMode == "uncorrect" {
+		finalPath = stationIDs
+	} else if calculationMode == "normal" {
+		finalPath = applyNormalBypassCorrection(stationIDs)
+	} else if calculationMode == "cheapest" {
+		cands := generateCheapestCandidates(stationIDs)
+		minFare := math.MaxInt
+		var bestPath []int
+		for _, cand := range cands {
+			if !isPathValidWasm(cand) {
+				continue
+			}
+			res, err := activeAmountCalc.Execute(cand, months)
+			if err != nil {
+				continue
+			}
+			fare := res.TotalAmount()
+			if fare < minFare {
+				minFare = fare
+				bestPath = cand
+			}
+		}
+		if bestPath == nil {
+			finalPath = applyNormalBypassCorrection(stationIDs)
+		} else {
+			finalPath = bestPath
+		}
+	} else {
+		finalPath = applyNormalBypassCorrection(stationIDs)
+	}
+
+	res, err := activeAmountCalc.Execute(finalPath, months)
 	if err != nil {
 		return js.ValueOf(fmt.Sprintf(`{"error":"calculation failed: %v"}`, err))
 	}
 
-	viaList := usecase.GetVia(wasmGraph, stationIDs)
+	viaList := usecase.GetVia(wasmGraph, finalPath)
+
+	correctedPathNames := make([]string, len(finalPath))
+	for i, id := range finalPath {
+		correctedPathNames[i] = wasmGraph.GetName(id)
+	}
 
 	type RoutePassResponse struct {
 		Fare            int      `json:"fare"`
@@ -748,6 +1021,7 @@ func calculateRoutePass(this js.Value, args []js.Value) interface{} {
 		Charge          int      `json:"charge"`
 		TotalEigyoKilo  int      `json:"totalEigyoKilo"`
 		PrintedViaLines []string `json:"printedViaLines"`
+		CorrectedPath   []string `json:"correctedPath"`
 		Error           string   `json:"error,omitempty"`
 	}
 
@@ -757,6 +1031,7 @@ func calculateRoutePass(this js.Value, args []js.Value) interface{} {
 		Charge:          res.Charge,
 		TotalEigyoKilo:  int(res.TotalEigyoKilo),
 		PrintedViaLines: viaList,
+		CorrectedPath:   correctedPathNames,
 	}
 
 	resBytes, _ := json.Marshal(resp)

--- a/src/app/api/mr/route.ts
+++ b/src/app/api/mr/route.ts
@@ -1,5 +1,5 @@
+import { generateKippu, getCorrectedPath } from '@/app/mr/lib/generateKippu';
 import { NextResponse } from 'next/server';
-import { generateKippu } from '@/app/mr/lib/generateKippu';
 
 import { RouteRequest } from '@/app/types';
 
@@ -33,6 +33,37 @@ export async function POST(request: Request) {
                     time: calculationTimeMs
                 },
                 { status: 400 }
+            );
+        }
+
+        const isPass = body.searchType && body.searchType !== "ticket";
+        if (isPass) {
+            const correctedPath = getCorrectedPath(body.path, body.calculationMode);
+            const stationNames = correctedPath.map(p => p.stationName);
+            const firstPart = stationNames.slice(0, -1);
+            const hasDuplicateInFirstPart = firstPart.some((name, index) => firstPart.indexOf(name) !== index);
+            if (hasDuplicateInFirstPart) {
+                const endTime = performance.now();
+                const calculationTimeMs = endTime - startTime;
+                return NextResponse.json(
+                    {
+                        error: '経路が重複しています。',
+                        time: calculationTimeMs
+                    },
+                    { status: 400 }
+                );
+            }
+
+            const endTime = performance.now();
+            const calculationTimeMs = endTime - startTime;
+            return NextResponse.json(
+                {
+                    data: {
+                        correctedPath: stationNames
+                    },
+                    time: calculationTimeMs
+                },
+                { status: 200 }
             );
         }
 

--- a/src/app/api/mr/route.ts
+++ b/src/app/api/mr/route.ts
@@ -38,8 +38,20 @@ export async function POST(request: Request) {
 
         const isPass = body.searchType && body.searchType !== "ticket";
         if (isPass) {
+            const TEMPORARY_STATIONS = [
+                "原生花園",
+                "ラベンダー畑",
+                "細岡",
+                "猪苗代湖畔",
+                "ガーラ湯沢",
+                "偕楽園",
+                "鹿島サッカースタジアム",
+                "津島ノ宮",
+                "田井ノ浜",
+                "バルーンさが"
+            ];
             const fullPath = createFullPath(body.path);
-            const stationNames = fullPath.map(p => p.stationName);
+            const stationNames = fullPath.map(p => p.stationName).filter(name => !TEMPORARY_STATIONS.includes(name));
             const firstPart = stationNames.slice(0, -1);
             const hasDuplicateInFirstPart = firstPart.some((name, index) => firstPart.indexOf(name) !== index);
             if (hasDuplicateInFirstPart) {

--- a/src/app/api/mr/route.ts
+++ b/src/app/api/mr/route.ts
@@ -1,4 +1,4 @@
-import { generateKippu, getCorrectedPath } from '@/app/mr/lib/generateKippu';
+import { generateKippu, createFullPath } from '@/app/mr/lib/generateKippu';
 import { NextResponse } from 'next/server';
 
 import { RouteRequest } from '@/app/types';
@@ -38,8 +38,8 @@ export async function POST(request: Request) {
 
         const isPass = body.searchType && body.searchType !== "ticket";
         if (isPass) {
-            const correctedPath = getCorrectedPath(body.path, body.calculationMode);
-            const stationNames = correctedPath.map(p => p.stationName);
+            const fullPath = createFullPath(body.path);
+            const stationNames = fullPath.map(p => p.stationName);
             const firstPart = stationNames.slice(0, -1);
             const hasDuplicateInFirstPart = firstPart.some((name, index) => firstPart.indexOf(name) !== index);
             if (hasDuplicateInFirstPart) {

--- a/src/app/api/mr/route.ts
+++ b/src/app/api/mr/route.ts
@@ -50,6 +50,20 @@ export async function POST(request: Request) {
                 "田井ノ浜",
                 "バルーンさが"
             ];
+            const startName = body.path[0].stationName;
+            const endName = body.path[body.path.length - 1].stationName;
+            if (TEMPORARY_STATIONS.includes(startName) || TEMPORARY_STATIONS.includes(endName)) {
+                const endTime = performance.now();
+                const calculationTimeMs = endTime - startTime;
+                return NextResponse.json(
+                    {
+                        error: '臨時駅発着の定期券は計算できません',
+                        time: calculationTimeMs
+                    },
+                    { status: 400 }
+                );
+            }
+
             const fullPath = createFullPath(body.path);
             const stationNames = fullPath.map(p => p.stationName).filter(name => !TEMPORARY_STATIONS.includes(name));
             const firstPart = stationNames.slice(0, -1);

--- a/src/app/mr/components/Form.tsx
+++ b/src/app/mr/components/Form.tsx
@@ -2,7 +2,7 @@
 
 import { useForm, Controller, SubmitHandler, useFieldArray, useWatch } from "react-hook-form";
 import type { SingleValue } from "react-select";
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { RiArrowUpDownLine } from "react-icons/ri";
 
 import stationData from "@/app/mr/data/stations.json";
@@ -10,27 +10,154 @@ import lineData from "@/app/mr/data/lines.json";
 import SelectStation from "@/app/mr/components/SelectStation";
 import SelectLine from "@/app/mr/components/SelectLine";
 
-import { Station, Line, KippuData, ApiFullResponse, IFormInput, PathStep, CalculationMode } from "@/app/types";
+import { Station, Line, KippuData, IFormInput, PathStep, CalculationMode } from "@/app/types";
 
 const stationMap = new Map(stationData.map(s => [s.name, s]));
 
+const TEMPORARY_STATIONS = [
+    "原生花園",
+    "ラベンダー畑",
+    "細岡",
+    "猪苗代湖畔",
+    "ガーラ湯沢",
+    "偕楽園",
+    "鹿島サッカースタジアム",
+    "津島ノ宮",
+    "田井ノ浜",
+    "バルーンさが",
+];
+
 interface FormValues extends IFormInput {
     calculationMode: CalculationMode;
+    searchType: "ticket" | "pass1" | "pass3" | "pass6";
 }
 
 export default function Form() {
-    const { register, handleSubmit, control, setValue, getValues, formState: { isValid } } = useForm<FormValues>({
+    const { register, handleSubmit, control, setValue, getValues, trigger, formState: { isValid } } = useForm<FormValues>({
         mode: 'onChange',
         defaultValues: {
             startStation: null,
             segments: [{ viaLine: null, destinationStation: null }],
             calculationMode: "normal",
+            searchType: "ticket",
         },
     });
 
     const { fields, append, replace } = useFieldArray({ control, name: "segments" });
 
     const formValues = useWatch({ control }) as FormValues;
+
+    // React state hooks defined before workerRef / useEffect to satisfy ESLint variable declaration order
+    const [result, setResult] = useState<KippuData | null>(null);
+    const [serverTime, setServerTime] = useState<number | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const workerRef = useRef<Worker | null>(null);
+    const [isWasmReady, setIsWasmReady] = useState(false);
+    const calculationCountRef = useRef<number>(0);
+
+    const [resultPass, setResultPass] = useState<{
+        fare: number;
+        barrierFreeFee: number;
+        charge: number;
+        totalEigyoKilo: number;
+        printedViaLines?: string[];
+    } | null>(null);
+    const [correctedStartPass, setCorrectedStartPass] = useState<string>("");
+    const [correctedEndPass, setCorrectedEndPass] = useState<string>("");
+
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+
+        const initWorker = () => {
+            if (workerRef.current) {
+                workerRef.current.terminate();
+                workerRef.current = null;
+            }
+            setIsWasmReady(false);
+
+            const worker = new Worker(new URL("../../split/split-pass.worker.ts", import.meta.url));
+            workerRef.current = worker;
+            calculationCountRef.current = 0;
+
+            worker.onmessage = (e) => {
+                const { type, result: wResult, error: wError } = e.data;
+                if (type === "ready") {
+                    setIsWasmReady(true);
+                } else if (type === "success_route_pass") {
+                    setResultPass(wResult);
+                    setIsLoading(false);
+
+                    calculationCountRef.current += 1;
+                    if (calculationCountRef.current >= 10) {
+                        console.log("Recycling Web Worker to reclaim Wasm linear memory...");
+                        initWorker();
+                    }
+                } else if (type === "error") {
+                    setError(wError);
+                    setIsLoading(false);
+                }
+            };
+        };
+
+        initWorker();
+
+        return () => {
+            if (workerRef.current) {
+                workerRef.current.terminate();
+                workerRef.current = null;
+            }
+        };
+    }, []);
+
+    const currentType = formValues.searchType;
+    const isPeriodDisabled = currentType === "ticket";
+
+    const handleTabChange = (tab: "ticket" | "pass") => {
+        setResult(null);
+        setResultPass(null);
+        setCorrectedStartPass("");
+        setCorrectedEndPass("");
+        setError(null);
+        setServerTime(null);
+
+        const nextSearchType = tab === "ticket" ? "ticket" : "pass1";
+        setValue("searchType", nextSearchType, { shouldValidate: true });
+
+        // 即時バリデーション
+        setTimeout(() => {
+            if (!getValues("startStation")) return;
+            const fieldsCount = getValues("segments").length;
+            const fieldsToTrigger = ["startStation"];
+            if (fieldsCount > 0) {
+                fieldsToTrigger.push(`segments.${fieldsCount - 1}.destinationStation`);
+            }
+            trigger(fieldsToTrigger as Parameters<typeof trigger>[0]);
+        }, 0);
+    };
+
+    const handlePeriodChange = (period: "pass1" | "pass3" | "pass6") => {
+        setResult(null);
+        setResultPass(null);
+        setCorrectedStartPass("");
+        setCorrectedEndPass("");
+        setError(null);
+        setServerTime(null);
+
+        setValue("searchType", period, { shouldValidate: true });
+
+        // 即時バリデーション
+        setTimeout(() => {
+            if (!getValues("startStation")) return;
+            const fieldsCount = getValues("segments").length;
+            const fieldsToTrigger = ["startStation"];
+            if (fieldsCount > 0) {
+                fieldsToTrigger.push(`segments.${fieldsCount - 1}.destinationStation`);
+            }
+            trigger(fieldsToTrigger as Parameters<typeof trigger>[0]);
+        }, 0);
+    };
 
     const lastSegment = formValues.segments?.[formValues.segments?.length - 1];
     const lastDestination = lastSegment?.destinationStation;
@@ -117,19 +244,18 @@ export default function Form() {
 
         return {
             path,
-            calculationMode: data.calculationMode
+            calculationMode: data.calculationMode,
+            searchType: data.searchType
         };
     };
-
-    const [result, setResult] = useState<KippuData | null>(null);
-    const [serverTime, setServerTime] = useState<number | null>(null);
-    const [isLoading, setIsLoading] = useState(false);
-    const [error, setError] = useState<string | null>(null);
 
     const onSubmit: SubmitHandler<FormValues> = async (data) => {
         setIsLoading(true);
         setError(null);
         setResult(null);
+        setResultPass(null);
+        setCorrectedStartPass("");
+        setCorrectedEndPass("");
         setServerTime(null);
 
         const apiRequestBody = createApiRequestBody(data);
@@ -162,10 +288,31 @@ export default function Form() {
                 throw new Error(errorData.error);
             }
 
-            const responseData: ApiFullResponse = await response.json();
-            if (responseData.data && typeof responseData.time === "number") {
+            const responseData = await response.json();
+            if (responseData.data && "correctedPath" in responseData.data) {
+                if (!workerRef.current || !isWasmReady) {
+                    throw new Error("計算エンジン (Web Worker) が初期化されていません。しばらく待ってから再度お試しください。");
+                }
+                const monthsMap: Record<string, number> = { pass1: 1, pass3: 3, pass6: 6 };
+                const months = monthsMap[data.searchType] || 1;
+
+                const cPath: string[] = responseData.data.correctedPath;
+                setCorrectedStartPass(cPath[0] || "");
+                setCorrectedEndPass(cPath[cPath.length - 1] || "");
+
+                workerRef.current.postMessage({
+                    type: "calculateRoutePass",
+                    payload: {
+                        stationNames: cPath,
+                        months,
+                        isIc: false
+                    }
+                });
+                setServerTime(responseData.time);
+            } else if (responseData.data) {
                 setResult(responseData.data);
                 setServerTime(responseData.time);
+                setIsLoading(false);
             } else {
                 throw new Error("サーバーからのレスポンス形式が不正です。");
             }
@@ -176,13 +323,82 @@ export default function Form() {
             } else {
                 setError("計算に失敗しました。");
             }
-        } finally {
             setIsLoading(false);
         }
     };
 
     return (
         <>
+            {/* 第1階層: きっぷ・定期券切り替えタブ */}
+            <div className="grid grid-cols-2 gap-1.5 p-1 bg-slate-100 rounded-xl mb-4">
+                <button
+                    type="button"
+                    onClick={() => handleTabChange("ticket")}
+                    className={`py-2 px-3 text-xs sm:text-sm font-medium rounded-lg transition-all cursor-pointer text-center ${currentType === "ticket"
+                        ? "bg-white text-blue-600 shadow-sm font-bold"
+                        : "text-slate-600 hover:text-slate-900 hover:bg-white/50"
+                        }`}
+                >
+                    普通乗車券
+                </button>
+                <button
+                    type="button"
+                    onClick={() => handleTabChange("pass")}
+                    className={`py-2 px-3 text-xs sm:text-sm font-medium rounded-lg transition-all cursor-pointer text-center ${currentType !== "ticket"
+                        ? "bg-white text-blue-600 shadow-sm font-bold"
+                        : "text-slate-600 hover:text-slate-900 hover:bg-white/50"
+                        }`}
+                >
+                    定期乗車券
+                </button>
+            </div>
+
+            {/* 第2階層: 定期券期間選択トグル */}
+            <div className="h-11 mb-6">
+                <div className="grid grid-cols-3 gap-1.5 p-1 bg-slate-50 border border-slate-200 rounded-xl">
+                    <button
+                        type="button"
+                        onClick={() => handlePeriodChange("pass1")}
+                        disabled={isPeriodDisabled}
+                        className={`py-1.5 px-3 text-xs sm:text-sm font-medium rounded-lg transition-all text-center ${!isPeriodDisabled && currentType === "pass1"
+                            ? "bg-white text-blue-600 shadow-sm font-bold cursor-pointer"
+                            : isPeriodDisabled
+                                ? "text-slate-400 cursor-not-allowed opacity-50"
+                                : "text-slate-500 hover:text-slate-800 hover:bg-white/30 cursor-pointer"
+                            }`}
+                    >
+                        1箇月
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => handlePeriodChange("pass3")}
+                        disabled={isPeriodDisabled}
+                        className={`py-1.5 px-3 text-xs sm:text-sm font-medium rounded-lg transition-all text-center ${!isPeriodDisabled && currentType === "pass3"
+                            ? "bg-white text-blue-600 shadow-sm font-bold cursor-pointer"
+                            : isPeriodDisabled
+                                ? "text-slate-400 cursor-not-allowed opacity-50"
+                                : "text-slate-500 hover:text-slate-800 hover:bg-white/30 cursor-pointer"
+                            }`}
+                    >
+                        3箇月
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => handlePeriodChange("pass6")}
+                        disabled={isPeriodDisabled}
+                        className={`py-1.5 px-3 text-xs sm:text-sm font-medium rounded-lg transition-all text-center ${!isPeriodDisabled && currentType === "pass6"
+                            ? "bg-white text-blue-600 shadow-sm font-bold cursor-pointer"
+                            : isPeriodDisabled
+                                ? "text-slate-400 cursor-not-allowed opacity-50"
+                                : "text-slate-500 hover:text-slate-800 hover:bg-white/30 cursor-pointer"
+                            }`}
+                    >
+                        6箇月
+                    </button>
+                </div>
+            </div>
+
+            {/* eslint-disable-next-line react-hooks/refs */}
             <form onSubmit={handleSubmit(onSubmit)} className="p-8 w-full">
                 <div className="flex flex-col gap-4 w-full">
 
@@ -197,7 +413,13 @@ export default function Form() {
                                 validate: (selected) => {
                                     if (!selected) return "発駅を入力してください";
                                     const exists = stationData.some(s => s.name === selected.name);
-                                    return exists || "該当する駅が存在しません";
+                                    if (!exists) return "該当する駅が存在しません";
+                                    
+                                    const currentSearchType = getValues("searchType");
+                                    if (currentSearchType !== "ticket" && TEMPORARY_STATIONS.includes(selected.name)) {
+                                        return "臨時駅発着の定期券は計算できません";
+                                    }
+                                    return true;
                                 }
                             }}
                             render={({ field, fieldState }) => (
@@ -275,7 +497,13 @@ export default function Form() {
                                             validate: (selected) => {
                                                 if (!selected) return `${stationLabel}を入力してください`;
                                                 const exists = stationsOnLine.some(s => s.name === selected.name);
-                                                return exists || "選択された路線にこの駅は存在しません";
+                                                if (!exists) return "選択された路線にこの駅は存在しません";
+
+                                                const currentSearchType = getValues("searchType");
+                                                if (currentSearchType !== "ticket" && isLastStation && TEMPORARY_STATIONS.includes(selected.name)) {
+                                                    return "臨時駅発着の定期券は計算できません";
+                                                }
+                                                return true;
                                             }
                                         }}
                                         render={({ field, fieldState }) => (
@@ -363,19 +591,28 @@ export default function Form() {
                         </div>
                     </div>
 
-                    <button type="submit" className="w-full px-6 py-3 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:bg-gray-400 disabled:text-white transition-colors mt-2" disabled={!isValid}>
-                        運賃計算をする
+                    <button
+                        type="submit"
+                        className="w-full px-6 py-3 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:bg-gray-400 disabled:text-white transition-colors mt-2 cursor-pointer disabled:cursor-not-allowed"
+                        disabled={!isValid || isLoading || (currentType !== "ticket" && !isWasmReady)}
+                    >
+                        {isLoading 
+                            ? "計算中..." 
+                            : (currentType !== "ticket" && !isWasmReady) 
+                                ? "計算エンジン初期化中..." 
+                                : "運賃計算をする"
+                        }
                     </button>
                 </div>
             </form>
 
             <div className="my-8 p-4">
-                {isLoading && <p className="py-5 border-t">計算中...</p>}
-                {serverTime && <p className="text-right text-xs text-gray-400">計算時間: {serverTime}ms</p>}
+                {isLoading && <p className="py-5 border-t text-center text-gray-500">計算中...</p>}
+                {!isLoading && serverTime && <p className="text-right text-xs text-gray-400">計算時間: {serverTime}ms</p>}
 
-                {error && <p className="py-5 border-t text-red-500">{error}</p>}
+                {!isLoading && error && <p className="py-5 border-t text-red-500 text-center">{error}</p>}
 
-                {result && (
+                {!isLoading && result && (
                     <div>
                         <h2 className="py-5 text-2xl border-t">計算結果</h2>
                         <div>営業キロ: {(result.totalEigyoKilo / 10).toFixed(1)} km</div>
@@ -402,6 +639,37 @@ export default function Form() {
                         <span className="flex justify-between items-center mt-2">
                             <span>{result.validDays + " 日間有効"}</span>
                             <span className="text-xl">¥{result.fare > 0 ? result.fare.toLocaleString() : "***"}</span>
+                        </span>
+                    </div>
+                )}
+
+                {!isLoading && resultPass && (
+                    <div>
+                        <h2 className="py-5 text-2xl border-t">計算結果</h2>
+                        <div>営業キロ: {(resultPass.totalEigyoKilo / 10).toFixed(1)} km</div>
+                        <div className="flex justify-between items-center my-3 gap-2">
+                            <div className="flex-1 text-right">
+                                <div className={`font-bold flex justify-around flex-wrap ${correctedStartPass.length > 6 ? 'text-lg sm:text-xl' : 'text-2xl'}`}>
+                                    {correctedStartPass.split('').map((char, idx) => (
+                                        <span key={idx}>{char}</span>
+                                    ))}
+                                </div>
+                            </div>
+
+                            <div className="text-2xl shrink-0 text-center text-slate-400">↔</div>
+
+                            <div className="flex-1 text-left text-wrap">
+                                <div className={`font-bold flex justify-around flex-wrap ${correctedEndPass.length > 6 ? 'text-lg sm:text-xl' : 'text-2xl'}`}>
+                                    {correctedEndPass.split('').map((char, idx) => (
+                                        <span key={idx}>{char}</span>
+                                    ))}
+                                </div>
+                            </div>
+                        </div>
+                        <span>経由：{!resultPass.printedViaLines || resultPass.printedViaLines.length === 0 ? "ーーー" : resultPass.printedViaLines.join("・")}</span>
+                        <span className="flex justify-between items-center mt-2">
+                            <span>{(( { pass1: 1, pass3: 3, pass6: 6 } as Record<string, number> )[formValues.searchType] || 1) + " 箇月有効"}</span>
+                            <span className="text-xl">¥{(resultPass.fare + resultPass.barrierFreeFee + resultPass.charge).toLocaleString()}</span>
                         </span>
                     </div>
                 )}

--- a/src/app/mr/components/Form.tsx
+++ b/src/app/mr/components/Form.tsx
@@ -87,6 +87,10 @@ export default function Form() {
                     setIsWasmReady(true);
                 } else if (type === "success_route_pass") {
                     setResultPass(wResult);
+                    if (wResult.correctedPath) {
+                        setCorrectedStartPass(wResult.correctedPath[0] || "");
+                        setCorrectedEndPass(wResult.correctedPath[wResult.correctedPath.length - 1] || "");
+                    }
                     setIsLoading(false);
 
                     calculationCountRef.current += 1;
@@ -297,13 +301,12 @@ export default function Form() {
                 const months = monthsMap[data.searchType] || 1;
 
                 const cPath: string[] = responseData.data.correctedPath;
-                setCorrectedStartPass(cPath[0] || "");
-                setCorrectedEndPass(cPath[cPath.length - 1] || "");
 
                 workerRef.current.postMessage({
                     type: "calculateRoutePass",
                     payload: {
                         stationNames: cPath,
+                        calculationMode: data.calculationMode,
                         months,
                         isIc: false
                     }

--- a/src/app/mr/components/Form.tsx
+++ b/src/app/mr/components/Form.tsx
@@ -220,6 +220,7 @@ export default function Form() {
 
         setValue("startStation", newStart, { shouldValidate: true });
         replace(reversedSegments);
+        trigger();
     };
 
     const createApiRequestBody = (data: FormValues) => {

--- a/src/app/mr/components/Form.tsx
+++ b/src/app/mr/components/Form.tsx
@@ -13,9 +13,18 @@ import SelectLine from "@/app/mr/components/SelectLine";
 import { Station, Line, KippuData, IFormInput, PathStep, CalculationMode } from "@/app/types";
 
 const stationMap = new Map(stationData.map(s => [s.name, s]));
-
-
-
+const TEMPORARY_STATIONS = [
+    "原生花園",
+    "ラベンダー畑",
+    "細岡",
+    "猪苗代湖畔",
+    "ガーラ湯沢",
+    "偕楽園",
+    "鹿島サッカースタジアム",
+    "津島ノ宮",
+    "田井ノ浜",
+    "バルーンさが"
+];
 interface FormValues extends IFormInput {
     calculationMode: CalculationMode;
     searchType: "ticket" | "pass1" | "pass3" | "pass6";
@@ -406,7 +415,10 @@ export default function Form() {
                                     if (!selected) return "発駅を入力してください";
                                     const exists = stationData.some(s => s.name === selected.name);
                                     if (!exists) return "該当する駅が存在しません";
-                                    
+                                    const currentSearchType = getValues("searchType");
+                                    if (currentSearchType !== "ticket" && TEMPORARY_STATIONS.includes(selected.name)) {
+                                        return "臨時駅発着の定期券は計算できません";
+                                    }
                                     return true;
                                 }
                             }}
@@ -487,6 +499,10 @@ export default function Form() {
                                                 const exists = stationsOnLine.some(s => s.name === selected.name);
                                                 if (!exists) return "選択された路線にこの駅は存在しません";
 
+                                                const currentSearchType = getValues("searchType");
+                                                if (currentSearchType !== "ticket" && isLastStation && TEMPORARY_STATIONS.includes(selected.name)) {
+                                                    return "臨時駅発着の定期券は計算できません";
+                                                }
                                                 return true;
                                             }
                                         }}

--- a/src/app/mr/components/Form.tsx
+++ b/src/app/mr/components/Form.tsx
@@ -14,18 +14,7 @@ import { Station, Line, KippuData, IFormInput, PathStep, CalculationMode } from 
 
 const stationMap = new Map(stationData.map(s => [s.name, s]));
 
-const TEMPORARY_STATIONS = [
-    "原生花園",
-    "ラベンダー畑",
-    "細岡",
-    "猪苗代湖畔",
-    "ガーラ湯沢",
-    "偕楽園",
-    "鹿島サッカースタジアム",
-    "津島ノ宮",
-    "田井ノ浜",
-    "バルーンさが",
-];
+
 
 interface FormValues extends IFormInput {
     calculationMode: CalculationMode;
@@ -418,10 +407,6 @@ export default function Form() {
                                     const exists = stationData.some(s => s.name === selected.name);
                                     if (!exists) return "該当する駅が存在しません";
                                     
-                                    const currentSearchType = getValues("searchType");
-                                    if (currentSearchType !== "ticket" && TEMPORARY_STATIONS.includes(selected.name)) {
-                                        return "臨時駅発着の定期券は計算できません";
-                                    }
                                     return true;
                                 }
                             }}
@@ -502,10 +487,6 @@ export default function Form() {
                                                 const exists = stationsOnLine.some(s => s.name === selected.name);
                                                 if (!exists) return "選択された路線にこの駅は存在しません";
 
-                                                const currentSearchType = getValues("searchType");
-                                                if (currentSearchType !== "ticket" && isLastStation && TEMPORARY_STATIONS.includes(selected.name)) {
-                                                    return "臨時駅発着の定期券は計算できません";
-                                                }
                                                 return true;
                                             }
                                         }}

--- a/src/app/mr/lib/generateKippu.ts
+++ b/src/app/mr/lib/generateKippu.ts
@@ -12,7 +12,7 @@ interface GenerateKippuOptions {
     calculationMode?: CalculationMode;
 }
 
-export function getCorrectedPath(path: PathStep[], calculationMode: CalculationMode): PathStep[] {
+function getCorrectedPath(path: PathStep[], calculationMode: CalculationMode): PathStep[] {
     let fullPath = createFullPath(path);
     let correctedPath: PathStep[];
 

--- a/src/app/mr/lib/generateKippu.ts
+++ b/src/app/mr/lib/generateKippu.ts
@@ -12,16 +12,8 @@ interface GenerateKippuOptions {
     calculationMode?: CalculationMode;
 }
 
-export function generateKippu(request: RouteRequest, options: GenerateKippuOptions = {}): KippuData {
-    const userInputPath = request.path;
-    const calculationMode = options.calculationMode ?? "normal";
-
-    // 経路の展開
-    let fullPath = createFullPath(userInputPath);
-
-    const majorCitySuburbanSection = whichMajorCitySuburbanSections(fullPath);
-
-    // 経路の補正
+export function getCorrectedPath(path: PathStep[], calculationMode: CalculationMode): PathStep[] {
+    let fullPath = createFullPath(path);
     let correctedPath: PathStep[];
 
     switch (calculationMode) {
@@ -29,26 +21,42 @@ export function generateKippu(request: RouteRequest, options: GenerateKippuOptio
             correctedPath = uncorrectPath(fullPath);
             break;
         case "cheapest":
-            if (majorCitySuburbanSection !== null) {
-                return load.getMajorCitySuburbanSectionFares(
-                    majorCitySuburbanSection,
-                    fullPath[0].stationName,
-                    fullPath[fullPath.length - 1].stationName
-                );
-            }
             correctedPath = cheapestPathAndFare(fullPath).path;
             break;
         case "normal":
         default:
-            if (majorCitySuburbanSection !== null) {
-                return load.getMajorCitySuburbanSectionFares(
-                    majorCitySuburbanSection,
-                    fullPath[0].stationName,
-                    fullPath[fullPath.length - 1].stationName
-                );
-            }
             correctedPath = correctPath(fullPath);
             break;
+    }
+    return correctedPath;
+}
+
+export function generateKippu(request: RouteRequest, options: GenerateKippuOptions = {}): KippuData {
+    const userInputPath = request.path;
+    const calculationMode = options.calculationMode ?? "normal";
+
+    const correctedPath = getCorrectedPath(userInputPath, calculationMode);
+
+    // 重複駅チェック (通常、最安、補正禁止の3パターンすべてに適用。環状・6の字乗車を許容するため、最後の一駅を除いた区間内での重複をチェックする)
+    const stationNames = correctedPath.map(p => p.stationName);
+    const firstPart = stationNames.slice(0, -1);
+    const hasDuplicateInFirstPart = firstPart.some((name, index) => firstPart.indexOf(name) !== index);
+    if (hasDuplicateInFirstPart) {
+        throw new Error("経路が重複しています。");
+    }
+
+    // 大都市近郊区間の判定と運賃取得
+    let fullPath = createFullPath(userInputPath);
+    const majorCitySuburbanSection = whichMajorCitySuburbanSections(fullPath);
+
+    if (calculationMode === "cheapest" || calculationMode === "normal") {
+        if (majorCitySuburbanSection !== null) {
+            return load.getMajorCitySuburbanSectionFares(
+                majorCitySuburbanSection,
+                fullPath[0].stationName,
+                fullPath[fullPath.length - 1].stationName
+            );
+        }
     }
 
     // 出発駅と到着駅の名前を取得して変数に代入
@@ -72,7 +80,7 @@ export function generateKippu(request: RouteRequest, options: GenerateKippuOptio
     };
 }
 
-function createFullPath(path: PathStep[]): PathStep[] {
+export function createFullPath(path: PathStep[]): PathStep[] {
     if (path.length <= 1) {
         return path;
     }

--- a/src/app/split/split-pass.worker.ts
+++ b/src/app/split/split-pass.worker.ts
@@ -16,6 +16,7 @@ interface WorkerGlobalScope {
   prepareGraphBuffer(size: number): number;
   initGraphFromBuffer(size: number): boolean | string;
   reconstructAndCalculate(splitStationsJson: string, months: number, isIc: boolean): string;
+  calculateRoutePass(stationNamesJson: string, months: number, isIc: boolean): string;
 }
 const workerSelf = (typeof self !== 'undefined' ? self : globalThis) as unknown as WorkerGlobalScope;
 
@@ -86,7 +87,26 @@ initWasm();
 onmessage = async (e: MessageEvent) => {
   const { type, payload } = e.data;
 
-  if (type === 'calculate') {
+  if (type === 'calculateRoutePass') {
+    if (!graphInitialized) {
+      postMessage({ type: 'error', error: 'Wasm graph not initialized yet' });
+      return;
+    }
+
+    const { stationNames, months, isIc } = payload;
+    try {
+      const stationNamesJson = JSON.stringify(stationNames);
+      const resultJsonStr = workerSelf.calculateRoutePass(stationNamesJson, months, isIc);
+      const result = JSON.parse(resultJsonStr);
+      if (result.error) {
+        postMessage({ type: 'error', error: result.error });
+        return;
+      }
+      postMessage({ type: 'success_route_pass', result });
+    } catch (err) {
+      postMessage({ type: 'error', error: String(err) });
+    }
+  } else if (type === 'calculate') {
     if (!graphInitialized) {
       postMessage({ type: 'error', error: 'Wasm graph not initialized yet' });
       return;

--- a/src/app/split/split-pass.worker.ts
+++ b/src/app/split/split-pass.worker.ts
@@ -16,7 +16,7 @@ interface WorkerGlobalScope {
   prepareGraphBuffer(size: number): number;
   initGraphFromBuffer(size: number): boolean | string;
   reconstructAndCalculate(splitStationsJson: string, months: number, isIc: boolean): string;
-  calculateRoutePass(stationNamesJson: string, months: number, isIc: boolean): string;
+  calculateRoutePass(stationNamesJson: string, months: number, isIc: boolean, calculationMode: string): string;
 }
 const workerSelf = (typeof self !== 'undefined' ? self : globalThis) as unknown as WorkerGlobalScope;
 
@@ -93,10 +93,10 @@ onmessage = async (e: MessageEvent) => {
       return;
     }
 
-    const { stationNames, months, isIc } = payload;
+    const { stationNames, months, isIc, calculationMode } = payload;
     try {
       const stationNamesJson = JSON.stringify(stationNames);
-      const resultJsonStr = workerSelf.calculateRoutePass(stationNamesJson, months, isIc);
+      const resultJsonStr = workerSelf.calculateRoutePass(stationNamesJson, months, isIc, calculationMode || 'normal');
       const result = JSON.parse(resultJsonStr);
       if (result.error) {
         postMessage({ type: 'error', error: result.error });

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -84,11 +84,6 @@ export interface SplitApiResponse {
     splitKippuDatasList: SplitKippuDatas[];
 }
 
-export interface ApiFullResponse {
-    data: KippuData;
-    time: number;
-}
-
 export interface CacheResult {
     data: SplitApiResponse;
     isCacheHit: boolean;

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -56,6 +56,7 @@ export interface PathStep {
 export interface RouteRequest {
     path: PathStep[];
     calculationMode: CalculationMode;
+    searchType?: SearchType;
 }
 
 export interface KippuData {

--- a/src/tests/integration/generateKippu.test.ts
+++ b/src/tests/integration/generateKippu.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { generateKippu } from "@/app/mr/lib/generateKippu";
+import { RouteRequest } from "@/app/types";
+
+describe("generateKippu 運賃計算プログラム - 重複駅チェック", () => {
+    it("最後尾以外で同じ駅が2度出現した場合はエラーをスローする (通常モード)", () => {
+        const request: RouteRequest = {
+            path: [
+                { stationName: "蘇我", lineName: "内房" },
+                { stationName: "浜野", lineName: "内房" },
+                { stationName: "蘇我", lineName: "内房" },
+                { stationName: "八幡宿", lineName: null }
+            ],
+            calculationMode: "normal"
+        };
+        expect(() => generateKippu(request)).toThrow("経路が重複しています。");
+    });
+
+    it("最後尾以外で同じ駅が2度出現した場合はエラーをスローする (最安モード)", () => {
+        const request: RouteRequest = {
+            path: [
+                { stationName: "蘇我", lineName: "内房" },
+                { stationName: "浜野", lineName: "内房" },
+                { stationName: "蘇我", lineName: "内房" },
+                { stationName: "八幡宿", lineName: null }
+            ],
+            calculationMode: "cheapest"
+        };
+        expect(() => generateKippu(request)).toThrow("経路が重複しています。");
+    });
+
+    it("最後尾以外で同じ駅が2度出現した場合はエラーをスローする (補正禁止モード)", () => {
+        const request: RouteRequest = {
+            path: [
+                { stationName: "蘇我", lineName: "内房" },
+                { stationName: "浜野", lineName: "内房" },
+                { stationName: "蘇我", lineName: "内房" },
+                { stationName: "八幡宿", lineName: null }
+            ],
+            calculationMode: "uncorrect"
+        };
+        expect(() => generateKippu(request)).toThrow("経路が重複しています。");
+    });
+
+    it("最後の一駅のみの重複 (環状/6の字) の場合はエラーをスローしない", () => {
+        const request: RouteRequest = {
+            path: [
+                { stationName: "蘇我", lineName: "内房" },
+                { stationName: "五井", lineName: "内房" },
+                { stationName: "八幡宿", lineName: null }
+            ],
+            calculationMode: "normal"
+        };
+        expect(() => generateKippu(request)).not.toThrow();
+        const res = generateKippu(request);
+        expect(res.totalEigyoKilo).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
## 関連Issue
Resolves #357 

## 変更内容
- `/mr` フォームにて、定期乗車券（1・3・6箇月）の運賃計算機能を追加しました。
- 計算ロジックをWeb Worker（`split-pass.worker.ts`）経由でWasmの `calculateRoutePass` へ渡し、クライアントサイドで処理を完結させるようにしました。
- 第69条等の特例補正によって発着駅が変更された際、その結果（`correctedStartPass`, `correctedEndPass`）が画面上の乗降駅名表示に反映されるようUIを修正しました。
- バリデーション発火のタイミングを最適化し、入力前の不自然なエラー表示を抑制しました。

## 影響範囲・検証手順
1. 本PR環境を起動し、`/mr` ページへアクセスする。
2. チケット種別を「定期乗車券」に切り替え、期間（1/3/6箇月）を選択する（未入力時にエラーが出ないことを確認）。
3. 任意の経路を入力し、「通常」「最安」「補正禁止」の各モードで計算を実行する。
4. 定期運賃が正しく計算され、経由路線が適切に印字表示されることを確認する。
5. 特例補正が発生するルート（特定区間を跨ぐ場合）で、結果の発着駅名が補正後のものに置き換わっていることを確認する。
6. Vitestによる結合テスト（`npm run test`）が全件パスすることを確認する。