### PR TITLE
fix: Cloud Buildでのローカル変数パースエラーを修正（エスケープ対応）

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -47,9 +47,9 @@ steps:
     args:
       - '-c'
       - |
-        CONTAINER_ID=$(docker create asia-northeast1-docker.pkg.dev/$PROJECT_ID/kippu-navi/kippu-navi:$SHORT_SHA)
-        docker cp $CONTAINER_ID:/app/.next/static /workspace/_next_static
-        docker rm $CONTAINER_ID
+        CONTAINER_ID=$(docker create "asia-northeast1-docker.pkg.dev/${PROJECT_ID}/kippu-navi/kippu-navi:${SHORT_SHA}")
+        docker cp $$CONTAINER_ID:/app/.next/static /workspace/_next_static
+        docker rm $$CONTAINER_ID
 
   # 4. _next/static の新規・変更ファイルのみを R2 へ差分アップロードする
   #    ※ デプロイ前に実行し、新チャンクが R2 に存在する状態を確保する


### PR DESCRIPTION
## 概要
Issue #363  に対応。
Cloud Build 実行時に `cloudbuild.yaml` で発生していたパースエラーを解消するための修正です。

## 変更内容
- `cloudbuild.yaml` 内のシェルスクリプト処理において、Docker展開時のコンテナID参照部（`$CONTAINER_ID`）を `$$CONTAINER_ID` にエスケープしました。

## 修正の背景
Cloud Build の仕様上、YAML内のスクリプトで `$` を単一で使用すると、Cloud Build の代入変数（Substitutions）として解釈されようとしてエラーになります。これを回避し、純粋なシェル側のローカル変数として評価させるために `$$` エスケープを適用しました。

## 影響範囲
- Cloud Build の CI/CD パイプライン（ビルド定義）のみ。
- アプリケーション自体のコードや動作への影響はありません。

## 確認事項
- [x] Cloud Build のトリガーが正常に作動し、パースエラーを出さずにデプロイが完了することを確認した。