### PR TITLE
refactor: WasmのR2配信化・Next.jsアセットの同一ドメイン化およびWasm実行のためのCSP修正

### DIFF
--- a/src/app/split/split-pass.worker.ts
+++ b/src/app/split/split-pass.worker.ts
@@ -46,8 +46,8 @@ async function initWasm(origin: string) {
     const isLocal = origin.includes('localhost') || origin.includes('127.0.0.1');
     const baseUrl = isLocal ? origin : 'https://assets.kippu-navi.com';
 
-    // 環境に応じたベースURLからロードする
-    importScripts(`${baseUrl}/engine/wasm_exec.js`);
+    // 軽量スクリプトである wasm_exec.js は同一オリジン (origin) からロードする
+    importScripts(`${origin}/engine/wasm_exec.js`);
     go = new Go();
 
     const wasmResponse = await fetch(`${baseUrl}/engine/split_pass.wasm`);


### PR DESCRIPTION
## 概要
Issue #388  に対応。
Web Workerの起動エラーおよびWasmのコンパイルエラー（CSPブロック）を根本から解決するため、インフラの配信アーキテクチャとセキュリティ設定を再構築しました。
大容量のWasm/データのみをR2からフェッチし、Next.jsの静的アセットや軽量スクリプトは同一オリジンから配信する堅牢な設計に変更しています。

## 主な変更内容
### 1. アーキテクチャとWorkerの正常化
- `layout.tsx` の `window.Worker` 用Blob URLパッチを完全削除。
- `next.config.ts` の `assetPrefix` を廃止し、Next.jsアセットを同一ドメイン配信へ回帰。
- `split-pass.worker.ts` において、`split_pass.wasm` と `graph_data.bin` はR2からフェッチし、`wasm_exec.js` はMIMEタイプ等のトラブルを避けるため同一オリジンから `importScripts()` するよう処理を分岐。

### 2. CSP修正とアセットのクリーンアップ
- `next.config.ts` のCSP (`script-src`) に `'wasm-unsafe-eval'` を追加し、本番/PR環境でのWasm実行を安全に許可。
- `public/wasm_exec.js` の重複を削除し、`public/engine/wasm_exec.js` に一元化。合わせて `.gitignore` を整理。
- `knip.json` の検証除外パスを更新し、未使用ファイルの誤検知を防止。

### 3. CI/CDの最適化
- Cloud Buildパイプラインから `ASSET_PREFIX` 引数、コンテナへのWasm同梱処理、および `_next/static` のR2アップロード（`rclone`）を全削除し、ビルドを高速化。

## 影響範囲とメリット
- Workerの起動がTurbopackの標準挙動のみに依存するようになり、未知のブラウザエラーやCORSの罠が排除されました。
- CSPエラーが解消され、本番環境でもWasmエンジンが正常に稼働します。
- CI/CDパイプラインが大幅にシンプルになり、メンテナンス性が向上しました。

## 確認・検証ステータス
- [x] `npm run typecheck` 成功
- [x] `npm run test` (Vitest: 84件) 全パス
- [x] `npx eslint .` エラー・警告ゼロ
- [x] `npx knip` 警告・エラーゼロ
- [x] `npm run build` 正常完了