### PR TITLE
fix: Blob Worker環境下でのwasm_exec.js読み込みエラーを絶対URL解決で修正

### DIFF
--- a/src/app/split/split-pass.worker.ts
+++ b/src/app/split/split-pass.worker.ts
@@ -1,7 +1,10 @@
 /// <reference lib="webworker" />
 
-// Go Wasm ローダーの読み込み
-importScripts('/wasm_exec.js');
+// Go Wasm ローダーの読み込み（Blob Worker環境で相対パスエラーを防ぐため絶対URLに解決）
+const selfOrigin = (typeof self !== 'undefined' && self.location && self.location.origin && self.location.origin !== 'null')
+  ? self.location.origin
+  : '';
+importScripts(`${selfOrigin}/wasm_exec.js`);
 
 interface GoInstance {
   importObject: WebAssembly.Imports;


### PR DESCRIPTION
## 概要
Web Workerの起動時に `TypeError: Load failed` が発生し、計算エンジン（Wasm）が初期化されないバグを修正しました。

## 発生していた問題と原因
Next.js（Turbopack）のビルド環境や特定のブラウザ挙動において、Web Workerが `blob:` URL（例: `blob:https://kippu-navi.com/...`）を経由して起動されるケースがあります。
この `blob:` コンテキスト下で、`importScripts('/engine/wasm_exec.js')` のように相対パスを指定すると、ブラウザがベースURLを `blob:https://...` と解釈してしまい、正しいドメインからファイルを取得できずにロードエラー（`TypeError`）を引き起こしていました。

## 実施した変更
- `split-pass.worker.ts` 内の `wasm_exec.js` の読み込み処理を修正しました。
- 相対パスでの読み込みを廃止し、`self.location.origin` をベースにした絶対URL（例: `https://kippu-navi.com/engine/wasm_exec.js`）を明示的に構築して `importScripts` に渡すように変更しました。

## 影響範囲
- 計算エンジンの初期化処理（Web Worker）のみ。
- これにより、Workerがどのようなコンテキスト（Blob等）で生成されても、確実に同一オリジンの自ホストから軽量スクリプトをロードできるようになります。（※Wasm本体とグラフデータは引き続きR2からロードされます）。

## 確認事項
- [x] プレビュー環境および本番環境のビルドにおいて、計算処理が正常に開始されること。
- [x] ブラウザのコンソールに `TypeError: Load failed` などの `importScripts` 関連のエラーが出力されていないこと。