### PR TITLE
fix: Cloudflareのセキュリティブロック回避のためのWASM同一ドメイン配信化

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -54,6 +54,14 @@ const nextConfig: NextConfig = {
       },
     ]
   },
+  async rewrites() {
+    return [
+      {
+        source: '/engine/:path*',
+        destination: 'https://assets.kippu-navi.com/engine/:path*',
+      },
+    ]
+  },
   output: 'standalone',
   poweredByHeader: false,
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -32,6 +32,15 @@ const nextConfig: NextConfig = {
           }
         ],
       },
+      {
+        source: '/engine/:path*',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, s-maxage=31536000, immutable',
+          },
+        ],
+      },
     ];
   },
   async redirects() {

--- a/src/app/split/split-pass.worker.ts
+++ b/src/app/split/split-pass.worker.ts
@@ -45,15 +45,8 @@ const go = new Go();
 let wasmInstance: WebAssembly.Instance | null = null;
 let graphInitialized = false;
 
-const isLocal = typeof self !== 'undefined' && (
-  self.location.hostname === 'localhost' ||
-  self.location.hostname === '127.0.0.1' ||
-  self.location.hostname.startsWith('192.168.') ||
-  self.location.hostname.endsWith('.local')
-);
-
-const WASM_URL = isLocal ? '/engine/split_pass.wasm' : 'https://assets.kippu-navi.com/engine/split_pass.wasm';
-const GRAPH_URL = isLocal ? '/engine/graph_data.bin' : 'https://assets.kippu-navi.com/engine/graph_data.bin';
+const WASM_URL = '/engine/split_pass.wasm';
+const GRAPH_URL = '/engine/graph_data.bin';
 
 async function initWasm() {
   if (wasmInstance) return;


### PR DESCRIPTION
## 概要
本番環境（`kippu-navi.com`）において、Web Workerから別ドメイン（R2: `assets.kippu-navi.com`）への巨大ファイルのフェッチが、CloudflareのBot Managementやセキュリティ保護によって強制切断される（`TypeError: Failed to fetch`）問題を解決しました。

## 解決へのアプローチ
Cloudflareのセキュリティ（WAF等）を対症療法的に緩めるのではなく、通信を完全に同一ドメイン（Same-Origin）化することで、ブラウザおよびCloudflareのクロスオリジン監視を自然にクリアするアーキテクチャへ移行しました。

## 実施した変更
1. **Workerのフェッチパス変更 (`split-pass.worker.ts`)**
   - WASM（`split_pass.wasm`）およびグラフデータ（`graph_data.bin`）の取得先URLを、R2の絶対URLから同一ドメインの相対パス（`/engine/...`）に統一しました。
2. **Next.jsのプロキシ設定 (`next.config.ts`)**
   - `rewrites()` を追加し、`/engine/:path*` へのリクエストをバックグラウンドで `https://assets.kippu-navi.com/engine/:path*` (R2) へ転送（プロキシ）するよう設定しました。

## 運用上の連携事項（インフラ設定）
この変更に伴い、Cloud RunがR2から毎度データを中継してエグレスコストが発生するのを防ぐため、Cloudflareのダッシュボードにて以下のキャッシュルールが設定されている（または設定する）ことを前提としています。
- **対象:** `kippu-navi.com/engine/*`
- **ルール:** Cache Everything（すべてキャッシュ）および Edge Cache TTL の明示的指定

## 確認事項
- [x] ローカルおよびPRプレビュー環境で計算エンジンが正常に動作すること。
- [x] 本番デプロイ後、シークレットモード等のBot判定が厳しくなる環境でも、WASMのロードが途切れることなく正常に完了すること。
- [x] Cloudflareのキャッシュステータス（レスポンスヘッダーの `cf-cache-status`）が `HIT` になり、Cloud Runの通信量が抑えられていること。