### PR TITLE
feat: 使い方ガイドページの追加とドキュメント・関連ページのUI/UXリファクタリング

### DIFF
--- a/src/app/guide/page.tsx
+++ b/src/app/guide/page.tsx
@@ -1,0 +1,433 @@
+import Link from "next/link";
+import { ReactNode } from "react";
+
+export const metadata = {
+    title: "はじめての方へ（使い方ガイド）",
+    description: "きっぷナビの使い方、駅の券売機やみどりの窓口（きっぷうりば）でのきっぷの買い方、よくある質問について解説します。",
+};
+
+// 汎用アコーディオン項目
+interface AccordionItemProps {
+    title: string;
+    children: ReactNode;
+}
+
+function AccordionItem({ title, children }: AccordionItemProps) {
+    return (
+        <details className="group border border-slate-200 rounded-xl p-4 bg-slate-50/50">
+            <summary className="flex justify-between items-center font-bold cursor-pointer list-none text-slate-800">
+                <span>{title}</span>
+                <span className="transition-transform duration-200 group-open:rotate-180 text-slate-500">
+                    <svg fill="none" height="24" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" width="24" className="w-5 h-5"><path d="M19 9l-7 7-7-7"></path></svg>
+                </span>
+            </summary>
+            <div className="text-slate-700 mt-3 text-sm leading-relaxed border-t border-slate-100 pt-3 space-y-2">
+                {children}
+            </div>
+        </details>
+    );
+}
+
+// FAQ専用アコーディオン項目（セマンティックな見出しとQ/Aアイコン付き）
+interface FaqItemProps {
+    question: string;
+    children: ReactNode;
+}
+
+function FaqItem({ question, children }: FaqItemProps) {
+    return (
+        <details className="group border border-slate-200 rounded-xl p-4 bg-slate-50/50">
+            <summary className="flex justify-between items-center font-bold cursor-pointer list-none text-slate-800">
+                <h3 className="flex items-center text-base m-0">
+                    <span className="shrink-0 bg-blue-100 text-blue-600 w-7 h-7 rounded-full flex items-center justify-center mr-3 text-sm">Q</span>
+                    {question}
+                </h3>
+                <span className="transition-transform duration-200 group-open:rotate-180 text-slate-500">
+                    <svg fill="none" height="24" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" width="24" className="w-5 h-5"><path d="M19 9l-7 7-7-7"></path></svg>
+                </span>
+            </summary>
+            <div className="text-slate-700 mt-3 text-sm leading-relaxed border-t border-slate-100 pt-3">
+                <div className="mt-1 flex items-start">
+                    <span className="shrink-0 bg-slate-200 text-slate-700 w-7 h-7 rounded-full flex items-center justify-center mr-3 text-sm">A</span>
+                    <div className="w-full space-y-2">
+                        {children}
+                    </div>
+                </div>
+            </div>
+        </details>
+    );
+}
+
+export default function GuidePage() {
+    return (
+        <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-4xl mx-auto space-y-8">
+            {/* ページヘッダー */}
+            <header className="text-center mb-8">
+                <h1 className="text-3xl font-bold text-slate-900 sm:text-4xl">
+                    はじめての方へ（使い方ガイド）
+                </h1>
+                <p className="mt-8 text-slate-500">
+                    <Link href="/split" className="text-blue-600 hover:underline decoration-blue-600 underline-offset-2 mx-1">
+                        分割乗車券プログラム
+                    </Link>
+                    の操作方法から、購入手順や利用方法まで分かりやすく解説します。
+                </p>
+            </header>
+
+            {/* 目次 (ナビゲーションとしてマークアップ) */}
+            <nav aria-label="ガイドの目次" className="bg-slate-50 border border-slate-200 rounded-xl p-6">
+                <h2 className="text-lg font-bold text-slate-900 mb-3">目次</h2>
+                <ul className="space-y-3 text-sm">
+                    <li className="flex items-start">
+                        <span className="mr-2 text-slate-900 w-5 shrink-0">1.</span>
+                        <a href="#how-to-search" className="text-blue-600 hover:underline font-medium">
+                            分割乗車券の調べ方
+                        </a>
+                    </li>
+                    <li className="flex items-start">
+                        <span className="mr-2 text-slate-900 w-5 shrink-0">2.</span>
+                        <a href="#how-to-buy" className="text-blue-600 hover:underline font-medium">
+                            分割乗車券の買い方
+                        </a>
+                    </li>
+                    <li className="flex items-start">
+                        <span className="mr-2 text-slate-900 w-5 shrink-0">3.</span>
+                        <a href="#how-to-use" className="text-blue-600 hover:underline font-medium">
+                            分割乗車券の使い方
+                        </a>
+                    </li>
+                    <li className="flex items-start">
+                        <span className="mr-2 text-slate-900 w-5 shrink-0">4.</span>
+                        <a href="#faq" className="text-blue-600 hover:underline font-medium">
+                            よくある質問（FAQ）
+                        </a>
+                    </li>
+                    <li className="flex items-start">
+                        <span className="mr-2 text-slate-900 w-5 shrink-0">5.</span>
+                        <a href="#about-logic" className="text-blue-600 hover:underline font-medium">
+                            仕組みについて
+                        </a>
+                    </li>
+                </ul>
+            </nav>
+
+            {/* コンテンツコンテナ */}
+            <div className="bg-white rounded-2xl shadow-sm border border-slate-200 p-6 sm:p-10 space-y-12">
+
+                {/* 1. 分割乗車券の調べ方 */}
+                <section id="how-to-search" className="scroll-mt-20">
+                    <h2 className="text-2xl font-bold text-slate-800 mb-6 border-b pb-2 flex items-center">
+                        1. 分割乗車券の調べ方
+                    </h2>
+                    <div className="space-y-6 text-slate-700 leading-relaxed">
+                        <div>
+                            <h3 className="text-lg font-bold text-slate-900 mb-2">そもそもなぜ分割するのか</h3>
+                            <p>
+                                基本的には<strong>安くなるから</strong>です。
+                                当サイトでは、発着駅間の最安解を求めるための
+                                <Link href="/split" className="text-blue-600 hover:underline decoration-blue-600 underline-offset-2 mx-1">
+                                    分割乗車券プログラム
+                                </Link>
+                                を公開してます。
+                            </p>
+                        </div>
+
+                        <div>
+                            <h3 className="text-lg font-bold text-slate-900 mb-2">発着駅の入力方法</h3>
+                            <p>
+                                検索ボックスに、発駅と着駅を入力します。入力に合わせて候補の駅名がサジェストされます。
+                            </p>
+                            <p className="bg-slate-50 p-4 rounded-lg text-sm text-slate-700 mt-2">
+                                ※定期券の場合、臨時駅を選択することはできません。また、IC定期券の場合、異なるエリア同士を選択することはできません。
+                            </p>
+                        </div>
+
+                        <div>
+                            <h3 className="text-lg font-bold text-slate-900 mb-2">計算結果画面について</h3>
+                            <p>
+                                計算が完了すると、通常通りに購入した場合（通し購入）と、乗車券を分割して購入した場合（分割購入）の運賃の比較が表示されます。
+                            </p>
+                            <ul className="list-disc list-inside space-y-1.5 ml-2 mt-2 text-sm">
+                                <li><strong>分割駅の表示：</strong> どの駅で乗車券を分割すれば最も安くなるかが視覚的に示されます。</li>
+                                <li><strong>運賃の比較：</strong> 分割することでいくら安くなるかの差額（オトク額）がひと目で分かります。</li>
+                                <li><strong>経路の確認：</strong> 経由する路線や経由駅のリストを確認できます。</li>
+                                <li><strong>パターンについて：</strong> 複数のパターンが表示された場合お好きなものを選んでください。</li>
+                            </ul>
+                        </div>
+                    </div>
+                </section>
+
+                {/* 2. 分割乗車券の買い方 */}
+                <section id="how-to-buy" className="scroll-mt-20">
+                    <h2 className="text-2xl font-bold text-slate-800 mb-6 border-b pb-2 flex items-center">
+                        2. 分割乗車券の買い方
+                    </h2>
+                    <div className="space-y-6 text-slate-700 leading-relaxed">
+                        <p>
+                            <Link href="/split" className="text-blue-600 hover:underline decoration-blue-600 underline-offset-2 mx-1">
+                                分割乗車券プログラム
+                            </Link>
+                            で出力された複数枚の乗車券を購入する手順です。
+                        </p>
+                        <p>
+                            原則として、<strong>分割乗車券は発駅から乗車する際に、これから利用する全ての乗車券を所持している必要があります。</strong>
+                        </p>
+                        <p>
+                            ここで前提知識として、以下に記載する
+                            <Link href="https://www.jreast.co.jp/ryokaku/02_hen/02_syo/01_setsu/02.html#20" target="_blank" className="text-blue-600 hover:underline decoration-blue-600 underline-offset-2 mx-1">
+                                旅客営業規則 第20条
+                            </Link>
+                            をご覧ください。
+                        </p>
+                        <blockquote className="bg-slate-50 p-4 rounded-lg text-slate-700 mt-2 space-y-2 border-l-4 border-slate-300">
+                            <p className="text-sm">
+                                駅において発売する乗車券類は、その駅から有効なものに限って発売する。ただし、他駅から有効な乗車券類を発売することがある。
+                            </p>
+                            <cite className="block text-xs text-slate-500 not-italic">
+                                出典：
+                                <Link href="https://www.jreast.co.jp/ryokaku/02_hen/02_syo/01_setsu/02.html" target="_blank" className="hover:underline underline-offset-2 mx-1">
+                                    JR東日本：旅客営業規則＞第2編 旅客営業 -第2章 乗車券類の発売 -第1節 通則
+                                </Link>
+                            </cite>
+                        </blockquote>
+                        <p>
+                            つまり、<strong>必ずしも駅の券売機やみどりの窓口（きっぷうりば）で分割乗車券を購入できるとは限りません。</strong>
+                        </p>
+
+                        <div className="space-y-4">
+                            <AccordionItem title="分割普通乗車券の購入方法">
+                                <p>
+                                    普通乗車券を分割購入したいときは
+                                    <Link href="https://www.eki-net.com" target="_blank" className="text-blue-600 hover:underline decoration-blue-600 underline-offset-2 mx-1">
+                                        えきねっと
+                                    </Link>
+                                    や
+                                    <Link href="https://e5489.jr-odekake.net/e5489/cspc/CBTopMenuPC" target="_blank" className="text-blue-600 hover:underline decoration-blue-600 underline-offset-2 mx-1">
+                                        e5489
+                                    </Link>
+                                    などのインターネット予約サービスを使うと便利です。
+                                    これらを利用すれば他駅発売の制限を受けませんが、受け取りできる駅が限られているため注意が必要です。
+                                    みどりの窓口（きっぷうりば）では、不正乗車防止の観点から発売してもらえる可能性は低くなりつつあります。
+                                    つまり無人駅から乗車する場合は、原則として通しの運賃を支払う必要があります。
+                                </p>
+                                <p>
+                                    ※近距離きっぷでも分割普通乗車券として利用できます。
+                                    ただ、出場時に発駅から分割駅までの運賃と一致しているかの確認に時間を要する可能性があります。
+                                    指定席券売機（みどりの券売機）やみどりの窓口（きっぷうりば）があれば、駅名→駅名となる普通乗車券（マルス券）の購入がおすすめです。
+                                </p>
+                                <div className="mt-4 p-3 bg-white border border-slate-200 rounded-lg space-y-1">
+                                    <p className="font-bold text-slate-800">【例】東京駅から横浜駅まで</p>
+                                    <p>
+                                        東京→横浜は530円ですが、東京→蒲田と蒲田→横浜はそれぞれ260円です。よって、分割することで10円安く移動することができます。
+                                        このとき、東京駅の自動券売機で東京→蒲田の普通乗車券を購入することはできますが、蒲田→横浜の普通乗車券を購入することはできません。
+                                        そのため、えきねっと等を利用して蒲田→横浜の乗車券を事前に購入し、東京駅で受け取る必要があります。
+                                    </p>
+                                </div>
+                            </AccordionItem>
+
+                            <AccordionItem title="分割定期乗車券の購入方法">
+                                <div className="space-y-4">
+                                    <div>
+                                        <p className="font-bold text-slate-800">【磁気定期券】</p>
+                                        <p>
+                                            駅の券売機やみどりの窓口で購入をしてください。購入後は有人改札へ行き「入場記録が無くても出場できる設定」をしてもらうことが多いです。
+                                            発売を断られたら、分割駅まで移動して購入するか諦めてください。
+                                        </p>
+                                    </div>
+                                    <hr className="border-slate-100" />
+                                    <div>
+                                        <p className="font-bold text-slate-800">【Kitaca / Suica定期券】</p>
+                                        <p>
+                                            各定期券を取り扱う駅の窓口で購入してください。最大分割数は1回（2区間）までで、他社線を含めることはできません。
+                                        </p>
+                                    </div>
+                                    <hr className="border-slate-100" />
+                                    <div>
+                                        <p className="font-bold text-slate-800">【ICOCA定期券】</p>
+                                        <p>
+                                            ICOCA定期券を取り扱う駅の窓口で購入してください。最大分割数は1回（2区間）までで、他社線を含めることはできません。
+                                            詳しくは
+                                            <Link href="https://www.jr-odekake.net/icoca/purchase/icoca_teiki.html#two" target="_blank" className="text-blue-600 hover:underline decoration-blue-600 underline-offset-2 mx-1">
+                                                こちら
+                                            </Link>
+                                            をご覧ください。
+                                        </p>
+                                    </div>
+                                    <hr className="border-slate-100" />
+                                    <div>
+                                        <p className="font-bold text-slate-800">【モバイルSuicaの定期券】</p>
+                                        <p>
+                                            <Link href="https://apfaq.mobilesuica.com/helpdesk?category_id=85" target="_blank" className="text-blue-600 hover:underline decoration-blue-600 underline-offset-2 mx-1">
+                                                モバイルSuicaサポートページ
+                                            </Link>
+                                            に沿って購入してください。最大分割数は1回（2区間）までで、他社線を含めることはできません。
+                                        </p>
+                                    </div>
+                                </div>
+                            </AccordionItem>
+                        </div>
+                    </div>
+                </section>
+
+                {/* 3. 分割乗車券の使い方 */}
+                <section id="how-to-use" className="scroll-mt-20">
+                    <h2 className="text-2xl font-bold text-slate-800 mb-6 border-b pb-2 flex items-center">
+                        3. 分割乗車券の使い方
+                    </h2>
+                    <div className="space-y-6 text-slate-700 leading-relaxed">
+                        <p>
+                            <Link href="/split" className="text-blue-600 hover:underline decoration-blue-600 underline-offset-2 mx-1">
+                                分割乗車券プログラム
+                            </Link>
+                            で出力された複数枚の乗車券を利用する手順です。
+                        </p>
+
+                        <AccordionItem title="分割普通乗車券の利用方法">
+                            <ul className="list-disc list-inside space-y-2 ml-2 mt-2 text-sm">
+                                <li><strong>入場時：</strong> 最初に乗車する区間の普通乗車券（発駅が含まれる普通乗車券）だけを使って入場します。</li>
+                                <li><strong>検札時：</strong> 車内検札がある場合は、所持している分割したすべての普通乗車券を提示してください。</li>
+                                <li><strong>出場時：</strong> 目的地の駅で出場する際は、有人改札で<strong>分割したすべての普通乗車券</strong>を渡してください。</li>
+                            </ul>
+                            <div className="mt-4 p-3 bg-white border border-slate-200 rounded-lg space-y-2">
+                                <p className="font-bold text-slate-800">【例】東京駅から横浜駅まで</p>
+                                <p>
+                                    東京駅では「東京→蒲田」の普通乗車券だけを使って入場してください。
+                                    このとき、蒲田駅を通過する東海道線で移動しても問題ありません。
+                                </p>
+                                <p className="text-rose-600 font-medium">
+                                    ただし、蒲田駅を経由しない横須賀線（品鶴線経由など）を利用して移動してはいけません。なぜなら、購入したきっぷの分割駅である「蒲田駅」を実際に経由する経路で乗車する必要があるためです。
+                                </p>
+                                <p>
+                                    横浜駅に着いたら、有人改札へ行き「東京→蒲田」と「蒲田→横浜」の両方の普通乗車券を渡せば出場できます。
+                                </p>
+                            </div>
+                        </AccordionItem>
+
+                        <AccordionItem title="分割定期乗車券の利用方法">
+                            <div className="space-y-4">
+                                <div>
+                                    <p className="font-bold text-slate-800">【磁気定期券】</p>
+                                    <ul className="list-disc list-inside space-y-1 ml-2 mt-1 text-sm">
+                                        <li><strong>入場時：</strong> 最初に乗車する区間の定期乗車券だけを使って入場します。</li>
+                                        <li><strong>検札時：</strong> 分割したすべての定期乗車券を提示してください。</li>
+                                        <li><strong>出場時：</strong> 最後に乗車する区間の定期乗車券だけを使って出場します。</li>
+                                    </ul>
+                                </div>
+                                <hr className="border-slate-100" />
+                                <div>
+                                    <p className="font-bold text-slate-800">【ICカード / モバイルSuica定期券】</p>
+                                    <ul className="list-disc list-inside space-y-1 ml-2 mt-1 text-sm">
+                                        <li><strong>入場時：</strong> 自動改札機にタッチして入場します。</li>
+                                        <li><strong>検札時：</strong> ICカードの券面、またはアプリ画面を提示してください。</li>
+                                        <li><strong>出場時：</strong> 自動改札機にタッチして出場します。</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </AccordionItem>
+                    </div>
+                </section>
+
+                {/* 4. よくある質問 */}
+                <section id="faq" className="scroll-mt-20">
+                    <h2 className="text-2xl font-bold text-slate-800 mb-6 border-b pb-2 flex items-center">
+                        4. よくある質問（FAQ）
+                    </h2>
+                    <div className="space-y-4">
+                        <FaqItem question="分割乗車券は違法ではありませんか？">
+                            <p>
+                                いいえ、全く問題ありません。
+                                <Link href="https://www.jreast.co.jp/ryokaku/02_hen/04_syo/02_setsu/03.html" target="_blank" className="text-blue-600 hover:underline decoration-blue-600 underline-offset-2 mx-1">
+                                    旅客営業規則 第157条
+                                </Link>
+                                にも、2枚以上の普通乗車券を併用して使用することが想定された条文が存在します。
+                            </p>
+                        </FaqItem>
+
+                        <FaqItem question="分割するデメリットはありますか？">
+                            <p>はい、あります。主に以下の2点です。</p>
+                            <ul className="list-disc list-outside ml-5 mt-2 space-y-1">
+                                <li>
+                                    払い戻しの際に、きっぷの枚数分の
+                                    <Link href="https://www.jreast.co.jp/kippu/22.html" target="_blank" className="text-blue-600 hover:underline decoration-blue-600 underline-offset-2 mx-1">
+                                        手数料
+                                    </Link>
+                                    がかかる。
+                                </li>
+                                <li>
+                                    <Link href="https://www.jreast.co.jp/ryokaku/02_hen/07_syo/03_setsu/10.html" target="_blank" className="text-blue-600 hover:underline decoration-blue-600 underline-offset-2 mx-1">
+                                        列車の運行不能・遅延等の場合の取扱方
+                                    </Link>
+                                    が通しのきっぷと異なる場合がある。
+                                </li>
+                            </ul>
+                        </FaqItem>
+
+                        <FaqItem question="分割した乗車券で、途中下車はできますか？">
+                            <p>
+                                原則、乗車券に記載の経路上であれば、全ての駅で降りることができます（分割駅を含む）。
+                                ただし、片道の営業キロが100km以下の場合など、購入した普通乗車券の条件によっては下車駅から先の区間が無効になる場合があります。
+                                詳しくは
+                                <Link href="https://www.jreast.co.jp/kippu/05.html" target="_blank" className="text-blue-600 hover:underline decoration-blue-600 underline-offset-2 mx-1">
+                                    こちら
+                                </Link>
+                                をご覧ください。
+                            </p>
+                        </FaqItem>
+
+                        <FaqItem question="特急券や新幹線特急券はどうすればよいですか？">
+                            <p>
+                                特急券は分割せず、通しで購入して問題ありません。ただし、特急券も区間を分割したほうが安くなる場合があります。
+                            </p>
+                            <p>
+                                乗車券のみを分割した状態で、新幹線特急券と一緒に自動改札機で使用することもできます（投入できる枚数制限あり）。このとき、必ず乗車経路と乗車券の経路が一致していることを確認してください。
+                            </p>
+                            <p className="text-xs text-slate-500 mt-2">
+                                ※当サイトのプログラムはJR在来線のみを対象としており、新幹線や在来線特急の料金計算には現在対応していません。
+                            </p>
+                        </FaqItem>
+
+                        {/* 追加されたFAQ 1 */}
+                        <FaqItem question="「東京都区内」などの特定都区市内発着のきっぷはどう計算されますか？">
+                            <p>
+                                当サイトの分割乗車券プログラムでは、特定都区市内発着の特例（旅客営業規則第86条）も考慮して最安となる経路を探索・計算しています。
+                            </p>
+                            <p>
+                                ただし、分割駅が特定都区市内の境界駅やエリア内の駅となる場合など、通常の通しきっぷと効力や途中下車の条件が異なることがあるため、実際の乗車経路と照らし合わせてご利用ください。
+                            </p>
+                        </FaqItem>
+
+                        {/* 追加されたFAQ 2 */}
+                        <FaqItem question="学生割引（学割）を適用した運賃の計算はできますか？">
+                            <p>
+                                現在のプログラムは、大人普通運賃（片道）を基準に計算しております。
+                            </p>
+                            <p>
+                                学割（片道101km以上で運賃が2割引）を適用可能な距離をご利用の場合、分割せずに通しで学割適用乗車券を購入した方が安くなるケースが多く存在します。長距離を利用される学生の方は、事前にみどりの窓口等で通しの学割運賃をご確認いただくことをおすすめします。
+                            </p>
+                        </FaqItem>
+                    </div>
+                </section>
+
+                {/* 5. 仕組みについて */}
+                <section id="about-logic" className="scroll-mt-20">
+                    <h2 className="text-2xl font-bold text-slate-800 mb-6 border-b pb-2 flex items-center">
+                        5. 仕組みについて
+                    </h2>
+                    <div className="space-y-4 text-slate-700 leading-relaxed">
+                        <p>
+                            きっぷナビがどのようにして最安経路や分割パターンを計算しているか、なぜ安くなるか、数学的な背景や探索アルゴリズムについて解説した技術資料を用意しています。
+                        </p>
+                        <p>
+                            最安値の計算ロジックや、同額パターンの完全列挙など、当サイトの裏側にあるプログラムの仕組みに興味がある方は、以下の詳細ページをご覧ください。どのように運営されているかの技術情報も含まれております。
+                        </p>
+                        <div className="pt-2">
+                            <Link href="/logic" className="text-blue-600 hover:underline decoration-blue-600 underline-offset-2 mx-1">
+                                計算の仕組み・技術情報を見る
+                            </Link>
+                        </div>
+                    </div>
+                </section>
+            </div>
+        </div>
+    );
+}

--- a/src/app/logic/page.tsx
+++ b/src/app/logic/page.tsx
@@ -1,526 +1,671 @@
 export const metadata = {
-    title: "運賃計算と分割乗車券の仕組み",
-    description: "JRの乗車券を分割すると安くなる理由や，当サイトが採用している経路探索アルゴリズムについて解説します．",
+    title: "計算の仕組み・技術情報",
+    description: "JRの乗車券を分割すると安くなる理由や、当サイトが採用している経路探索アルゴリズム、技術情報について解説します。",
 };
 
-export default function Page() {
+export default function LogicPage() {
     return (
-        <div className="container mx-auto px-4 py-8 max-w-4xl leading-relaxed text-gray-800">
-            <h1 className="text-3xl font-bold mb-6 border-b pb-4">
-                運賃計算と分割乗車券の仕組み
-            </h1>
-
-            <p className="mb-8">
-                当サイトは、JR線の利用において移動コストを最小化する「最安分割乗車券」と、それを実現する経路を自動的に導出するシステムです。ここでは、なぜ乗車券を分割すると安くなるのかという仕組みと、当サイトを支える情報工学に基づいた計算アルゴリズムについて解説します。
-            </p>
-
-            <section className="mb-12">
-                <h2 className="text-2xl font-semibold mb-6 text-blue-800 border-l-4 border-blue-600 pl-3">
-                    1. なぜ乗車券を分割すると安くなるのか？
-                </h2>
-                <p className="mb-6">
-                    JRの運賃は原則として乗車する営業キロの合計に基づいて算出されますが、以下の5つの要因により、途中の駅で乗車券を分割して購入した方が合計運賃が安価になるケースが存在します。
+        <div className="py-12 px-4 sm:px-6 lg:px-8 max-w-4xl mx-auto space-y-8">
+            {/* ページヘッダー */}
+            <header className="text-center mb-8">
+                <h1 className="text-3xl font-bold text-slate-900 sm:text-4xl">
+                    計算の仕組み・技術情報
+                </h1>
+                <p className="mt-8 text-slate-500">
+                    当サイトは、JR線の利用において移動コストを最小化する「最安分割乗車券」と、それを実現する経路を自動的に導出するシステムです。
+                    ここでは、なぜ乗車券を分割すると安くなるのかという仕組みと、当サイトを支える情報工学に基づいた計算アルゴリズムについて解説します。
+                    また、どのように運営されているかの技術情報も説明します。
                 </p>
+            </header>
 
-                <div className="space-y-8 ml-2 mb-6">
-                    <div>
-                        <h3 className="text-lg font-bold text-gray-900 mb-2">① キロ単価の非単調性</h3>
-                        <p className="mb-2">
-                            運賃のキロ単価は一定ではなく、距離帯によって変動するため、分割した方が安価となる場合があります。
+            {/* 目次 */}
+            <nav className="bg-slate-50 border border-slate-200 rounded-xl p-6">
+                <h2 className="text-lg font-bold text-slate-900 mb-3">目次</h2>
+                <ul className="space-y-3 text-sm">
+                    <li className="flex items-start">
+                        <span className="mr-2 text-slate-900 w-5 shrink-0">1.</span>
+                        <a href="#why-split" className="text-blue-600 hover:underline font-medium">
+                            なぜ乗車券を分割すると安くなるのか？
+                        </a>
+                    </li>
+                    <li className="flex items-start">
+                        <span className="mr-2 text-slate-900 w-5 shrink-0">2.</span>
+                        <a href="#algorithm" className="text-blue-600 hover:underline font-medium">
+                            当サイトの探索アルゴリズムと技術的優位性
+                        </a>
+                    </li>
+                    <li className="flex items-start">
+                        <span className="mr-2 text-slate-900 w-5 shrink-0">3.</span>
+                        <a href="#reversal-phenomenon" className="text-blue-600 hover:underline font-medium">
+                            運賃の「逆転現象」への対応
+                        </a>
+                    </li>
+                    <li className="flex items-start">
+                        <span className="mr-2 text-slate-900 w-5 shrink-0">4.</span>
+                        <a href="#technical-info" className="text-blue-600 hover:underline font-medium">
+                            技術情報
+                        </a>
+                    </li>
+                </ul>
+            </nav>
+
+            {/* コンテンツコンテナ */}
+            <div className="bg-white rounded-2xl shadow-sm border border-slate-200 p-6 sm:p-10 space-y-12">
+
+                {/* 1. なぜ乗車券を分割すると安くなるのか？ */}
+                <section id="why-split" className="scroll-mt-20">
+                    <h2 className="text-2xl font-bold text-slate-800 mb-6 border-b pb-2 flex items-center">
+                        1. なぜ乗車券を分割すると安くなるのか？
+                    </h2>
+                    <div className="space-y-6 text-slate-700 leading-relaxed">
+                        <p>
+                            JRの運賃は原則として乗車する営業キロの合計に基づいて算出されますが、以下の5つの要因により、途中の駅で乗車券を分割して購入した方が合計運賃が安価になるケースが存在します。
                         </p>
-                        <div className="bg-gray-50 p-4 rounded text-sm text-gray-700">
-                            <p className="font-semibold mb-1">【例：横浜駅〜東京駅（東海道本線）の場合】</p>
-                            <ul className="list-disc list-inside space-y-1 ml-2">
-                                <li><strong>通しで購入：</strong> 営業キロ28.8kmは「26km～30km」の運賃帯（28kmとして計算）となり、消費税や端数処理を経て<strong>530円</strong>となります。</li>
-                                <li><strong>蒲田駅で分割：</strong> 横浜〜蒲田（14.4km）、蒲田〜東京（14.4km）はそれぞれ「10km～15km」の運賃帯（13kmとして計算）となり、260円×2枚で<strong>520円</strong>となります。</li>
-                            </ul>
-                            <p className="mt-2">結果として、分割するだけで10円安くなります。</p>
-                            <div className="w-full flex justify-center my-8 overflow-x-auto">
-                                <svg
-                                    viewBox="0 0 800 250"
-                                    className="w-full max-w-3xl min-w-150 h-auto font-sans"
-                                    aria-label="横浜から東京までの分割乗車券の運賃比較図"
-                                >
-                                    <defs>
-                                        <marker
-                                            id="arrowhead"
-                                            markerWidth="10"
-                                            markerHeight="7"
-                                            refX="9"
-                                            refY="3.5"
-                                            orient="auto"
+
+                        <div className="space-y-8">
+                            <div>
+                                <h3 className="text-lg font-bold text-slate-900 mb-2">① キロ単価の非単調性</h3>
+                                <p className="mb-2">
+                                    運賃のキロ単価は一定ではなく、距離帯によって変動するため、分割した方が安価となる場合があります。
+                                </p>
+                                <div className="bg-slate-50 p-4 rounded-xl border border-slate-200 text-sm text-slate-700">
+                                    <p className="font-semibold mb-1">【例：横浜駅〜東京駅（東海道本線）の場合】</p>
+                                    <ul className="list-disc list-inside space-y-1 ml-2">
+                                        <li><strong>通しで購入：</strong> 営業キロ28.8kmは「26km～30km」の運賃帯（28kmとして計算）となり、消費税や端数処理を経て<strong>530円</strong>となります。</li>
+                                        <li><strong>蒲田駅で分割：</strong> 横浜〜蒲田（14.4km）、蒲田〜東京（14.4km）はそれぞれ「10km～15km」の運賃帯（13kmとして計算）となり、260円×2枚で<strong>520円</strong>となります。</li>
+                                    </ul>
+                                    <p className="mt-2">結果として、分割するだけで10円安くなります。</p>
+                                    <div className="w-full flex justify-center my-8 overflow-x-auto">
+                                        <svg
+                                            viewBox="0 0 800 250"
+                                            className="w-full max-w-3xl min-w-150 h-auto font-sans"
+                                            aria-label="横浜から東京までの分割乗車券の運賃比較図"
                                         >
-                                            <polygon points="0 0, 10 3.5, 0 7" fill="#374151" />
-                                        </marker>
-                                    </defs>
+                                            <defs>
+                                                <marker
+                                                    id="arrowhead"
+                                                    markerWidth="10"
+                                                    markerHeight="7"
+                                                    refX="9"
+                                                    refY="3.5"
+                                                    orient="auto"
+                                                >
+                                                    <polygon points="0 0, 10 3.5, 0 7" fill="#374151" />
+                                                </marker>
+                                            </defs>
 
-                                    {/* 1. 路線（ベースとなる太い線） */}
-                                    <line x1="100" y1="125" x2="700" y2="125" stroke="#9CA3AF" strokeWidth="4" />
+                                            {/* 1. 路線（ベースとなる太い線） */}
+                                            <line x1="100" y1="125" x2="700" y2="125" stroke="#9CA3AF" strokeWidth="4" />
 
-                                    {/* 2. 上部の矢印（通し運賃：蒲田〜東京） */}
-                                    <line
-                                        x1="100" y1="70" x2="700" y2="70"
-                                        stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
-                                    />
-                                    <text x="400" y="55" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
-                                        530円（28.8km）
-                                    </text>
+                                            {/* 2. 上部の矢印（通し運賃：蒲田〜東京） */}
+                                            <line
+                                                x1="100" y1="70" x2="700" y2="70"
+                                                stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
+                                            />
+                                            <text x="400" y="55" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
+                                                530円（28.8km）
+                                            </text>
 
-                                    {/* 3. 下部の矢印1（横浜〜蒲田の分割運賃） */}
-                                    <line
-                                        x1="100" y1="180" x2="385" y2="180"
-                                        stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
-                                    />
-                                    <text x="242.5" y="205" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
-                                        260円（14.4km）
-                                    </text>
+                                            {/* 3. 下部の矢印1（横浜〜蒲田の分割運賃） */}
+                                            <line
+                                                x1="100" y1="180" x2="385" y2="180"
+                                                stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
+                                            />
+                                            <text x="242.5" y="205" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
+                                                260円（14.4km）
+                                            </text>
 
-                                    {/* 4. 下部の矢印2（蒲田〜東京の分割運賃） */}
-                                    <line
-                                        x1="415" y1="180" x2="700" y2="180"
-                                        stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
-                                    />
-                                    <text x="557.5" y="205" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
-                                        260円（14.4km）
-                                    </text>
+                                            {/* 4. 下部の矢印2（蒲田〜東京の分割運賃） */}
+                                            <line
+                                                x1="415" y1="180" x2="700" y2="180"
+                                                stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
+                                            />
+                                            <text x="557.5" y="205" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
+                                                260円（14.4km）
+                                            </text>
 
-                                    {/* 5. 駅のノード（円）とラベル */}
-                                    {/* 横浜駅 */}
-                                    <circle cx="100" cy="125" r="8" fill="white" stroke="#111827" strokeWidth="3" />
-                                    <text x="100" y="152" textAnchor="middle" fill="#111827" className="text-base font-bold">横浜</text>
+                                            {/* 5. 駅のノード（円）とラベル */}
+                                            {/* 横浜駅 */}
+                                            <circle cx="100" cy="125" r="8" fill="white" stroke="#111827" strokeWidth="3" />
+                                            <text x="100" y="152" textAnchor="middle" fill="#111827" className="text-base font-bold">横浜</text>
 
-                                    {/* 蒲田駅 */}
-                                    <circle cx="400" cy="125" r="8" fill="white" stroke="#111827" strokeWidth="3" />
-                                    <text x="400" y="152" textAnchor="middle" fill="#111827" className="text-base font-bold">蒲田</text>
+                                            {/* 蒲田駅 */}
+                                            <circle cx="400" cy="125" r="8" fill="white" stroke="#111827" strokeWidth="3" />
+                                            <text x="400" y="152" textAnchor="middle" fill="#111827" className="text-base font-bold">蒲田</text>
 
-                                    {/* 東京駅 */}
-                                    <circle cx="700" cy="125" r="8" fill="white" stroke="#111827" strokeWidth="3" />
-                                    <text x="700" y="152" textAnchor="middle" fill="#111827" className="text-base font-bold">東京</text>
-                                </svg>
+                                            {/* 東京駅 */}
+                                            <circle cx="700" cy="125" r="8" fill="white" stroke="#111827" strokeWidth="3" />
+                                            <text x="700" y="152" textAnchor="middle" fill="#111827" className="text-base font-bold">東京</text>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div>
+                                <h3 className="text-lg font-bold text-slate-900 mb-2">② 特定区間運賃の利用</h3>
+                                <p className="mb-2">
+                                    私鉄などと競合する区間には、通常の距離制運賃よりも安い「特定運賃」が設定されていることがあり、その区間を独立させて分割することで全体が安くなります。
+                                </p>
+                                <div className="bg-slate-50 p-4 rounded-xl border border-slate-200 text-sm text-slate-700">
+                                    <p className="font-semibold mb-1">【例：横浜駅〜池袋駅（東海道本線・山手線）の場合】</p>
+                                    <ul className="list-disc list-inside space-y-1 ml-2">
+                                        <li><strong>通しで購入：</strong> 営業キロ37.4kmに対する通常計算で<strong>720円</strong>となります。</li>
+                                        <li><strong>渋谷駅で分割：</strong> 営業キロ29.2kmに対する運賃は530円ですが、渋谷〜横浜間には東急東横線に対抗するための「特定運賃」が設定されており、特例として<strong>440円</strong>となります。池袋〜渋谷間は通常の計算よる<strong>210円</strong>です。</li>
+                                    </ul>
+                                    <p className="mt-2">これらを合計すると<strong>650円</strong>となり、特定運賃の恩恵を受けることで通しで買うよりも安くなります。</p>
+                                    <div className="w-full flex justify-center my-8 overflow-x-auto">
+                                        <svg
+                                            viewBox="0 0 800 250"
+                                            className="w-full max-w-3xl min-w-150 h-auto font-sans"
+                                            aria-label="横浜から池袋までの分割乗車券の運賃比較図"
+                                        >
+                                            <defs>
+                                                <marker
+                                                    id="arrowhead"
+                                                    markerWidth="10"
+                                                    markerHeight="7"
+                                                    refX="9"
+                                                    refY="3.5"
+                                                    orient="auto"
+                                                >
+                                                    <polygon points="0 0, 10 3.5, 0 7" fill="#374151" />
+                                                </marker>
+                                            </defs>
+
+                                            {/* 1. 路線（ベースとなる太い線） */}
+                                            <line x1="100" y1="125" x2="700" y2="125" stroke="#9CA3AF" strokeWidth="4" />
+
+                                            {/* 2. 上部の矢印（通し運賃） */}
+                                            <line
+                                                x1="100" y1="70" x2="700" y2="70"
+                                                stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
+                                            />
+                                            <text x="400" y="55" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
+                                                720円（37.4km）
+                                            </text>
+
+                                            {/* 3. 下部の矢印1（横浜〜渋谷の分割運賃） */}
+                                            <line
+                                                x1="100" y1="180" x2="485" y2="180"
+                                                stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
+                                            />
+                                            <text x="292.5" y="205" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
+                                                440円（29.2km）
+                                            </text>
+
+                                            {/* 4. 下部の矢印2（渋谷〜池袋の分割運賃） */}
+                                            <line
+                                                x1="515" y1="180" x2="700" y2="180"
+                                                stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
+                                            />
+                                            <text x="607.5" y="205" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
+                                                210円（8.2km）
+                                            </text>
+
+                                            {/* 5. 駅のノード（円）とラベル */}
+                                            {/* 横浜駅 */}
+                                            <circle cx="100" cy="125" r="8" fill="white" stroke="#111827" strokeWidth="3" />
+                                            <text x="100" y="152" textAnchor="middle" fill="#111827" className="text-base font-bold">横浜</text>
+
+                                            {/* 渋谷駅 */}
+                                            <circle cx="500" cy="125" r="8" fill="white" stroke="#111827" strokeWidth="3" />
+                                            <text x="500" y="152" textAnchor="middle" fill="#111827" className="text-base font-bold">渋谷</text>
+
+                                            {/* 池袋駅 */}
+                                            <circle cx="700" cy="125" r="8" fill="white" stroke="#111827" strokeWidth="3" />
+                                            <text x="700" y="152" textAnchor="middle" fill="#111827" className="text-base font-bold">池袋</text>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div>
+                                <h3 className="text-lg font-bold text-slate-900 mb-2">③ 長距離区間における距離帯間隔の拡大</h3>
+                                <p className="mb-2">
+                                    これは①とよく似ています。営業キロが長くなるにつれて運賃が上昇する間隔が広がるため（例：50kmまでは5kmごと、101km〜600kmは20kmごと）、短距離の乗車券を別途購入して長距離側の営業キロを調整することで、全体を低減できる場合があります。
+                                </p>
+                                <div className="bg-slate-50 p-4 rounded-xl border border-slate-200 text-sm text-slate-700">
+                                    <p className="font-semibold mb-1">【例：福山駅〜静岡駅（山陽本線・東海道本線）の場合】</p>
+                                    <ul className="list-disc list-inside space-y-1 ml-2">
+                                        <li><strong>通しで購入：</strong> 営業キロ611.0kmは「601km～640km」の運賃帯（620kmとして計算）となり<strong>9,790円</strong>となります。</li>
+                                        <li><strong>焼津駅で分割：</strong> 営業キロ597.5kmは「581km～600km」の運賃帯（590kmとして計算）となり、<strong>9,460円</strong>となります。焼津から静岡は13.5kmで240円です。1.5km分は無駄になりますが、先述の7.5km分の運賃削減効果（通し運賃の620km帯から590km帯への引き下げによる差額）が上回るため、全体として安くなります。</li>
+                                    </ul>
+                                    <p className="mt-2">これらを合計すると<strong>9,700円</strong>となり、営業キロの幅を小さく調整することで通しで買うよりも安くなります。</p>
+                                    <div className="w-full flex justify-center my-8 overflow-x-auto">
+                                        <svg
+                                            viewBox="0 0 800 250"
+                                            className="w-full max-w-3xl min-w-150 h-auto font-sans"
+                                            aria-label="福山から静岡までの分割乗車券の運賃比較図"
+                                        >
+                                            <defs>
+                                                <marker
+                                                    id="arrowhead"
+                                                    markerWidth="10"
+                                                    markerHeight="7"
+                                                    refX="9"
+                                                    refY="3.5"
+                                                    orient="auto"
+                                                >
+                                                    <polygon points="0 0, 10 3.5, 0 7" fill="#374151" />
+                                                </marker>
+                                            </defs>
+
+                                            {/* 1. 路線（ベースとなる太い線） */}
+                                            <line x1="100" y1="125" x2="700" y2="125" stroke="#9CA3AF" strokeWidth="4" />
+
+                                            {/* 2. 上部の矢印（通し運賃） */}
+                                            <line
+                                                x1="100" y1="70" x2="700" y2="70"
+                                                stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
+                                            />
+                                            <text x="400" y="55" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
+                                                9,790円（611.0km）
+                                            </text>
+
+                                            {/* 3. 下部の矢印1（福山〜焼津の分割運賃） */}
+                                            <line
+                                                x1="100" y1="180" x2="485" y2="180"
+                                                stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
+                                            />
+                                            <text x="292.5" y="205" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
+                                                9,460円（597.5km）
+                                            </text>
+
+                                            {/* 4. 下部の矢印2（焼津〜静岡の分割運賃） */}
+                                            <line
+                                                x1="515" y1="180" x2="700" y2="180"
+                                                stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
+                                            />
+                                            <text x="607.5" y="205" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
+                                                240円（13.5km）
+                                            </text>
+
+                                            {/* 5. 駅のノード（円）とラベル */}
+                                            {/* 福山駅 */}
+                                            <circle cx="100" cy="125" r="8" fill="white" stroke="#111827" strokeWidth="3" />
+                                            <text x="100" y="152" textAnchor="middle" fill="#111827" className="text-base font-bold">福山</text>
+
+                                            {/* 焼津駅 */}
+                                            <circle cx="500" cy="125" r="8" fill="white" stroke="#111827" strokeWidth="3" />
+                                            <text x="500" y="152" textAnchor="middle" fill="#111827" className="text-base font-bold">焼津</text>
+
+                                            {/* 静岡駅 */}
+                                            <circle cx="700" cy="125" r="8" fill="white" stroke="#111827" strokeWidth="3" />
+                                            <text x="700" y="152" textAnchor="middle" fill="#111827" className="text-base font-bold">静岡</text>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div>
+                                <h3 className="text-lg font-bold text-slate-900 mb-2">④ 電車特定区間運賃の適用</h3>
+                                <p className="mb-2">
+                                    割安な「電車特定区間」と通常の「幹線」をまたがって乗車する場合、全区間が割高な幹線の賃率で計算されてしまうため、境界付近で分割して電車特定区間を独立させます。
+                                </p>
+                                <div className="bg-slate-50 p-4 rounded-xl border border-slate-200 text-sm text-slate-700">
+                                    <p className="font-semibold mb-1">【例：久宝寺駅〜大河原駅（関西本線）の場合】</p>
+                                    <ul className="list-disc list-inside space-y-1 ml-2">
+                                        <li><strong>通しで購入：</strong> 営業キロ55.5kmは「51km～60km」の運賃帯で幹線の賃率として計算され、消費税や端数処理を経て<strong>990円</strong>となります。</li>
+                                        <li><strong>法隆寺駅と木津駅で分割：</strong> 3つの分割区間の営業キロはそれぞれ「16km～20km」の運賃帯（18kmとして計算）となり、幹線運賃のままだとそれぞれ330円となります。しかし、法隆寺駅で分割することにより久宝寺駅～法隆寺駅間が電車特定区間内完結で320円となり、合計は<strong>980円</strong>となります。</li>
+                                    </ul>
+                                    <p className="mt-2">結果として、分割すると10円安くなります。</p>
+                                    <div className="w-full flex justify-center my-8 overflow-x-auto">
+                                        <svg
+                                            viewBox="0 0 800 300"
+                                            className="w-full max-w-3xl min-w-150 h-auto font-sans"
+                                            aria-label="電車特定区間を跨ぐ分割乗車券の運賃比較図"
+                                        >
+                                            <defs>
+                                                <marker
+                                                    id="arrowhead"
+                                                    markerWidth="10"
+                                                    markerHeight="7"
+                                                    refX="9"
+                                                    refY="3.5"
+                                                    orient="auto"
+                                                >
+                                                    <polygon points="0 0, 10 3.5, 0 7" fill="#374151" />
+                                                </marker>
+                                            </defs>
+
+                                            {/* 0. 電車特定区間エリア（背景の破線ボックス） */}
+                                            {/* 久宝寺(100)から法隆寺(300)をすっぽり覆うように配置 */}
+                                            <rect
+                                                x="40"
+                                                y="30"
+                                                width="320"
+                                                height="240"
+                                                rx="12"
+                                                fill="#F3F4F6"
+                                                stroke="#9CA3AF"
+                                                strokeWidth="2"
+                                                strokeDasharray="6 4"
+                                            />
+                                            {/* 背景エリアのラベル */}
+                                            <text x="200" y="60" textAnchor="middle" fill="#1F2937" className="text-base font-bold">
+                                                電車特定区間内
+                                            </text>
+
+                                            {/* 1. 路線（ベースとなる太い線） */}
+                                            <line x1="100" y1="150" x2="700" y2="150" stroke="#9CA3AF" strokeWidth="4" />
+
+                                            {/* 2. 上部の矢印（通し運賃） */}
+                                            <line
+                                                x1="100" y1="100" x2="700" y2="100"
+                                                stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
+                                            />
+                                            {/* テキストは特定区間のラベルと被らないよう、右側（木津駅付近）に配置 */}
+                                            <text x="500" y="85" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
+                                                990円（55.5km）
+                                            </text>
+
+                                            {/* 3. 下部の矢印1（久宝寺〜法隆寺） */}
+                                            <line
+                                                x1="100" y1="210" x2="285" y2="210"
+                                                stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
+                                            />
+                                            <text x="192.5" y="235" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
+                                                320円（18.6km）
+                                            </text>
+
+                                            {/* 4. 下部の矢印2（法隆寺〜木津） */}
+                                            <line
+                                                x1="315" y1="210" x2="485" y2="210"
+                                                stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
+                                            />
+                                            <text x="400" y="235" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
+                                                330円（18.8km）
+                                            </text>
+
+                                            {/* 5. 下部の矢印3（木津〜大河原） */}
+                                            <line
+                                                x1="515" y1="210" x2="700" y2="210"
+                                                stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
+                                            />
+                                            <text x="607.5" y="235" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
+                                                330円（18.1km）
+                                            </text>
+
+                                            {/* 6. 駅のノード（円）とラベル */}
+                                            {/* 久宝寺駅 */}
+                                            <circle cx="100" cy="150" r="8" fill="white" stroke="#111827" strokeWidth="3" />
+                                            <text x="100" y="177" textAnchor="middle" fill="#111827" className="text-base font-bold">久宝寺</text>
+
+                                            {/* 法隆寺駅 */}
+                                            <circle cx="300" cy="150" r="8" fill="white" stroke="#111827" strokeWidth="3" />
+                                            <text x="300" y="177" textAnchor="middle" fill="#111827" className="text-base font-bold">法隆寺</text>
+
+                                            {/* 木津駅 */}
+                                            <circle cx="500" cy="150" r="8" fill="white" stroke="#111827" strokeWidth="3" />
+                                            <text x="500" y="177" textAnchor="middle" fill="#111827" className="text-base font-bold">木津</text>
+
+                                            {/* 大河原駅 */}
+                                            <circle cx="700" cy="150" r="8" fill="white" stroke="#111827" strokeWidth="3" />
+                                            <text x="700" y="177" textAnchor="middle" fill="#111827" className="text-base font-bold">大河原</text>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div>
+                                <h3 className="text-lg font-bold text-slate-900 mb-2">⑤ 特定都区市内制度の適用または回避</h3>
+                                <p className="mb-2">
+                                    分割することにより、特定都区市内の特例制度を利用して運賃計算経路を短縮したり、逆に特例の適用を避けるために境界駅で分割することで安くなることがあります。
+                                </p>
+                                <div className="bg-slate-50 p-4 rounded-xl border border-slate-200 text-sm text-slate-700">
+                                    <p className="font-semibold mb-1">【例：宮島口駅〜網干駅（山陽本線）の場合】</p>
+                                    <ul className="list-disc list-inside space-y-1 ml-2">
+                                        <li><strong>通しで購入：</strong> 営業キロ261.1kmは「261km～280km」の運賃帯で<strong>4,840円</strong>となります。</li>
+                                        <li><strong>五日市駅で分割：</strong> 五日市駅は広島市内にあるので、五日市〜東京（251.7km）は、「広島市内→網干」として中心駅の広島駅からの運賃計算です。広島～網干（239.6km）は「221～240km」の運賃帯（230kmとして計算）となり、<strong>4,070円</strong>となります。</li>
+                                    </ul>
+                                    <p className="mt-2">結果として、分割するだけで250円安くなります。</p>
+                                    <div className="w-full flex justify-center my-8 overflow-x-auto">
+                                        {/* viewBoxで描画領域を定義（幅800, 高さ280に拡張してゾーンを収める） */}
+                                        <svg
+                                            viewBox="0 0 800 280"
+                                            className="w-full max-w-3xl min-w-150 h-auto font-sans"
+                                            aria-label="特定都区市内制度による分割乗車券の逆転現象の解説図"
+                                        >
+                                            <defs>
+                                                <marker
+                                                    id="arrowhead"
+                                                    markerWidth="10"
+                                                    markerHeight="7"
+                                                    refX="9"
+                                                    refY="3.5"
+                                                    orient="auto"
+                                                >
+                                                    <polygon points="0 0, 10 3.5, 0 7" fill="#374151" />
+                                                </marker>
+                                            </defs>
+
+                                            {/* 1. 特定都区市内のゾーン（背景の点線枠） */}
+                                            <rect
+                                                x="250" y="20" width="300" height="175"
+                                                rx="12" fill="#F3F4F6" stroke="#9CA3AF" strokeWidth="2" strokeDasharray="6 6"
+                                            />
+                                            <text x="400" y="55" textAnchor="middle" fill="#374151" className="text-lg font-bold">
+                                                広島市内
+                                            </text>
+
+                                            {/* 2. 上部の矢印（宮島口〜網干の通し運賃） */}
+                                            <text x="400" y="85" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
+                                                4,840円（261.1km）
+                                            </text>
+                                            <line
+                                                x1="100" y1="95" x2="690" y2="95"
+                                                stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
+                                            />
+
+                                            {/* 3. 中心駅のラベル */}
+                                            <text x="400" y="125" textAnchor="middle" fill="#4B5563" className="text-xs font-bold">
+                                                中心駅
+                                            </text>
+
+                                            {/* 4. 路線（ベースとなる太い線） */}
+                                            <line x1="100" y1="150" x2="700" y2="150" stroke="#9CA3AF" strokeWidth="4" />
+
+                                            {/* 5. 下部の矢印1（宮島口〜五日市の分割運賃） */}
+                                            <line
+                                                x1="100" y1="220" x2="290" y2="220"
+                                                stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
+                                            />
+                                            <text x="195" y="245" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
+                                                200円（9.7km）
+                                            </text>
+
+                                            {/* 6. 下部の矢印2（広島〜網干の特定都区市内運賃） */}
+                                            <line
+                                                x1="410" y1="220" x2="690" y2="220"
+                                                stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
+                                            />
+                                            <text x="550" y="245" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
+                                                4,070円（239.6km）
+                                            </text>
+
+                                            {/* 7. 駅のノード（円）とラベル */}
+                                            {/* 宮島口駅 */}
+                                            <circle cx="100" cy="150" r="8" fill="white" stroke="#111827" strokeWidth="3" />
+                                            <text x="100" y="178" textAnchor="middle" fill="#111827" className="text-base font-bold">宮島口</text>
+
+                                            {/* 五日市駅 */}
+                                            <circle cx="300" cy="150" r="8" fill="white" stroke="#111827" strokeWidth="3" />
+                                            <text x="300" y="178" textAnchor="middle" fill="#111827" className="text-base font-bold">五日市</text>
+
+                                            {/* 広島駅 */}
+                                            <circle cx="400" cy="150" r="8" fill="white" stroke="#111827" strokeWidth="3" />
+                                            <text x="400" y="178" textAnchor="middle" fill="#111827" className="text-base font-bold">広島</text>
+
+                                            {/* 網干駅 */}
+                                            <circle cx="700" cy="150" r="8" fill="white" stroke="#111827" strokeWidth="3" />
+                                            <text x="700" y="178" textAnchor="middle" fill="#111827" className="text-base font-bold">網干</text>
+                                        </svg>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>
+                </section>
 
-                    <div>
-                        <h3 className="text-lg font-bold text-gray-900 mb-2">② 特定区間運賃の利用</h3>
-                        <p className="mb-2">
-                            私鉄などと競合する区間には、通常の距離制運賃よりも安い「特定運賃」が設定されていることがあり、その区間を独立させて分割することで全体が安くなります。
+                {/* 2. 当サイトの探索アルゴリズムと技術的優位性 */}
+                <section id="algorithm" className="scroll-mt-20">
+                    <h2 className="text-2xl font-bold text-slate-800 mb-6 border-b pb-2 flex items-center">
+                        2. 当サイトの探索アルゴリズムと技術的優位性
+                    </h2>
+                    <div className="space-y-6 text-slate-700 leading-relaxed">
+                        <p>
+                            既存の分割乗車券プログラムの多くは、利用者が事前に「乗車する経路」を指定する必要がありました。また、計算速度を優先した単純な動的計画法（DP）では、最適化の過程で同額となる別の分割パターンが枝刈りされてしまい、出力される解が一つに限定されるという課題がありました。
                         </p>
-                        <div className="bg-gray-50 p-4 rounded text-sm text-gray-700">
-                            <p className="font-semibold mb-1">【例：横浜駅〜池袋駅（東海道本線・山手線）の場合】</p>
-                            <ul className="list-disc list-inside space-y-1 ml-2">
-                                <li><strong>通しで購入：</strong> 営業キロ37.4kmに対する通常計算で<strong>720円</strong>となります。</li>
-                                <li><strong>渋谷駅で分割：</strong> 営業キロ29.2kmに対する運賃は530円ですが、渋谷〜横浜間には東急東横線に対抗するための「特定運賃」が設定されており、特例として<strong>440円</strong>となります。池袋〜渋谷間は通常の計算よる<strong>210円</strong>です。</li>
-                            </ul>
-                            <p className="mt-2">これらを合計すると<strong>650円</strong>となり、特定運賃の恩恵を受けることで通しで買うよりも安くなります。</p>
-                            <div className="w-full flex justify-center my-8 overflow-x-auto">
-                                <svg
-                                    viewBox="0 0 800 250"
-                                    className="w-full max-w-3xl min-w-150 h-auto font-sans"
-                                    aria-label="横浜から池袋までの分割乗車券の運賃比較図"
-                                >
-                                    <defs>
-                                        <marker
-                                            id="arrowhead"
-                                            markerWidth="10"
-                                            markerHeight="7"
-                                            refX="9"
-                                            refY="3.5"
-                                            orient="auto"
-                                        >
-                                            <polygon points="0 0, 10 3.5, 0 7" fill="#374151" />
-                                        </marker>
-                                    </defs>
+                        <p>
+                            当システムでは、情報工学におけるグラフ理論と最新のWeb技術を応用し、以下の独自アプローチを採用しています。
+                        </p>
 
-                                    {/* 1. 路線（ベースとなる太い線） */}
-                                    <line x1="100" y1="125" x2="700" y2="125" stroke="#9CA3AF" strokeWidth="4" />
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <div className="bg-white p-5 rounded-xl border border-slate-200 shadow-sm">
+                                <h3 className="text-lg font-bold mb-3 text-slate-900">経路指定不要の自動探索</h3>
+                                <p className="text-sm text-slate-700">
+                                    K-最短経路アルゴリズム（{"Yen's Algorithm"}）を応用することで、利用者が自ら経路を指定することなく、分割乗車券によって安価となる「迂回経路」も含めた候補ルートの列挙を自動で行います。
+                                </p>
+                            </div>
 
-                                    {/* 2. 上部の矢印（通し運賃） */}
-                                    <line
-                                        x1="100" y1="70" x2="700" y2="70"
-                                        stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
-                                    />
-                                    <text x="400" y="55" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
-                                        720円（37.4km）
-                                    </text>
+                            <div className="bg-white p-5 rounded-xl border border-slate-200 shadow-sm">
+                                <h3 className="text-lg font-bold mb-3 text-slate-900">ヒューリスティック探索の不採用</h3>
+                                <p className="text-sm text-slate-700">
+                                    A* アルゴリズムなどは高速ですが、JRには「営業キロが物理的な距離よりも短く設定されている区間」が存在します。物理的距離を推定値に用いるとコストを過大評価し最安解を見逃すリスクがあるため、解の正当性を完全に保証する手法を採用しています。
+                                </p>
+                            </div>
 
-                                    {/* 3. 下部の矢印1（横浜〜渋谷の分割運賃） */}
-                                    <line
-                                        x1="100" y1="180" x2="485" y2="180"
-                                        stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
-                                    />
-                                    <text x="292.5" y="205" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
-                                        440円（29.2km）
-                                    </text>
+                            <div className="bg-white p-5 rounded-xl border border-slate-200 shadow-sm">
+                                <h3 className="text-lg font-bold mb-3 text-slate-900">同額パターンの完全列挙</h3>
+                                <p className="text-sm text-slate-700">
+                                    現実の鉄道利用では、分割位置による途中下車の可否など利便性を左右する要因があります。当システムは1次元DPの最適化過程で枝刈りを行わず、同額となる複数の最安分割パターンを完全に列挙し、実用上の選択肢を全て提示します。
+                                </p>
+                            </div>
 
-                                    {/* 4. 下部の矢印2（渋谷〜池袋の分割運賃） */}
-                                    <line
-                                        x1="515" y1="180" x2="700" y2="180"
-                                        stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
-                                    />
-                                    <text x="607.5" y="205" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
-                                        210円（8.2km）
-                                    </text>
-
-                                    {/* 5. 駅のノード（円）とラベル */}
-                                    {/* 横浜駅 */}
-                                    <circle cx="100" cy="125" r="8" fill="white" stroke="#111827" strokeWidth="3" />
-                                    <text x="100" y="152" textAnchor="middle" fill="#111827" className="text-base font-bold">横浜</text>
-
-                                    {/* 渋谷駅 */}
-                                    <circle cx="500" cy="125" r="8" fill="white" stroke="#111827" strokeWidth="3" />
-                                    <text x="500" y="152" textAnchor="middle" fill="#111827" className="text-base font-bold">渋谷</text>
-
-                                    {/* 池袋駅 */}
-                                    <circle cx="700" cy="125" r="8" fill="white" stroke="#111827" strokeWidth="3" />
-                                    <text x="700" y="152" textAnchor="middle" fill="#111827" className="text-base font-bold">池袋</text>
-                                </svg>
+                            <div className="bg-white p-5 rounded-xl border border-slate-200 shadow-sm">
+                                <h3 className="text-lg font-bold mb-3 text-slate-900">多層キャッシュによる高速化</h3>
+                                <p className="text-sm text-slate-700">
+                                    複雑な計算アルゴリズムによるサーバー負荷を軽減するため、Cloud RunとFirebase Firestoreを連携。一度計算された解は非同期でデータベースにキャッシュされ、2回目以降の同一検索に対しては数ミリ秒での即時応答を実現しています。
+                                </p>
                             </div>
                         </div>
                     </div>
+                </section>
 
-                    <div>
-                        <h3 className="text-lg font-bold text-gray-900 mb-2">③ 長距離区間における距離帯間隔の拡大</h3>
-                        <p className="mb-2">
-                            これは①とよく似ています。営業キロが長くなるにつれて運賃が上昇する間隔が広がるため（例：50kmまでは5kmごと、101km〜600kmは20kmごと）、短距離の乗車券を別途購入して長距離側の営業キロを調整することで、全体を低減できる場合があります。
+                {/* 3. 運賃の「逆転現象」への対応 */}
+                <section id="reversal-phenomenon" className="scroll-mt-20">
+                    <h2 className="text-2xl font-bold text-slate-800 mb-6 border-b pb-2 flex items-center">
+                        3. 運賃の「逆転現象」への対応
+                    </h2>
+                    <div className="space-y-6 text-slate-700 leading-relaxed">
+                        <p>
+                            特定の条件下では、乗車経路を外方へ延伸することで運賃が安くなる「逆転現象」が発生します。
+                            例えば、特定都区市内制度において、あえて目的地の先の駅まで切符を買うことで、発駅が都区市内中心駅からの計算に切り替わり、結果的に運賃が安くなる現象などです。
                         </p>
-                        <div className="bg-gray-50 p-4 rounded text-sm text-gray-700">
-                            <p className="font-semibold mb-1">【例：福山駅〜静岡駅（山陽本線・東海道本線）の場合】</p>
-                            <ul className="list-disc list-inside space-y-1 ml-2">
-                                <li><strong>通しで購入：</strong> 営業キロ611.0kmは「601km～640km」の運賃帯（620kmとして計算）となり<strong>9,790円</strong>となります。</li>
-                                <li><strong>焼津駅で分割：</strong> 営業キロ597.5kmは「581km～600km」の運賃帯（590kmとして計算）となり7.5km分<strong>9,460円</strong>で、620km分の運賃という利用区間を超える運賃を回避しています。焼津から静岡は13.5kmで5km単位の運賃帯であるため、1.5km分は無駄に払っていますが、先ほどの7.5km分得していることに加えて9.0kmに比べたら小さいことがわかります。</li>
-                            </ul>
-                            <p className="mt-2">これらを合計すると<strong>9,700円</strong>となり、営業キロの幅を小さく調整することで通しで買うよりも安くなります。</p>
-                            <div className="w-full flex justify-center my-8 overflow-x-auto">
-                                <svg
-                                    viewBox="0 0 800 250"
-                                    className="w-full max-w-3xl min-w-150 h-auto font-sans"
-                                    aria-label="福山から静岡までの分割乗車券の運賃比較図"
-                                >
-                                    <defs>
-                                        <marker
-                                            id="arrowhead"
-                                            markerWidth="10"
-                                            markerHeight="7"
-                                            refX="9"
-                                            refY="3.5"
-                                            orient="auto"
-                                        >
-                                            <polygon points="0 0, 10 3.5, 0 7" fill="#374151" />
-                                        </marker>
-                                    </defs>
+                        <p>
+                            当システムでは、こうした複雑な運賃規則（経路特定区間や特定都区市内など）をアルゴリズムの内部に組み込み、限界距離を算出した上での枝刈りを行うことで、延伸による逆転現象も考慮した「真の最安運賃」を導出する処理を行っています。
+                        </p>
+                        <p>
+                            ただし、区間変更を用いて運賃を安くする方法については採用していません。
+                        </p>
+                    </div>
+                </section>
 
-                                    {/* 1. 路線（ベースとなる太い線） */}
-                                    <line x1="100" y1="125" x2="700" y2="125" stroke="#9CA3AF" strokeWidth="4" />
+                {/* 4. 技術情報 */}
+                <section id="technical-info" className="scroll-mt-20">
+                    <h2 className="text-2xl font-bold text-slate-800 mb-6 border-b pb-2 flex items-center">
+                        4. 技術情報
+                    </h2>
+                    <div className="space-y-6 text-slate-700 leading-relaxed">
+                        <p>
+                            当サイトは、高度なアルゴリズムの実行とレスポンスの高速化を両立するため、現代的なWeb技術スタックとクラウドインフラを組み合わせて構築されています。
+                        </p>
 
-                                    {/* 2. 上部の矢印（通し運賃） */}
-                                    <line
-                                        x1="100" y1="70" x2="700" y2="70"
-                                        stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
-                                    />
-                                    <text x="400" y="55" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
-                                        9,790円（611.0km）
-                                    </text>
+                        <h3 className="text-xl font-bold mb-4 text-slate-900 border-b pb-2">技術スタック</h3>
+                        <div className="overflow-x-auto mb-8">
+                            <table className="w-full text-left border-collapse text-sm border-slate-200">
+                                <thead>
+                                    <tr className="bg-slate-50 border-b border-slate-200">
+                                        <th className="p-3 font-semibold text-slate-700">領域</th>
+                                        <th className="p-3 font-semibold text-slate-700">技術・ツール</th>
+                                        <th className="p-3 font-semibold text-slate-700">採用の目的・意図</th>
+                                    </tr>
+                                </thead>
+                                <tbody className="divide-y divide-slate-200 text-slate-700">
+                                    <tr>
+                                        <td className="p-3 font-medium text-slate-900">Frontend</td>
+                                        <td className="p-3">Next.js (App Router), TypeScript</td>
+                                        <td className="p-3 text-slate-600">サーバーサイドレンダリング(SSR)による初期表示の高速化と、複雑な運賃ドメインモデルの型安全性担保。</td>
+                                    </tr>
+                                    <tr>
+                                        <td className="p-3 font-medium text-slate-900">Styling</td>
+                                        <td className="p-3">Tailwind CSS</td>
+                                        <td className="p-3 text-slate-600">一貫性のあるモダンなUIデザインの迅速な実装と、クリーンなスタイル管理。</td>
+                                    </tr>
+                                    <tr>
+                                        <td className="p-3 font-medium text-slate-900">Backend / API</td>
+                                        <td className="p-3">Next.js Route Handlers</td>
+                                        <td className="p-3 text-slate-600">フロントエンドと同一リポジトリ（モノレポ）で型定義やユーティリティを共有し、開発効率を最大化。</td>
+                                    </tr>
+                                    <tr>
+                                        <td className="p-3 font-medium text-slate-900">Database</td>
+                                        <td className="p-3">Firebase Firestore</td>
+                                        <td className="p-3 text-slate-600">計算コストの高い経路探索結果をキャッシュし、2回目以降の同一検索を数ミリ秒で即時応答。</td>
+                                    </tr>
+                                    <tr>
+                                        <td className="p-3 font-medium text-slate-900">Infrastructure</td>
+                                        <td className="p-3">Google Cloud Run</td>
+                                        <td className="p-3 text-slate-600">ステートレスなコンテナによる安定稼働と、アクセス状況に応じた柔軟なオートスケーリング。</td>
+                                    </tr>
+                                    <tr>
+                                        <td className="p-3 font-medium text-slate-900">Object Storage</td>
+                                        <td className="p-3">Cloudflare R2</td>
+                                        <td className="p-3 text-slate-600">経路探索に使用するグラフデータ（`graph_data.bin`）やWasmモジュール（`split_pass.wasm`）を低レイテンシかつデータ転送（エグレス）手数料無料で高速配信。</td>
+                                    </tr>
+                                    <tr>
+                                        <td className="p-3 font-medium text-slate-900">CI/CD / DevSecOps</td>
+                                        <td className="p-3">GitHub Actions, Vitest, Takumi Guard, Cloud Build</td>
+                                        <td className="p-3 text-slate-600">自動テスト・Strict Lintの実施、npmパッケージのサプライチェーン攻撃対策、およびブランチごとのプレビュー環境自動生成。</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
 
-                                    {/* 3. 下部の矢印1（福山〜焼津の分割運賃） */}
-                                    <line
-                                        x1="100" y1="180" x2="485" y2="180"
-                                        stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
-                                    />
-                                    <text x="292.5" y="205" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
-                                        9,460円（597.5km）
-                                    </text>
+                        <h3 className="text-xl font-bold mb-4 text-slate-900 border-b pb-2">システムの工夫と最適化</h3>
+                        <div className="space-y-6">
+                            <div>
+                                <h4 className="text-lg font-semibold text-slate-900 mb-2">① 浮動小数点数演算エラーの完全排除</h4>
+                                <p className="text-sm text-slate-700 leading-relaxed">
+                                    JavaScriptで小数の計算を行うと、IEEE 754規格に起因する丸め誤差が発生します。
+                                    JRの営業キロは「小数第1位」まで定義されているというドメイン特性を考慮し、計算前にすべてのキロ数を10倍して「整数」として扱い、最終的な出力時のみ10で割るゼロ依存のアーキテクチャを採用しています。これにより、計算精度と処理速度を極限まで両立させています。
+                                </p>
+                            </div>
 
-                                    {/* 4. 下部の矢印2（焼津〜静岡の分割運賃） */}
-                                    <line
-                                        x1="515" y1="180" x2="700" y2="180"
-                                        stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
-                                    />
-                                    <text x="607.5" y="205" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
-                                        240円（13.5km）
-                                    </text>
+                            <div>
+                                <h4 className="text-lg font-semibold text-slate-900 mb-2">② ノンブロッキングな Fire-and-Forget キャッシュ</h4>
+                                <p className="text-sm text-slate-700 leading-relaxed">
+                                    新規経路探索時の計算結果をFirestoreへキャッシュ保存する際、クライアントへのレスポンス返却処理をブロックすることなく（`await`せずに）バックグラウンドで非同期書き込みを実行します。キャッシュ書き込みの遅延がユーザー体験の低下に直結しないノンブロッキング設計にしています。
+                                </p>
+                            </div>
 
-                                    {/* 5. 駅のノード（円）とラベル */}
-                                    {/* 福山駅 */}
-                                    <circle cx="100" cy="125" r="8" fill="white" stroke="#111827" strokeWidth="3" />
-                                    <text x="100" y="152" textAnchor="middle" fill="#111827" className="text-base font-bold">福山</text>
+                            <div>
+                                <h4 className="text-lg font-semibold text-slate-900 mb-2">③ 安全かつ低コストなCI/CD運用</h4>
+                                <p className="text-sm text-slate-700 leading-relaxed">
+                                    GitHub Rulesetによるメインブランチ保護と自動テスト、サプライチェーン攻撃を防ぐセキュリティスキャン（Takumi Guard）を統合。
+                                    また、モックデータのGitHubへのキャッシュによるGCS費用削減（FinOps）や、プルリクエストごとに Cloud Run のタグ付きデプロイを用いて動的に検証用プレビューURLを発行する体制を整えています。
+                                </p>
+                            </div>
 
-                                    {/* 焼津駅 */}
-                                    <circle cx="500" cy="125" r="8" fill="white" stroke="#111827" strokeWidth="3" />
-                                    <text x="500" y="152" textAnchor="middle" fill="#111827" className="text-base font-bold">焼津</text>
-
-                                    {/* 静岡駅 */}
-                                    <circle cx="700" cy="125" r="8" fill="white" stroke="#111827" strokeWidth="3" />
-                                    <text x="700" y="152" textAnchor="middle" fill="#111827" className="text-base font-bold">静岡</text>
-                                </svg>
+                            <div>
+                                <h4 className="text-lg font-semibold text-slate-900 mb-2">④ WasmとグラフデータのR2配信による高速化とコスト最適化</h4>
+                                <p className="text-sm text-slate-700 leading-relaxed">
+                                    最速の経路計算を実現するためにWebAssemblyを採用しています。Wasmモジュール（`split_pass.wasm`）および運賃計算に必要なグラフデータ（`graph_data.bin`）は、配信にかかるデータ転送量（エグレス）手数料が発生しない Cloudflare R2 から配信しています。これにより、インフラコストを最小限に抑えつつ、ユーザーへのロード時間を大幅に短縮しています。
+                                </p>
                             </div>
                         </div>
                     </div>
-
-                    <div>
-                        <h3 className="text-lg font-bold text-gray-900 mb-2">④ 電車特定区間運賃の適用</h3>
-                        <p className="mb-2">
-                            割安な「電車特定区間」と通常の「幹線」をまたがって乗車する場合、全区間が割高な幹線の賃率で計算されてしまうため、境界付近で分割して電車特定区間を独立させます。
-                        </p>
-                        <div className="bg-gray-50 p-4 rounded text-sm text-gray-700">
-                            <p className="font-semibold mb-1">【例：久宝寺駅〜大河原駅（関西本線）の場合】</p>
-                            <ul className="list-disc list-inside space-y-1 ml-2">
-                                <li><strong>通しで購入：</strong> 営業キロ55.5kmは「51km～60km」の運賃帯で幹線の賃率として計算され、消費税や端数処理を経て<strong>990円</strong>となります。</li>
-                                <li><strong>法隆寺駅と木津駅で分割：</strong> 3つの駅間の営業キロはそれぞれ「16km～20km」の運賃帯（18kmとして計算）となり、幹線の運賃は330円となります。しかし、法隆寺駅で分割することにより久宝寺駅～法隆寺駅間が電車特定区間内完結で320円となり、合計は<strong>980円</strong>となります。</li>
-                            </ul>
-                            <p className="mt-2">結果として、分割すると10円安くなります。</p>
-                            <div className="w-full flex justify-center my-8 overflow-x-auto">
-                                {/* 破線エリアが収まるよう、viewBoxの高さを300に拡張 */}
-                                <svg
-                                    viewBox="0 0 800 300"
-                                    className="w-full max-w-3xl min-w-150 h-auto font-sans"
-                                    aria-label="電車特定区間を跨ぐ分割乗車券の運賃比較図"
-                                >
-                                    <defs>
-                                        <marker
-                                            id="arrowhead"
-                                            markerWidth="10"
-                                            markerHeight="7"
-                                            refX="9"
-                                            refY="3.5"
-                                            orient="auto"
-                                        >
-                                            <polygon points="0 0, 10 3.5, 0 7" fill="#374151" />
-                                        </marker>
-                                    </defs>
-
-                                    {/* 0. 電車特定区間エリア（背景の破線ボックス） */}
-                                    {/* 久宝寺(100)から法隆寺(300)をすっぽり覆うように配置 */}
-                                    <rect
-                                        x="40"
-                                        y="30"
-                                        width="320"
-                                        height="240"
-                                        rx="12"
-                                        fill="#F3F4F6"
-                                        stroke="#9CA3AF"
-                                        strokeWidth="2"
-                                        strokeDasharray="6 4"
-                                    />
-                                    {/* 背景エリアのラベル */}
-                                    <text x="200" y="60" textAnchor="middle" fill="#1F2937" className="text-base font-bold">
-                                        電車特定区間内
-                                    </text>
-
-                                    {/* 1. 路線（ベースとなる太い線） */}
-                                    <line x1="100" y1="150" x2="700" y2="150" stroke="#9CA3AF" strokeWidth="4" />
-
-                                    {/* 2. 上部の矢印（通し運賃） */}
-                                    <line
-                                        x1="100" y1="100" x2="700" y2="100"
-                                        stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
-                                    />
-                                    {/* テキストは特定区間のラベルと被らないよう、右側（木津駅付近）に配置 */}
-                                    <text x="500" y="85" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
-                                        990円（55.5km）
-                                    </text>
-
-                                    {/* 3. 下部の矢印1（久宝寺〜法隆寺） */}
-                                    <line
-                                        x1="100" y1="210" x2="285" y2="210"
-                                        stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
-                                    />
-                                    <text x="192.5" y="235" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
-                                        320円（18.6km）
-                                    </text>
-
-                                    {/* 4. 下部の矢印2（法隆寺〜木津） */}
-                                    <line
-                                        x1="315" y1="210" x2="485" y2="210"
-                                        stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
-                                    />
-                                    <text x="400" y="235" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
-                                        330円（18.8km）
-                                    </text>
-
-                                    {/* 5. 下部の矢印3（木津〜大河原） */}
-                                    <line
-                                        x1="515" y1="210" x2="700" y2="210"
-                                        stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
-                                    />
-                                    <text x="607.5" y="235" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
-                                        330円（18.1km）
-                                    </text>
-
-                                    {/* 6. 駅のノード（円）とラベル */}
-                                    {/* 久宝寺駅 */}
-                                    <circle cx="100" cy="150" r="8" fill="white" stroke="#111827" strokeWidth="3" />
-                                    <text x="100" y="177" textAnchor="middle" fill="#111827" className="text-base font-bold">久宝寺</text>
-
-                                    {/* 法隆寺駅 */}
-                                    <circle cx="300" cy="150" r="8" fill="white" stroke="#111827" strokeWidth="3" />
-                                    <text x="300" y="177" textAnchor="middle" fill="#111827" className="text-base font-bold">法隆寺</text>
-
-                                    {/* 木津駅 */}
-                                    <circle cx="500" cy="150" r="8" fill="white" stroke="#111827" strokeWidth="3" />
-                                    <text x="500" y="177" textAnchor="middle" fill="#111827" className="text-base font-bold">木津</text>
-
-                                    {/* 大河原駅 */}
-                                    <circle cx="700" cy="150" r="8" fill="white" stroke="#111827" strokeWidth="3" />
-                                    <text x="700" y="177" textAnchor="middle" fill="#111827" className="text-base font-bold">大河原</text>
-                                </svg>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div>
-                        <h3 className="text-lg font-bold text-gray-900 mb-2">⑤ 特定都区市内制度の適用または回避</h3>
-                        <p className="mb-2">
-                            分割することにより、特定都区市内の特例制度を利用して運賃計算経路を短縮したり、逆に特例の適用を避けるために境界駅で分割することで安くなることがあります。
-                        </p>
-                        <div className="bg-gray-50 p-4 rounded text-sm text-gray-700">
-                            <p className="font-semibold mb-1">【例：宮島口駅〜網干駅（山陽本線）の場合】</p>
-                            <ul className="list-disc list-inside space-y-1 ml-2">
-                                <li><strong>通しで購入：</strong> 営業キロ261.1kmは「261km～280km」の運賃帯で<strong>4,840円</strong>となります。</li>
-                                <li><strong>五日市駅で分割：</strong> 五日市駅は広島市内にあるので、五日市〜東京（251.7km）は、「広島市内→網干」として中心駅の広島駅からの運賃計算です。広島～網干（239.6km）は「221～240km」の運賃帯（230kmとして計算）となり、<strong>4,070円</strong>となります。</li>
-                            </ul>
-                            <p className="mt-2">結果として、分割するだけで250円安くなります。</p>
-                            <div className="w-full flex justify-center my-8 overflow-x-auto">
-                                {/* viewBoxで描画領域を定義（幅800, 高さ280に拡張してゾーンを収める） */}
-                                <svg
-                                    viewBox="0 0 800 280"
-                                    className="w-full max-w-3xl min-w-150 h-auto font-sans"
-                                    aria-label="特定都区市内制度による分割乗車券の逆転現象の解説図"
-                                >
-                                    <defs>
-                                        <marker
-                                            id="arrowhead"
-                                            markerWidth="10"
-                                            markerHeight="7"
-                                            refX="9"
-                                            refY="3.5"
-                                            orient="auto"
-                                        >
-                                            <polygon points="0 0, 10 3.5, 0 7" fill="#374151" />
-                                        </marker>
-                                    </defs>
-
-                                    {/* 1. 特定都区市内のゾーン（背景の点線枠） */}
-                                    <rect
-                                        x="250" y="20" width="300" height="175"
-                                        rx="12" fill="#F3F4F6" stroke="#9CA3AF" strokeWidth="2" strokeDasharray="6 6"
-                                    />
-                                    <text x="400" y="55" textAnchor="middle" fill="#374151" className="text-lg font-bold">
-                                        広島市内
-                                    </text>
-
-                                    {/* 2. 上部の矢印（宮島口〜網干の通し運賃） */}
-                                    <text x="400" y="85" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
-                                        4,840円（261.1km）
-                                    </text>
-                                    <line
-                                        x1="100" y1="95" x2="690" y2="95"
-                                        stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
-                                    />
-
-                                    {/* 3. 中心駅のラベル */}
-                                    <text x="400" y="125" textAnchor="middle" fill="#4B5563" className="text-xs font-bold">
-                                        中心駅
-                                    </text>
-
-                                    {/* 4. 路線（ベースとなる太い線） */}
-                                    <line x1="100" y1="150" x2="700" y2="150" stroke="#9CA3AF" strokeWidth="4" />
-
-                                    {/* 5. 下部の矢印1（宮島口〜五日市の分割運賃） */}
-                                    <line
-                                        x1="100" y1="220" x2="290" y2="220"
-                                        stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
-                                    />
-                                    <text x="195" y="245" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
-                                        200円（9.7km）
-                                    </text>
-
-                                    {/* 6. 下部の矢印2（広島〜網干の特定都区市内運賃） */}
-                                    <line
-                                        x1="410" y1="220" x2="690" y2="220"
-                                        stroke="#374151" strokeWidth="2" markerEnd="url(#arrowhead)"
-                                    />
-                                    <text x="550" y="245" textAnchor="middle" fill="#1F2937" className="text-sm font-bold">
-                                        4,070円（239.6km）
-                                    </text>
-
-                                    {/* 7. 駅のノード（円）とラベル */}
-                                    {/* 宮島口駅 */}
-                                    <circle cx="100" cy="150" r="8" fill="white" stroke="#111827" strokeWidth="3" />
-                                    <text x="100" y="178" textAnchor="middle" fill="#111827" className="text-base font-bold">宮島口</text>
-
-                                    {/* 五日市駅 */}
-                                    <circle cx="300" cy="150" r="8" fill="white" stroke="#111827" strokeWidth="3" />
-                                    <text x="300" y="178" textAnchor="middle" fill="#111827" className="text-base font-bold">五日市</text>
-
-                                    {/* 広島駅 */}
-                                    <circle cx="400" cy="150" r="8" fill="white" stroke="#111827" strokeWidth="3" />
-                                    <text x="400" y="178" textAnchor="middle" fill="#111827" className="text-base font-bold">広島</text>
-
-                                    {/* 網干駅 */}
-                                    <circle cx="700" cy="150" r="8" fill="white" stroke="#111827" strokeWidth="3" />
-                                    <text x="700" y="178" textAnchor="middle" fill="#111827" className="text-base font-bold">網干</text>
-                                </svg>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </section>
-
-            <section className="mb-12">
-                <h2 className="text-2xl font-semibold mb-6 text-blue-800 border-l-4 border-blue-600 pl-3">
-                    2. 当サイトの探索アルゴリズムと技術的優位性
-                </h2>
-                <p className="mb-6">
-                    既存の分割乗車券プログラムの多くは、利用者が事前に「乗車する経路」を指定する必要がありました。また、計算速度を優先した単純な動的計画法（DP）では、最適化の過程で同額となる別の分割パターンが枝刈りされてしまい、出力される解が一つに限定されるという課題がありました。
-                </p>
-                <p className="mb-6">
-                    当システムでは、情報工学におけるグラフ理論と最新のWeb技術を応用し、以下の独自アプローチを採用しています。
-                </p>
-
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div className="bg-white p-5 rounded-lg border border-gray-200 shadow-sm">
-                        <h3 className="text-lg font-bold mb-3 text-blue-700">経路指定不要の自動探索</h3>
-                        <p className="text-sm text-gray-700">
-                            K-最短経路アルゴリズム（{"Yen's Algorithm"}）を応用することで、利用者が自ら経路を指定することなく、分割乗車券によって安価となる「迂回経路」も含めた候補ルートの列挙を自動で行います。
-                        </p>
-                    </div>
-
-                    <div className="bg-white p-5 rounded-lg border border-gray-200 shadow-sm">
-                        <h3 className="text-lg font-bold mb-3 text-blue-700">ヒューリスティック探索の不採用</h3>
-                        <p className="text-sm text-gray-700">
-                            A* アルゴリズムなどは高速ですが、JRには「営業キロが物理的な距離よりも短く設定されている区間」が存在します。物理的距離を推定値に用いるとコストを過大評価し最安解を見逃すリスクがあるため、解の正当性を完全に保証する手法を採用しています。
-                        </p>
-                    </div>
-
-                    <div className="bg-white p-5 rounded-lg border border-gray-200 shadow-sm">
-                        <h3 className="text-lg font-bold mb-3 text-blue-700">同額パターンの完全列挙</h3>
-                        <p className="text-sm text-gray-700">
-                            現実の鉄道利用では、分割位置による途中下車の可否など利便性を左右する要因があります。当システムは1次元DPの最適化過程で枝刈りを行わず、同額となる複数の最安分割パターンを完全に列挙し、実用上の選択肢を全て提示します。
-                        </p>
-                    </div>
-
-                    <div className="bg-white p-5 rounded-lg border border-gray-200 shadow-sm">
-                        <h3 className="text-lg font-bold mb-3 text-blue-700">多層キャッシュによる高速化</h3>
-                        <p className="text-sm text-gray-700">
-                            複雑な計算アルゴリズムによるサーバー負荷を軽減するため、Cloud RunとFirebase Firestoreを連携。一度計算された解は非同期でデータベースにキャッシュされ、2回目以降の同一検索に対しては数ミリ秒での即時応答を実現しています。
-                        </p>
-                    </div>
-                </div>
-            </section>
-
-            <section className="mb-12">
-                <h2 className="text-2xl font-semibold mb-6 text-blue-800 border-l-4 border-blue-600 pl-3">
-                    3. 運賃の「逆転現象」への対応
-                </h2>
-                <p className="mb-4">
-                    特定の条件下では、乗車経路を外方へ延伸することで運賃が安くなる「逆転現象」が発生します。
-                    例えば、特定都区市内制度において、あえて目的地の先の駅まで切符を買うことで、発駅が都区市内中心駅からの計算に切り替わり、結果的に運賃が安くなる現象などです。
-                </p>
-                <p>
-                    当システムでは、こうした複雑な運賃規則（経路特定区間や特定都区市内など）をアルゴリズムの内部に組み込み、限界距離を算出した上での枝刈りを行うことで、延伸による逆転現象も考慮した「真の最安運賃」を導出する処理を行っています。
-                </p>
-            </section>
+                </section>
+            </div>
         </div>
     );
 }

--- a/src/app/mr/page.tsx
+++ b/src/app/mr/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   description: "経路を入力してJRの運賃と営業キロを計算するためのページです。有効期限も正しく計算されます。",
 };
 
-export default function Page() {
+export default function MrPage() {
   return (
     <div className="py-12 px-4 sm:px-6 lg:px-8">
       <main className="max-w-xl mx-auto">
@@ -34,7 +34,7 @@ export default function Page() {
             <ul className="text-xs sm:text-sm text-slate-500 list-disc list-inside space-y-1">
               <li>このプログラムで計算できる経由路線数の上限は99です。</li>
               <li>経路の重複による運賃計算の制限は行っていません。</li>
-              <li>大都市近郊区間内完結の場合の「最安」は外方に経路を伸ばしません。</li>
+              <li>大都市近郊区間内完結の場合は、実際の乗車経路に関わらず最安経路に補正されます。</li>
               <li>出力される経由は実際の経由印字と異なることがあります。</li>
               <li>新幹線を経由する場合の運賃計算は現在開発中の機能です。</li>
             </ul>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,7 +37,7 @@ export default async function Home() {
               </h2>
             </div>
             <p className="text-slate-600 mb-6 grow">
-              一番安くなる分割乗車券の組み合わせを検索します。実際の旅行や交通費の節約に活用したい方はこちらをご利用ください。いわゆる分割定期券にも対応しました。
+              最も安くなる分割乗車券の組み合わせを検索します。実際の旅行や交通費の節約に活用したい方はこちらをご利用ください。また、定期券の分割（分割定期券）にも対応しています。
             </p>
             <div className="text-blue-600 font-bold flex items-center group-hover:translate-x-2 transition-transform duration-300">
               分割計算をする
@@ -90,8 +90,8 @@ export default async function Home() {
               当サイトの計算アルゴリズムは、2026年3～4月にユーザーが実行した1,625通りの計算データに基づくと、高い節約効果を出しています。
             </p>
             <ul className="list-disc list-inside bg-slate-50 p-4 rounded-lg space-y-2 mt-4 text-slate-700">
-              <li><strong>一般的なルート：</strong> 本システムを利用することで<strong>平均して約123円（中央値：70円）の運賃削減</strong>を確認しました。</li>
-              <li><strong>最大割引額：</strong> 長距離や複雑な境界線を跨ぐルートにおいて、1回の乗車で1,000円以上の差額が発生した事例も存在します。</li>
+              <li><strong>一般的な経路：</strong> 本システムを利用することで<strong>平均して約123円（中央値：70円）の運賃削減</strong>を確認しました。</li>
+              <li><strong>最大割引額：</strong> 長距離や複雑な境界線を跨ぐ経路において、1回の乗車で1,000円以上の差額が発生した事例も存在します。</li>
             </ul>
             <p className="text-sm mt-4">
               ※実際の割引額や分割枚数は、利用する区間やJRの最新の運賃改定状況によって変動します。また、分割乗車券が最安の移動方法とは限らないため、他の交通手段と比較検討することもおすすめします。
@@ -157,124 +157,6 @@ export default async function Home() {
             )}
           </ul>
         </div>
-
-        {/* 4. よくある質問 (FAQ) */}
-        <div className="mt-8 bg-white p-8 rounded-2xl shadow-sm border border-slate-100">
-          <h2 className="text-2xl font-bold text-slate-800 mb-6 border-b pb-2">
-            よくある質問 (FAQ)
-          </h2>
-          <div className="space-y-4">
-
-            {/* Q1 */}
-            <div className="bg-slate-50 p-5 rounded-xl border border-slate-100">
-              <h3 className="font-bold text-slate-800 flex items-start">
-                <span className="shrink-0 bg-blue-100 text-blue-600 w-7 h-7 rounded-full flex items-center justify-center mr-3 text-sm">Q</span>
-                <span className="mt-0.5">分割乗車券は違法ではありませんか？</span>
-              </h3>
-              <div className="mt-3 flex items-start">
-                <span className="shrink-0 bg-slate-200 text-slate-600 w-7 h-7 rounded-full flex items-center justify-center mr-3 text-sm">A</span>
-                <div className="mt-0.5 text-slate-600 leading-relaxed">
-                  いいえ、全く問題ありません。JRの旅客営業規則に則った正当な乗車券の購入方法です。
-                  <Link href="https://www.jreast.co.jp/ryokaku/02_hen/04_syo/02_setsu/03.html" className="text-blue-600 underline decoration-blue-600 underline-offset-2 mx-1">
-                    旅客営業規則 第157条
-                  </Link>
-                  にも、複数枚のきっぷを併用して使用することが想定された条文が存在します。
-                </div>
-              </div>
-            </div>
-
-            {/* Q2 */}
-            <div className="bg-slate-50 p-5 rounded-xl border border-slate-100">
-              <h3 className="font-bold text-slate-800 flex items-start">
-                <span className="shrink-0 bg-blue-100 text-blue-600 w-7 h-7 rounded-full flex items-center justify-center mr-3 text-sm">Q</span>
-                <span className="mt-0.5">分割乗車券はどのようにして買いますか？</span>
-              </h3>
-              <div className="mt-3 flex items-start">
-                <span className="shrink-0 bg-slate-200 text-slate-600 w-7 h-7 rounded-full flex items-center justify-center mr-3 text-sm">A</span>
-                <div className="mt-0.5 text-slate-600 leading-relaxed">
-                  <Link href="https://www.eki-net.com" className="text-blue-600 underline decoration-blue-600 underline-offset-2 mr-1">
-                    えきねっと
-                  </Link>
-                  や
-                  <Link href="https://e5489.jr-odekake.net/e5489/cspc/CBTopMenuPC" className="text-blue-600 underline decoration-blue-600 underline-offset-2 mx-1">
-                    e5489
-                  </Link>
-                  などのインターネット予約サービスを使うと便利です。駅の自動券売機やみどりの窓口では、他駅発の乗車券を発売しないことがあります。
-                </div>
-              </div>
-            </div>
-
-            {/* Q3 */}
-            <div className="bg-slate-50 p-5 rounded-xl border border-slate-100">
-              <h3 className="font-bold text-slate-800 flex items-start">
-                <span className="shrink-0 bg-blue-100 text-blue-600 w-7 h-7 rounded-full flex items-center justify-center mr-3 text-sm">Q</span>
-                <span className="mt-0.5">分割乗車券はどのようにして使いますか？</span>
-              </h3>
-              <div className="mt-3 flex items-start">
-                <span className="shrink-0 bg-slate-200 text-slate-600 w-7 h-7 rounded-full flex items-center justify-center mr-3 text-sm">A</span>
-                <div className="mt-0.5 text-slate-600 leading-relaxed">
-                  改札を入場する際には分割された最初の区間のきっぷを使い、改札を出場する際には有人改札等で全てのきっぷ提示すれば問題ないです。
-                </div>
-              </div>
-            </div>
-
-            {/* Q4 */}
-            <div className="bg-slate-50 p-5 rounded-xl border border-slate-100">
-              <h3 className="font-bold text-slate-800 flex items-start">
-                <span className="shrink-0 bg-blue-100 text-blue-600 w-7 h-7 rounded-full flex items-center justify-center mr-3 text-sm">Q</span>
-                <span className="mt-0.5">分割するデメリットはありますか？</span>
-              </h3>
-              <div className="mt-3 flex items-start">
-                <span className="shrink-0 bg-slate-200 text-slate-600 w-7 h-7 rounded-full flex items-center justify-center mr-3 text-sm">A</span>
-                <div className="mt-0.5 text-slate-600 leading-relaxed">
-                  <p>はい、あります。主に以下の2点です。</p>
-                  <ul className="list-disc list-outside ml-5 mt-2 space-y-1">
-                    <li>払い戻しの際に、きっぷの枚数分手数料がかかる。</li>
-                    <li>
-                      <Link href="https://www.jreast.co.jp/ryokaku/02_hen/07_syo/03_setsu/10.html" className="text-blue-600 underline decoration-blue-600 underline-offset-2 mr-1">
-                        列車の運行不能・遅延等の場合の取扱方
-                      </Link>
-                      が異なる。
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-
-            {/* Q5 */}
-            <div className="bg-slate-50 p-5 rounded-xl border border-slate-100">
-              <h3 className="font-bold text-slate-800 flex items-start">
-                <span className="shrink-0 bg-blue-100 text-blue-600 w-7 h-7 rounded-full flex items-center justify-center mr-3 text-sm">Q</span>
-                <span className="mt-0.5">なぜ運賃が安くなるのですか？</span>
-              </h3>
-              <div className="mt-3 flex items-start">
-                <span className="shrink-0 bg-slate-200 text-slate-600 w-7 h-7 rounded-full flex items-center justify-center mr-3 text-sm">A</span>
-                <div className="mt-0.5 text-slate-600 leading-relaxed">
-                  <Link href="/logic" className="text-blue-600 underline decoration-blue-600 underline-offset-2 mr-1">
-                    仕組み
-                  </Link>
-                  をご覧ください。
-                </div>
-              </div>
-            </div>
-
-            {/* Q6 */}
-            <div className="bg-slate-50 p-5 rounded-xl border border-slate-100">
-              <h3 className="font-bold text-slate-800 flex items-start">
-                <span className="shrink-0 bg-blue-100 text-blue-600 w-7 h-7 rounded-full flex items-center justify-center mr-3 text-sm">Q</span>
-                <span className="mt-0.5">割引乗車券やIC定期券を使った計算できますか？</span>
-              </h3>
-              <div className="mt-3 flex items-start">
-                <span className="shrink-0 bg-slate-200 text-slate-600 w-7 h-7 rounded-full flex items-center justify-center mr-3 text-sm">A</span>
-                <div className="mt-0.5 text-slate-600 leading-relaxed">
-                  現在のプログラムは大人の普通乗車券と通勤定期乗車券の計算に対応しています。割引乗車券との併用計算やIC定期券の対応は今しばらくお待ちください。
-                </div>
-              </div>
-            </div>
-
-          </div>
-        </div>
-
       </div>
     </div>
   );

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -20,11 +20,11 @@ export default function PrivacyPage() {
             <div className="bg-white rounded-2xl shadow-sm border border-slate-200 p-6 sm:p-10 space-y-10 text-slate-700 leading-loose">
 
                 <section>
-                    <h2 className="text-xl font-bold text-slate-900 border-b pb-2 mb-4">
+                    <h2 className="text-2xl font-bold text-slate-800 mb-6 border-b pb-2">
                         アクセス解析ツールについて
                     </h2>
                     <p>
-                        当サイトでは、サービスの品質向上や利用状況の分析のため、プロダクト分析ツール「PostHog」および、「Google Analytics」を利用しています。
+                        当サイトでは、サービスの品質向上や利用状況の分析のため、プロダクト分析ツール「PostHog」および「Google Analytics」を利用しています。
                     </p>
                     <p className="mt-4">
                         これらのツールはトラフィックデータやサイト内での行動履歴（検索条件やエラーの発生等）を収集するためにCookieを使用しています。データは匿名で収集されており、個人を特定するものではありません。
@@ -34,46 +34,56 @@ export default function PrivacyPage() {
                         各ツールの利用規約や、データ使用の仕組みについては、以下のリンクからご確認いただけます。
                     </p>
 
-                    <ul className="mt-6 space-y-4 list-none ml-1 sm:ml-2">
-                        <li className="flex flex-col space-y-1">
-                            <span className="font-bold text-slate-800 border-l-4 border-slate-300 pl-2 mb-1">
+                    <div className="mt-6 space-y-4 ml-1 sm:ml-2">
+                        <div>
+                            <span className="font-bold text-slate-800 border-l-4 border-slate-300 pl-2 mb-2 block">
                                 Google Analytics
                             </span>
-                            <Link
-                                href="https://marketingplatform.google.com/about/analytics/terms/jp/"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-blue-600 hover:underline underline-offset-2 before:content-['・'] before:mr-1"
-                            >
-                                Google Analytics利用規約
-                            </Link>
-                            <Link
-                                href="https://policies.google.com/technologies/partner-sites?hl=ja"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-blue-600 hover:underline underline-offset-2 before:content-['・'] before:mr-1"
-                            >
-                                Googleのサービスを使用するサイトやアプリから収集した情報のGoogleによる使用
-                            </Link>
-                        </li>
+                            <ul className="list-disc list-outside ml-5 space-y-1.5 text-sm text-slate-600">
+                                <li>
+                                    <Link
+                                        href="https://marketingplatform.google.com/about/analytics/terms/jp/"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="text-blue-600 hover:underline underline-offset-2"
+                                    >
+                                        Google Analytics利用規約
+                                    </Link>
+                                </li>
+                                <li>
+                                    <Link
+                                        href="https://policies.google.com/technologies/partner-sites?hl=ja"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="text-blue-600 hover:underline underline-offset-2"
+                                    >
+                                        Googleのサービスを使用するサイトやアプリから収集した情報のGoogleによる使用
+                                    </Link>
+                                </li>
+                            </ul>
+                        </div>
 
-                        <li className="flex flex-col space-y-1 pt-2">
-                            <span className="font-bold text-slate-800 border-l-4 border-slate-300 pl-2 mb-1">
+                        <div className="pt-2">
+                            <span className="font-bold text-slate-800 border-l-4 border-slate-300 pl-2 mb-2 block">
                                 PostHog
                             </span>
-                            <Link
-                                href="https://posthog.com/privacy"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-blue-600 hover:underline underline-offset-2 before:content-['・'] before:mr-1"
-                            >
-                                PostHog Privacy Policy
-                            </Link>
-                        </li>
-                    </ul>
+                            <ul className="list-disc list-outside ml-5 space-y-1.5 text-sm text-slate-600">
+                                <li>
+                                    <Link
+                                        href="https://posthog.com/privacy"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="text-blue-600 hover:underline underline-offset-2"
+                                    >
+                                        PostHog Privacy Policy
+                                    </Link>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
                 </section>
                 <section>
-                    <h2 className="text-xl font-bold text-slate-900 border-b pb-2 mb-4">
+                    <h2 className="text-2xl font-bold text-slate-800 mb-6 border-b pb-2">
                         広告の配信について
                     </h2>
                     <p>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -36,6 +36,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
             priority: 0.8,
         },
         {
+            url: `${baseUrl}/guide`,
+            lastModified,
+            changeFrequency: 'monthly',
+            priority: 0.8,
+        },
+        {
             url: `${baseUrl}/changelog`,
             lastModified,
             changeFrequency: 'weekly',

--- a/src/app/split-icpass/page.tsx
+++ b/src/app/split-icpass/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   description: "JR在来線の「発駅」「着駅」から分割IC定期券の最安解を計算します。",
 };
 
-export default async function Page({ searchParams }: { searchParams: Promise<{ [key: string]: string | string[] | undefined }> }) {
+export default async function SplitIcPassPage({ searchParams }: { searchParams: Promise<{ [key: string]: string | string[] | undefined }> }) {
   const params = await searchParams;
   const from = typeof params.from === "string" ? params.from : undefined;
   const to = typeof params.to === "string" ? params.to : undefined;
@@ -34,7 +34,7 @@ export default async function Page({ searchParams }: { searchParams: Promise<{ [
           <div className="text-sm text-amber-800 leading-relaxed">
             <span className="font-bold block mb-1">【お知らせ】長距離区間の計算制限について</span>
             <p>
-              システム負荷軽減のため、<strong>発着駅間の駅数が100を超える場合</strong>の計算をしないことがあります。
+              システム負荷軽減のため、<strong>発着駅間の駅数が100を超える場合</strong>は計算を制限することがあります。
             </p>
           </div>
         </div>

--- a/src/app/split/page.tsx
+++ b/src/app/split/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   description: "JR在来線の「発駅」「着駅」から普通乗車券と定期乗車券の分割乗車券の最安解を計算します。",
 };
 
-export default async function Page({ searchParams }: { searchParams: Promise<{ [key: string]: string | string[] | undefined }> }) {
+export default async function SplitPage({ searchParams }: { searchParams: Promise<{ [key: string]: string | string[] | undefined }> }) {
   const params = await searchParams;
   const from = typeof params.from === "string" ? params.from : undefined;
   const to = typeof params.to === "string" ? params.to : undefined;
@@ -33,7 +33,7 @@ export default async function Page({ searchParams }: { searchParams: Promise<{ [
           <div className="text-sm text-amber-800 leading-relaxed">
             <span className="font-bold block mb-1">【お知らせ】長距離区間の計算制限について</span>
             <p>
-              システム負荷軽減のため、<strong>発着駅間の駅数が100を超える場合</strong>の計算をしないことがあります。
+              システム負荷軽減のため、<strong>発着駅間の駅数が100を超える場合</strong>は計算を制限することがあります。
             </p>
           </div>
         </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,15 +2,14 @@
 
 import Link from "next/link";
 import { useState, useEffect } from "react";
-import { FaBookOpen } from "react-icons/fa";
 import { MdMenu, MdClear, MdHome } from "react-icons/md";
-import { RiGuideLine, RiScissorsFill } from "react-icons/ri";
+import { RiBookOpenFill, RiGuideLine, RiScissorsFill } from "react-icons/ri";
 
 import { menuItem } from "@/app/types";
 
 const MENU_ITEMS: menuItem[] = [
     { href: "/", icon: MdHome, label: "ホーム" },
-    { href: "/logic", icon: FaBookOpen, label: "仕組み" },
+    { href: "/guide", icon: RiBookOpenFill, label: "はじめての方へ" },
     { href: "/mr", icon: RiGuideLine, label: "運賃計算" },
     { href: "/split", icon: RiScissorsFill, label: "分割乗車券" }
 ];


### PR DESCRIPTION
## 関連 Issue
Closed #402 
## 変更内容
### 1. ナビゲーション・トップページ
- **`src/components/Header.tsx`**: ナビゲーションメニューの「仕組み」へのリンクを「はじめての方へ (`/guide`)」に変更し、アイコンを `RiBookOpenFill` に変更。
- **`src/app/sitemap.ts`**: `/guide` へのクロール用サイトマップエントリーを追加。
- **`src/app/page.tsx`**: 従来トップページ下部に直書きされていたFAQ（Q1〜Q6）セクションを削除。コンテンツは新設の `/guide` へ完全に移設・整理。
### 2. ガイドページ
- **`src/app/guide/page.tsx` [NEW]**:
  - 初めての利用ユーザー向けの操作手順やFAQを集約した「使い方ガイド」ページを新設。
  - アコーディオンコンポーネント等の型定義を施し、暗黙の `any` エラーを解消。
  - 目次の数字・ドット部分はリンクタグの外側に配置し、CSSの `flex items-start` 等を用いて複数行になっても開始位置が整列するよう実装。
### 3. 各計算・検索機能ページ (`/mr`, `/split`, `/split-icpass`)
- **`src/app/mr/page.tsx`**, **`src/app/split/page.tsx`**, **`src/app/split-icpass/page.tsx`**:
  - デフォルトエクスポート関数名をそれぞれ `MrPage`, `SplitPage`, `SplitIcPassPage` にリネーム。
  - 100駅を超える長距離区間の警告表示テキストを、「計算をしないことがあります」から「計算を制限することがあります」に微修正。
### 4. 既存解説・ポリシーページ (`/logic`, `/privacy`)
- **`src/app/logic/page.tsx`**:
  - ページレイアウト（中央揃えヘッダー、白背景のカードコンテナラッパー等）をガイドページと完全統一。
  - Cloudflare R2を用いたWasmやグラフデータ配信などの記述を含めた「4. 技術情報」セクションを執筆。
  - 大項目のみの目次を追加し、アンカー位置ズレ防止用の `scroll-mt-20` を付与。数字とドットはリンク外側に配置し折り返し時にも美しく整列。
- **`src/app/privacy/page.tsx`**:
  - `h2` タグの見出しフォントサイズを他ページと合わせるため、`text-xl text-slate-900` から `text-2xl font-bold text-slate-800 mb-6 border-b pb-2` に変更。
  - 外部リンクの箇条書きに存在した「・」をリンクタグの外部へ排除。さらに手動記述の `・` を廃止し、標準の `ul/li` タグによる `list-disc` のリストマークに変更。
## 検証内容
- **型チェック (`npm run typecheck`)**: すべての型エラーが解消され正常終了することを確認。
- **Lint (`npm run lint`)**: 警告・エラーがないことを確認。
- **Next.jsビルド (`npm run build`)**: すべての静的・動的ページのビルドと静的プレレンダリングが正常完了することを確認。