### PR TITLE
fix: レイアウト構成の改善によるハイドレーションエラーの修正

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -65,13 +65,13 @@ export default function RootLayout({
         <link rel="icon" href="https://assets.kippu-navi.com/icons/favicon.ico" sizes="any" />
         <link rel="apple-touch-icon" href="https://assets.kippu-navi.com/icons/apple-touch-icon.png" />
         <link rel="apple-touch-icon-precomposed" href="https://assets.kippu-navi.com/icons/apple-touch-icon-precomposed.png" />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
       </head>
-      <PHProvider>
-        <body className={`flex flex-col min-h-screen bg-slate-50 text-slate-900 overflow-x-hidden ${geistSans.variable} ${geistMono.variable} antialiased`}>
-          <script
-            type="application/ld+json"
-            dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-          />
+      <body className={`flex flex-col min-h-screen bg-slate-50 text-slate-900 overflow-x-hidden ${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <PHProvider>
           <PostHogPageView />
           {gaId && <GoogleAnalytics gaId={gaId} />}
           <AdSense />
@@ -79,8 +79,8 @@ export default function RootLayout({
           <main className="grow">{children}</main>
           <Footer />
           <ScrollToTopButton />
-        </body>
-      </PHProvider>
+        </PHProvider>
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
## 概要
開発環境およびページ表示時にブラウザのコンソールに出力されていた、ハイドレーション不一致エラー（Hydration Mismatch）を修正しました。

## 原因と修正内容
1. **HTML構造の不正**
   `src/app/layout.tsx` において `<PHProvider>` が `<body>` タグの外側を囲っており、HTML規格外のネスト構造になっていたため、`<PHProvider>` を `<body>` の内側に移動しました。
2. **PostHogによるスクリプト割り込み**
   `<body>` の直下に置かれていた構造化データ用の `<script type="application/ld+json">` が、PostHogのクライアント初期化時に挿入される動的スクリプトによって押し出され、Reactのハイドレーション時のノード不一致を招いていました。これを防ぐため、JSON-LDスクリプトを `<head>` タグ内に移動しました。

## 影響範囲
- 全ページの基本レイアウト（ハイドレーション警告が解消されます）

## 動作確認
- [x] `npm run typecheck` による型チェック通過
- [x] `npm run build` による本番ビルドの正常完了
- [x] コンソールにハイドレーション警告が出ないことの確認