### PR TITLE
refactor: ルーティングとセキュリティヘッダー処理のCloudflareへの完全移譲

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,76 +1,6 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  async headers() {
-    return [
-      {
-        source: '/:path*',
-        headers: [
-          {
-            key: 'X-Content-Type-Options',
-            value: 'nosniff',
-          },
-          {
-            key: 'X-Frame-Options',
-            value: 'SAMEORIGIN',
-          },
-          {
-            key: 'Referrer-Policy',
-            value: 'strict-origin-when-cross-origin',
-          },
-          {
-            key: 'Strict-Transport-Security',
-            value: 'max-age=63072000; includeSubDomains; preload',
-          },
-          {
-            key: 'Permissions-Policy',
-            value: 'camera=(), microphone=(), geolocation=(), browsing-topics=()',
-          },
-          {
-            key: 'Content-Security-Policy',
-            value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' 'unsafe-inline' https://www.google-analytics.com https://www.googletagmanager.com https://pagead2.googlesyndication.com https://partner.googleadservices.com https://tpc.googlesyndication.com https://adservice.google.com https://static.cloudflareinsights.com https://us-assets.i.posthog.com https://*.adtrafficquality.google; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://assets.kippu-navi.com https://*.posthog.com https://*.firebaseio.com https://*.googleapis.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.g.doubleclick.net https://pagead2.googlesyndication.com https://*.adtrafficquality.google; frame-src 'self' https://googleads.g.doubleclick.net https://tpc.googlesyndication.com https://docs.google.com https://*.adtrafficquality.google https://www.google.com; worker-src 'self' blob:; child-src 'self' blob:; frame-ancestors 'self';",
-          }
-        ],
-      },
-      {
-        source: '/engine/:path*',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: 'public, max-age=31536000, s-maxage=31536000, immutable',
-          },
-        ],
-      },
-    ];
-  },
-  async redirects() {
-    return [
-      {
-        source: '/Bthesis_main.pdf',
-        destination: 'https://assets.kippu-navi.com/documents/Bthesis_main.pdf',
-        permanent: true,
-      },
-      {
-        source: '/:path*',
-        has: [
-          {
-            type: 'host',
-            value: 'www.kippu-navi.com',
-          },
-        ],
-        destination: 'https://kippu-navi.com/:path*',
-        permanent: true,
-      },
-    ]
-  },
-  async rewrites() {
-    return [
-      {
-        source: '/engine/:path*',
-        destination: 'https://assets.kippu-navi.com/engine/:path*',
-      },
-    ]
-  },
   output: 'standalone',
   poweredByHeader: false,
   experimental: {
@@ -79,5 +9,4 @@ const nextConfig: NextConfig = {
     },
   },
 };
-
 export default nextConfig;


### PR DESCRIPTION
## 概要
Resolves #416 

Cloud Runのインフラコスト削減とパフォーマンス向上のため、Next.js側で担っていたルーティング（リダイレクト/リライト）およびレスポンスヘッダーの付与ロジックを廃止し、Cloudflare Edge（Workers / Rules）へアーキテクチャを移行しました。

## 変更内容
### コードベース (`next.config.ts`)
- `headers()`, `redirects()`, `rewrites()` を削除。

### インフラ環境
- **Cloudflare Workers**: `/Bthesis_main.pdf` の転送と `/engine/` パスのプロキシ（および長期キャッシュヘッダーの注入）ロジックを追加。
- **Cloudflare Rules**: HSTS、CSP、その他のセキュリティヘッダーをエッジ側で一括付与するよう設定済み。

## 影響範囲
- サイト全体のセキュリティヘッダー。
- `/engine/*` 経由でのアセットファイル（計算エンジン等）の取得経路とキャッシュ生存期間。
- `www.kippu-navi.com` からのアクセス挙動。
※Next.jsのアプリケーションロジック（UIや乗車券計算のコアロジック）自体に変更はありません。

## 動作確認
- [x] 本番環境にて、`www` ありのURLからルートドメインへ301リダイレクトされること。
- [x] `/engine/` 以下のファイル取得時に `Cache-Control: immutable` ヘッダーが付与されていること。
- [x] 定期券・普通乗車券の分割計算（Server Actions および GET API）が500エラーにならず正常に完了すること。
- [x] デベロッパーツールにて、HSTSやCSPなどのセキュリティヘッダーが二重に付与されず、正しく1つだけ出力されていること。